### PR TITLE
feat: projects - support auto deploy mode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-19T09:28:12Z",
+  "generated_at": "2025-10-02T08:57:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -622,7 +622,7 @@
         "hashed_secret": "4fe2c50d3e572f60977cb06e8995a5d7c368758d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 282,
+        "line_number": 287,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -642,7 +642,7 @@
         "hashed_secret": "06d988e96c3d9325c9fbc7c0ef3c6c0f2b4eb8e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -842,7 +842,7 @@
         "hashed_secret": "731438016c5ab94431f61820f35e3ae5f8ad6004",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 548,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -850,7 +850,7 @@
         "hashed_secret": "12da2e35d6b50c902c014f1ab9e3032650368df7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 554,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -858,7 +858,7 @@
         "hashed_secret": "165722fe6dd0ec0afbeefb51c8258a177497956b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 843,
+        "line_number": 846,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -866,7 +866,7 @@
         "hashed_secret": "813274ccae5b6b509379ab56982d862f7b5969b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1509,
+        "line_number": 1529,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -876,7 +876,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 148,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,23 +884,15 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1594,
+        "line_number": 1562,
         "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1669,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3782,
+        "line_number": 3766,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +900,15 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3795,
+        "line_number": 3779,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3826,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -916,7 +916,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3837,
+        "line_number": 3846,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -954,7 +954,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2463,
+        "line_number": 2490,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -962,7 +962,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2469,
+        "line_number": 2496,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3594,7 +3594,7 @@
         "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1388,
+        "line_number": 1431,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3700,7 +3700,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3708,7 +3708,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 601,
+        "line_number": 602,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3736,7 +3736,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 67,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3744,7 +3744,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 171,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3772,7 +3772,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3780,7 +3780,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 885,
+        "line_number": 886,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3790,7 +3790,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 77,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3798,7 +3798,7 @@
         "hashed_secret": "cf82ffec7623dc7b6f0931140a5b5bae30f5cc69",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 619,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3808,7 +3808,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3816,7 +3816,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 312,
+        "line_number": 313,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3826,7 +3826,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 731,
+        "line_number": 736,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4769,6 +4769,16 @@
         "verified_result": null
       }
     ],
+    "website/docs/d/pi_network_peer_route_filter.html.markdown": [
+      {
+        "hashed_secret": "e22a2c86b8cfdb254165910934051a52ba2e3c06",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
     "website/docs/d/sm_public_certificate_configuration_ca_lets_encrypt.html.markdown": [
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
@@ -4803,6 +4813,22 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 206,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cca04aa5bbf459bb406df2c401738966138d0dba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 222,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5e9b97965aa8f82caad07bb66151c2dafb4ab322",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 224,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5450,7 +5476,7 @@
         "hashed_secret": "13ef22c6a31093830639f12a9feb34a8acd9c34f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 33,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5458,7 +5484,7 @@
         "hashed_secret": "b93b47a3e2ea958f8ca87a70ebc9ad0f4d5ffa45",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 53,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/examples/ibm-project/main.tf
+++ b/examples/ibm-project/main.tf
@@ -29,6 +29,7 @@ resource "ibm_project" "project_instance" {
     destroy_on_delete = true
     monitoring_enabled = true
     auto_deploy = true
+    auto_deploy_mode = "auto_approval"
   }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/IBM/mqcloud-go-sdk v0.4.0
 	github.com/IBM/networking-go-sdk v0.51.12
 	github.com/IBM/platform-services-go-sdk v0.87.0
-	github.com/IBM/project-go-sdk v0.3.8
+	github.com/IBM/project-go-sdk v0.3.9
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.45.0
 	github.com/IBM/scc-go-sdk/v5 v5.5.3
@@ -51,6 +51,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
+	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/jinzhu/copier v0.3.2
 	github.com/minsikl/netscaler-nitro-go v0.0.0-20170827154432-5b14ce3643e3
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/IBM/networking-go-sdk v0.51.12 h1:2qv6neG8msFR1dtf9v+rbaC2gIkw9Hnzohv
 github.com/IBM/networking-go-sdk v0.51.12/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
 github.com/IBM/platform-services-go-sdk v0.87.0 h1:hLx/I7n7cb1CyAXdb2qypmCoFiYuxh2g50qN8OGnEQc=
 github.com/IBM/platform-services-go-sdk v0.87.0/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
-github.com/IBM/project-go-sdk v0.3.8 h1:RPu4vrNHLrs1+csKMI/TWXCgJMf23la8IM2OBd+zb1o=
-github.com/IBM/project-go-sdk v0.3.8/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
+github.com/IBM/project-go-sdk v0.3.9 h1:D/UfMMn+vMQyvYf9EfocV6HrD3HcVpeIVoUSjNKuROo=
+github.com/IBM/project-go-sdk v0.3.9/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5/go.mod h1:b07XHUVh0XYnQE9s2mqgjYST1h9buaQNqN4EcKhOsX0=
 github.com/IBM/sarama v1.45.0 h1:IzeBevTn809IJ/dhNKhP5mpxEXTmELuezO2tgHD9G5E=
@@ -750,6 +750,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 h1:NFPMacTrY/IdcIcnUB+7hsore1ZaRWU9cnB6jFoBnIM=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0/go.mod h1:QYmYnLfsosrxjCnGY1p9c7Zj6n9thnEE+7RObeYs3fA=
+github.com/hashicorp/terraform-plugin-testing v1.13.3 h1:QLi/khB8Z0a5L54AfPrHukFpnwsGL8cwwswj4RZduCo=
+github.com/hashicorp/terraform-plugin-testing v1.13.3/go.mod h1:WHQ9FDdiLoneey2/QHpGM/6SAYf4A7AZazVg7230pLE=
 github.com/hashicorp/terraform-registry-address v0.2.5 h1:2GTftHqmUhVOeuu9CW3kwDkRe4pcBDq0uuK5VJngU1M=
 github.com/hashicorp/terraform-registry-address v0.2.5/go.mod h1:PpzXWINwB5kuVS5CA7m1+eO2f1jKb5ZDIxrOPfpnGkg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/ibm/service/project/data_source_ibm_project.go
+++ b/ibm/service/project/data_source_ibm_project.go
@@ -394,10 +394,10 @@ func DataSourceIbmProject() *schema.Resource {
 							Computed:    true,
 							Description: "A brief explanation of the project's use in the configuration of a deployable architecture. A project can be created without providing a description.",
 						},
-						"auto_deploy": &schema.Schema{
-							Type:        schema.TypeBool,
+						"auto_deploy_mode": &schema.Schema{
+							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "A boolean flag to enable auto deploy.",
+							Description: "This is an advanced setting to auto deploy to tell how auto deploy should behave when it is enabled. There are 2 options:> 1. `auto_approval` will automatically approve the configuration after validated without user confirmation.> 2. `manual_approval` will require user confirmation to approve the configuration after validated before deploying the configuration starts.",
 						},
 						"monitoring_enabled": &schema.Schema{
 							Type:        schema.TypeBool,
@@ -457,6 +457,11 @@ func DataSourceIbmProject() *schema.Resource {
 									},
 								},
 							},
+						},
+						"auto_deploy": &schema.Schema{
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "A boolean flag to enable deploying configurations automatically.",
 						},
 					},
 				},
@@ -563,7 +568,7 @@ func dataSourceIbmProjectRead(context context.Context, d *schema.ResourceData, m
 	}
 
 	definition := []map[string]interface{}{}
-	definitionMap, err := DataSourceIbmProjectProjectDefinitionPropertiesToMap(project.Definition)
+	definitionMap, err := DataSourceIbmProjectProjectDefinitionToMap(project.Definition)
 	if err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_project", "read", "definition-to-map").GetDiag()
 	}
@@ -706,7 +711,7 @@ func DataSourceIbmProjectProjectEnvironmentSummaryDefinitionToMap(model *project
 	return modelMap, nil
 }
 
-func DataSourceIbmProjectProjectDefinitionPropertiesToMap(model *projectv1.ProjectDefinitionProperties) (map[string]interface{}, error) {
+func DataSourceIbmProjectProjectDefinitionToMap(model *projectv1.ProjectDefinition) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.Name != nil {
 		modelMap["name"] = *model.Name
@@ -714,9 +719,7 @@ func DataSourceIbmProjectProjectDefinitionPropertiesToMap(model *projectv1.Proje
 	if model.Description != nil {
 		modelMap["description"] = *model.Description
 	}
-	if model.AutoDeploy != nil {
-		modelMap["auto_deploy"] = *model.AutoDeploy
-	}
+	modelMap["auto_deploy_mode"] = *model.AutoDeployMode
 	if model.MonitoringEnabled != nil {
 		modelMap["monitoring_enabled"] = *model.MonitoringEnabled
 	}
@@ -736,6 +739,9 @@ func DataSourceIbmProjectProjectDefinitionPropertiesToMap(model *projectv1.Proje
 			return modelMap, err
 		}
 		modelMap["terraform_engine"] = []map[string]interface{}{terraformEngineMap}
+	}
+	if model.AutoDeploy != nil {
+		modelMap["auto_deploy"] = *model.AutoDeploy
 	}
 	return modelMap, nil
 }

--- a/ibm/service/project/data_source_ibm_project_config_test.go
+++ b/ibm/service/project/data_source_ibm_project_config_test.go
@@ -61,6 +61,7 @@ func testAccCheckIbmProjectConfigDataSourceConfigBasic() string {
                 destroy_on_delete = true
                 monitoring_enabled = true
                 auto_deploy = false
+                auto_deploy_mode = "manual_approval"
             }
 		}
 

--- a/ibm/service/project/data_source_ibm_project_environment_test.go
+++ b/ibm/service/project/data_source_ibm_project_environment_test.go
@@ -52,7 +52,8 @@ func testAccCheckIbmProjectEnvironmentDataSourceConfigBasic() string {
                 description = "acme-microservice description"
                 destroy_on_delete = true
                 monitoring_enabled = true
-                auto_deploy = true
+                auto_deploy = false
+                auto_deploy_mode = "manual_approval"
             }
         }
 

--- a/ibm/service/project/data_source_ibm_project_test.go
+++ b/ibm/service/project/data_source_ibm_project_test.go
@@ -61,7 +61,8 @@ func testAccCheckIbmProjectDataSourceConfigBasic(projectLocation string, project
                 description = "acme-microservice description"
                 destroy_on_delete = true
                 monitoring_enabled = true
-                auto_deploy = true
+                auto_deploy = false
+                auto_deploy_mode = "manual_approval"
             }
 		}
 
@@ -357,7 +358,7 @@ func TestDataSourceIbmProjectProjectEnvironmentSummaryDefinitionToMap(t *testing
 	checkResult(result)
 }
 
-func TestDataSourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
+func TestDataSourceIbmProjectProjectDefinitionToMap(t *testing.T) {
 	checkResult := func(result map[string]interface{}) {
 		projectDefinitionStoreModel := make(map[string]interface{})
 		projectDefinitionStoreModel["type"] = "gh"
@@ -372,11 +373,12 @@ func TestDataSourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
 		model := make(map[string]interface{})
 		model["name"] = "testString"
 		model["description"] = "testString"
-		model["auto_deploy"] = false
+		model["auto_deploy_mode"] = "manual_approval"
 		model["monitoring_enabled"] = false
 		model["destroy_on_delete"] = true
 		model["store"] = []map[string]interface{}{projectDefinitionStoreModel}
 		model["terraform_engine"] = []map[string]interface{}{projectTerraformEngineSettingsModel}
+		model["auto_deploy"] = false
 
 		assert.Equal(t, result, model)
 	}
@@ -391,16 +393,17 @@ func TestDataSourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
 	projectTerraformEngineSettingsModel.ID = core.StringPtr("testString")
 	projectTerraformEngineSettingsModel.Type = core.StringPtr("terraform-enterprise")
 
-	model := new(projectv1.ProjectDefinitionProperties)
+	model := new(projectv1.ProjectDefinition)
 	model.Name = core.StringPtr("testString")
 	model.Description = core.StringPtr("testString")
-	model.AutoDeploy = core.BoolPtr(false)
+	model.AutoDeployMode = core.StringPtr("manual_approval")
 	model.MonitoringEnabled = core.BoolPtr(false)
 	model.DestroyOnDelete = core.BoolPtr(true)
 	model.Store = projectDefinitionStoreModel
 	model.TerraformEngine = projectTerraformEngineSettingsModel
+	model.AutoDeploy = core.BoolPtr(false)
 
-	result, err := project.DataSourceIbmProjectProjectDefinitionPropertiesToMap(model)
+	result, err := project.DataSourceIbmProjectProjectDefinitionToMap(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }

--- a/ibm/service/project/resource_ibm_project_config_test.go
+++ b/ibm/service/project/resource_ibm_project_config_test.go
@@ -55,6 +55,7 @@ func testAccCheckIbmProjectConfigConfigBasic() string {
                 destroy_on_delete = true
                 monitoring_enabled = true
                 auto_deploy = false
+                auto_deploy_mode = "manual_approval"
             }
 		}
 

--- a/ibm/service/project/resource_ibm_project_environment_test.go
+++ b/ibm/service/project/resource_ibm_project_environment_test.go
@@ -54,6 +54,7 @@ func testAccCheckIbmProjectEnvironmentConfigBasic() string {
                 destroy_on_delete = true
                 monitoring_enabled = true
                 auto_deploy = true
+                auto_deploy_mode = "auto_approval"
             }
         }
 

--- a/ibm/service/project/resource_ibm_project_test.go
+++ b/ibm/service/project/resource_ibm_project_test.go
@@ -57,6 +57,7 @@ func testAccCheckIbmProjectConfigBasic(location string, resourceGroup string) st
                 destroy_on_delete = true
                 monitoring_enabled = true
                 auto_deploy = true
+                auto_deploy_mode = "auto_approval"
             }
 		}
 	`, location, resourceGroup)
@@ -380,7 +381,7 @@ func TestResourceIbmProjectProjectEnvironmentSummaryDefinitionToMap(t *testing.T
 	checkResult(result)
 }
 
-func TestResourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
+func TestResourceIbmProjectProjectDefinitionToMap(t *testing.T) {
 	checkResult := func(result map[string]interface{}) {
 		projectDefinitionStoreModel := make(map[string]interface{})
 		projectDefinitionStoreModel["type"] = "gh"
@@ -395,11 +396,12 @@ func TestResourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
 		model := make(map[string]interface{})
 		model["name"] = "testString"
 		model["description"] = "testString"
-		model["auto_deploy"] = false
+		model["auto_deploy_mode"] = "manual_approval"
 		model["monitoring_enabled"] = false
 		model["destroy_on_delete"] = true
 		model["store"] = []map[string]interface{}{projectDefinitionStoreModel}
 		model["terraform_engine"] = []map[string]interface{}{projectTerraformEngineSettingsModel}
+		model["auto_deploy"] = false
 
 		assert.Equal(t, result, model)
 	}
@@ -414,16 +416,17 @@ func TestResourceIbmProjectProjectDefinitionPropertiesToMap(t *testing.T) {
 	projectTerraformEngineSettingsModel.ID = core.StringPtr("testString")
 	projectTerraformEngineSettingsModel.Type = core.StringPtr("terraform-enterprise")
 
-	model := new(projectv1.ProjectDefinitionProperties)
+	model := new(projectv1.ProjectDefinition)
 	model.Name = core.StringPtr("testString")
 	model.Description = core.StringPtr("testString")
-	model.AutoDeploy = core.BoolPtr(false)
+	model.AutoDeployMode = core.StringPtr("manual_approval")
 	model.MonitoringEnabled = core.BoolPtr(false)
 	model.DestroyOnDelete = core.BoolPtr(true)
 	model.Store = projectDefinitionStoreModel
 	model.TerraformEngine = projectTerraformEngineSettingsModel
+	model.AutoDeploy = core.BoolPtr(false)
 
-	result, err := project.ResourceIbmProjectProjectDefinitionPropertiesToMap(model)
+	result, err := project.ResourceIbmProjectProjectDefinitionToMap(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }
@@ -505,11 +508,12 @@ func TestResourceIbmProjectMapToProjectPrototypeDefinition(t *testing.T) {
 		model := new(projectv1.ProjectPrototypeDefinition)
 		model.Name = core.StringPtr("testString")
 		model.Description = core.StringPtr("testString")
-		model.AutoDeploy = core.BoolPtr(false)
+		model.AutoDeployMode = core.StringPtr("manual_approval")
 		model.MonitoringEnabled = core.BoolPtr(false)
 		model.DestroyOnDelete = core.BoolPtr(true)
 		model.Store = projectDefinitionStoreModel
 		model.TerraformEngine = projectTerraformEngineSettingsModel
+		model.AutoDeploy = core.BoolPtr(false)
 
 		assert.Equal(t, result, model)
 	}
@@ -527,11 +531,12 @@ func TestResourceIbmProjectMapToProjectPrototypeDefinition(t *testing.T) {
 	model := make(map[string]interface{})
 	model["name"] = "testString"
 	model["description"] = "testString"
-	model["auto_deploy"] = false
+	model["auto_deploy_mode"] = "manual_approval"
 	model["monitoring_enabled"] = false
 	model["destroy_on_delete"] = true
 	model["store"] = []interface{}{projectDefinitionStoreModel}
 	model["terraform_engine"] = []interface{}{projectTerraformEngineSettingsModel}
+	model["auto_deploy"] = false
 
 	result, err := project.ResourceIbmProjectMapToProjectPrototypeDefinition(model)
 	assert.Nil(t, err)
@@ -760,8 +765,8 @@ func TestResourceIbmProjectMapToSchematicsWorkspace(t *testing.T) {
 	checkResult(result)
 }
 
-func TestResourceIbmProjectMapToProjectPatchDefinitionBlock(t *testing.T) {
-	checkResult := func(result *projectv1.ProjectPatchDefinitionBlock) {
+func TestResourceIbmProjectMapToProjectDefinitionPatch(t *testing.T) {
+	checkResult := func(result *projectv1.ProjectDefinitionPatch) {
 		projectDefinitionStoreModel := new(projectv1.ProjectDefinitionStore)
 		projectDefinitionStoreModel.Type = core.StringPtr("gh")
 		projectDefinitionStoreModel.URL = core.StringPtr("testString")
@@ -772,14 +777,15 @@ func TestResourceIbmProjectMapToProjectPatchDefinitionBlock(t *testing.T) {
 		projectTerraformEngineSettingsModel.ID = core.StringPtr("testString")
 		projectTerraformEngineSettingsModel.Type = core.StringPtr("terraform-enterprise")
 
-		model := new(projectv1.ProjectPatchDefinitionBlock)
+		model := new(projectv1.ProjectDefinitionPatch)
 		model.Name = core.StringPtr("testString")
-		model.AutoDeploy = core.BoolPtr(true)
 		model.Description = core.StringPtr("testString")
+		model.AutoDeployMode = core.StringPtr("auto_approval")
 		model.MonitoringEnabled = core.BoolPtr(true)
 		model.DestroyOnDelete = core.BoolPtr(true)
 		model.Store = projectDefinitionStoreModel
 		model.TerraformEngine = projectTerraformEngineSettingsModel
+		model.AutoDeploy = core.BoolPtr(true)
 
 		assert.Equal(t, result, model)
 	}
@@ -796,14 +802,15 @@ func TestResourceIbmProjectMapToProjectPatchDefinitionBlock(t *testing.T) {
 
 	model := make(map[string]interface{})
 	model["name"] = "testString"
-	model["auto_deploy"] = true
 	model["description"] = "testString"
+	model["auto_deploy_mode"] = "auto_approval"
 	model["monitoring_enabled"] = true
 	model["destroy_on_delete"] = true
 	model["store"] = []interface{}{projectDefinitionStoreModel}
 	model["terraform_engine"] = []interface{}{projectTerraformEngineSettingsModel}
+	model["auto_deploy"] = true
 
-	result, err := project.ResourceIbmProjectMapToProjectPatchDefinitionBlock(model)
+	result, err := project.ResourceIbmProjectMapToProjectDefinitionPatch(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -111,8 +111,10 @@ Nested schema for **cumulative_needs_attention_view**:
   * Constraints: The default value is `false`.
 * `definition` - (List) The definition of the project.
 Nested schema for **definition**:
-	* `auto_deploy` - (Boolean) A boolean flag to enable auto deploy.
+	* `auto_deploy` - (Boolean) A boolean flag to enable deploying configurations automatically.
 	  * Constraints: The default value is `false`.
+	* `auto_deploy_mode` - (String) This is an advanced setting to auto deploy to tell how auto deploy should behave when it is enabled. There are 2 options:> 1. `auto_approval` will automatically approve the configuration after validated without user confirmation.> 2. `manual_approval` will require user confirmation to approve the configuration after validated before deploying the configuration starts.
+	  * Constraints: The default value is `manual_approval`. Allowable values are: `auto_approval`, `manual_approval`.
 	* `description` - (String) A brief explanation of the project's use in the configuration of a deployable architecture. A project can be created without providing a description.
 	  * Constraints: The default value is `''`. The maximum length is `1024` characters. The minimum length is `0` characters. The value must match regular expression `/^$|^(?!\\s)(?!.*\\s$)[^\\x00-\\x1F]*$/`.
 	* `destroy_on_delete` - (Boolean) The policy that indicates whether the resources are undeployed or not when a project is deleted.

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -20,6 +20,7 @@ resource "ibm_project" "project_instance" {
     destroy_on_delete = true
     monitoring_enabled = true
     auto_deploy = true
+    auto_deploy_mode = "auto_approval"
   }
   location = "us-south"
   resource_group = "Default"
@@ -95,8 +96,10 @@ Nested schema for **configs**:
 	  * Constraints: The maximum value is `10000`. The minimum value is `0`.
 * `definition` - (Required, List) The definition of the project.
 Nested schema for **definition**:
-	* `auto_deploy` - (Optional, Boolean) A boolean flag to enable auto deploy.
+	* `auto_deploy` - (Optional, Boolean) A boolean flag to enable deploying configurations automatically.
 	  * Constraints: The default value is `false`.
+	* `auto_deploy_mode` - (Required, String) This is an advanced setting to auto deploy to tell how auto deploy should behave when it is enabled. There are 2 options:> 1. `auto_approval` will automatically approve the configuration after validated without user confirmation.> 2. `manual_approval` will require user confirmation to approve the configuration after validated before deploying the configuration starts.
+	  * Constraints: The default value is `manual_approval`. Allowable values are: `auto_approval`, `manual_approval`.
 	* `description` - (Optional, String) A brief explanation of the project's use in the configuration of a deployable architecture. A project can be created without providing a description.
 	  * Constraints: The default value is `''`. The maximum length is `1024` characters. The minimum length is `0` characters. The value must match regular expression `/^$|^(?!\\s)(?!.*\\s$)[^\\x00-\\x1F]*$/`.
 	* `destroy_on_delete` - (Optional, Boolean) The policy that indicates whether the resources are undeployed or not when a project is deleted.


### PR DESCRIPTION
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
rangelil@Riccardos-MacBook-Pro terraform-provider-ibm % make testacc TEST=./ibm/service/project
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/project -v  -timeout 700m 
[WARN] Set the environment variable IBM_APPID_TENANT_ID for testing AppID resources, AppID tests will fail if this is not set
[WARN] Set the environment variable IBM_APPID_TEST_USER_EMAIL for testing AppID user resources, the tests will fail if this is not set
[WARN] Set the environment variable IBM_ORG for testing ibm_org  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_SPACE for testing ibm_space  resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID1 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_ID2 for testing ibm_space resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAMACCOUNTID for testing ibm_iam_trusted_profile resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_SERVICE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_IAM_TRUSTED_PROFILE_ID for testing ibm_iam_trusted_profile_identity resource Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_DATACENTER for testing ibm_container_cluster resource else it is set to default value 'par01'
[WARN] Set the environment variable IBM_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'b3c.4x16'
[WARN] Set the environment variable IBM_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_UPDATE_CERT_CRN for testing ibm_container_alb_cert or ibm_container_ingress_secret_tls resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_SECRET_CRN_2 for testing ibm_container_ingress_secret_opaque resource else it is set to default value
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_CRN for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_INGRESS_INSTANCE_SECRET_GROUP_ID for testing ibm_container_ingress_instance resource. Some tests for that resource will fail if this is not set correctly
[WARN] Set the environment variable IBM_CONTAINER_REGION for testing ibm_container resources else it is set to default value 'eu-de'
[WARN] Set the environment variable IBM_CIS_INSTANCE with a VALID CIS Instance NAME for testing ibm_cis resources on staging/test
[WARN] Set the environment variable IBM_CIS_DOMAIN_STATIC with the Domain name registered with the CIS instance on test/staging. Domain must be predefined in CIS to avoid CIS billing costs due to domain delete/create
[WARN] Set the environment variable IBM_CIS_DOMAIN_TEST with a VALID Domain name for testing the one time create and delete of a domain in CIS. Note each create/delete will trigger a monthly billing instance. Only to be run in staging/test
[WARN] Set the environment variable IBM_CIS_RESOURCE_GROUP with the resource group for the CIS Instance 
[WARN] Set the environment variable IBM_COS_CRN with a VALID COS instance CRN for testing ibm_cos_* resources
[WARN] Set the environment variable IBM_COS_Bucket_CRN with a VALID BUCKET CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_COS_Backup_Vault2 with a VALID BACKUP VAULT NAME  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_COS_Backup_Crn with a VALID BACKUP VAULT CRN  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_COS_Backup_Crn2 with a VALID BACKUP VAULT CRN  for testing ibm_cos_backup_vault* resources
[WARN] Set the environment variable IBM_KMS_KEY_CRN with a VALID key crn for a KP/HPCS root key
[WARN] Set the environment variable IBM_COS_Backup_Policy_Id with a VALID POLICYS ID for testing ibm_cos_backup_policy* resources
[WARN] Set the environment variable IBM_COS_ACTIVITY_TRACKER_CRN with a VALID ACTIVITY TRACKER INSTANCE CRN in valid region for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_METRICS_MONITORING_CRN with a VALID METRICS MONITORING CRN for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_BUCKET_NAME with a VALID BUCKET Name for testing ibm_cos_bucket* resources
[WARN] Set the environment variable IBM_COS_NAME with a VALID COS instance name for testing resources with cos deps
[WARN] Set the environment variable IBM_TRUSTED_MACHINE_TYPE for testing ibm_container_cluster resource else it is set to default value 'mb1c.16x64'
[WARN] Set the environment variable IBM_BM_EXTENDED_HW_TESTING to true/false for testing ibm_compute_bare_metal resource else it is set to default value 'false'
[WARN] Set the environment variable IBM_PUBLIC_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393319'
[WARN] Set the environment variable IBM_PRIVATE_VLAN_ID for testing ibm_container_cluster resource else it is set to default value '2393321'
[WARN] Set the environment variable IBM_KUBE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.18.14'
[WARN] Set the environment variable IBM_KUBE_UPDATE_VERSION for testing ibm_container_cluster resource else it is set to default value '1.19.6'
[WARN] Set the environment variable IBM_PRIVATE_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1636107'
[WARN] Set the environment variable IBM_PUBLIC_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[WARN] Set the environment variable IBM_SUBNET_ID for testing ibm_container_cluster resource else it is set to default value '1165645'
[INFO] Set the environment variable IBM_IPSEC_DATACENTER for testing ibm_ipsec_vpn resource else it is set to default value 'tok02'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_SUBNET_ID for testing ibm_ipsec_vpn resource else it is set to default value '123456'
[INFO] Set the environment variable IBM_IPSEC_CUSTOMER_PEER_IP for testing ibm_ipsec_vpn resource else it is set to default value '192.168.0.1'
[WARN] Set the environment variable IBM_LBAAS_DATACENTER for testing ibm_lbaas resource else it is set to default value 'dal13'
[WARN] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '2144241'
[WARN] Set the environment variable IBM_LB_LISTENER_CERTIFICATE_INSTANCE for testing ibm_is_lb_listener resource for https redirect else it is set to default value 'crn:v1:staging:public:cloudcerts:us-south:a/2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed'
[WARN] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'
[WARN] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value 'ams03'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538975'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2538967'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PRIVATE_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388377'
[WARN] Set the environment variable IBM_WORKER_POOL_ZONE_UPDATE_PUBLIC_VLAN for testing ibm_container_worker_pool_zone_attachment resource else it is set to default value '2388375'
[WARN] Set the environment variable IBM_WORKER_POOL_SECONDARY_STORAGE for testing secondary_storage attachment to IKS workerpools
[WARN] Set the environment variable IBM_PLACEMENT_GROUP_NAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-group'
[INFO] Set the environment variable SL_REGION for testing ibm_is_region datasource else it is set to default value 'us-south'
[INFO] Set the environment variable SL_ZONE for testing ibm_is_zone datasource else it is set to default value 'us-south-1'
[INFO] Set the environment variable SL_ZONE_2 for testing ibm_is_zone datasource else it is set to default value 'us-south-2'
[INFO] Set the environment variable SL_ZONE_3 for testing ibm_is_zone datasource else it is set to default value 'us-south-3'
[INFO] Set the environment variable SL_CIDR for testing ibm_is_subnet else it is set to default value '10.240.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable IS_IPV4_ADDRESS for testing ibm_is_instance else it is set to default value '10.240.0.6'
[INFO] Set the environment variable IS_ACCOUNT_ID for testing private_path_service_gateway_account_policy else it is set to default value 'fee82deba12e4c0fb69c3b09d1f12345'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_PROFILE_NAME for testing cluster_network_profile else it is set to default value 'h100'
[INFO] Set the environment variable IS_INSTANCE_GPU_PROFILE_NAME for testing cluster_network_attachments else it is set to default value 'gx3d-160x1792x8h100'
[INFO] Set the environment variable IS_CLUSTER_NETWORK_SUBNET_PREFIXES_CIDR for testing cluster_network else it is set to default value '10.1.0.0/24'
[INFO] Set the environment variable SL_ADDRESS_PREFIX_CIDR for testing ibm_is_vpc_address_prefix else it is set to default value '10.120.0.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_subnet else it is set to default value '10.240.64.0/24'
[INFO] Set the environment variable SL_CIDR_2 for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa.pub'
[INFO] Set the environment variable IS_PRIVATE_SSH_KEY_PATH for testing ibm_is_instance datasource else it is set to default value './test-fixtures/.ssh/pkcs8_rsa'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable SL_RESOURCE_GROUP_ID_UPDATE for testing with different resource group id else it is set to default value 'c01d34dff4364763476834c990398zz8'
[INFO] Set the environment variable IS_RESOURCE_CRN for testing with created resource instance
[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-587a041d-9246-44f0-980b-56a327cf5bd7'
[INFO] Set the environment variable IS_IMAGE2 for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r134-f47cc24c-e020-4db5-ad96-1e5be8b5853b'
[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776'
[INFO] Set the environment variable IS_COS_BUCKET_NAME for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_COS_BUCKET_CRN for testing ibm_is_image_export_job else it is set to default value 'bucket-27200-lwx4cfvcue'
[INFO] Set the environment variable IS_INSTANCE_NAME for testing ibm_is_instance resource else it is set to default value 'instance-01'
[INFO] Set the environment variable IS_BACKUP_POLICY_JOB_ID for testing ibm_is_backup_policy_job datasource
[INFO] Set the environment variable IS_BACKUP_POLICY_ID for testing ibm_is_backup_policy_jobs datasource
[INFO] Set the environment variable IS_REMOTE_CP_BAAS_ENCRYPTION_KEY_CRN for testing remote_copies_policy with Baas plans, else it is set to default value, 'crn:v1:bluemix:public:kms:us-south:a/dffc98a0f1f0f95f6613b3b752286b87:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'cx2-2x4'
[INFO] Set the environment variable SL_KMS_INSTANCE_ID for testing ibm_kms_key resource else it is set to default value '30222bb5-1c6d-3834-8d78-ae6348cf8z61'
[INFO] Set the environment variable SL_KMS_KEY_NAME for testing ibm_kms_key resource else it is set to default value 'tfp-test-key'
[INFO] Set the environment variable SL_INSTANCE_PROFILE_UPDATE for testing ibm_is_instance resource else it is set to default value 'cx2-4x8'
[INFO] Set the environment variable IS_CATALOG_IMAGE_NAME for testing ibm_is_instance_template resource else it is set to default value 'test-catalog'
[INFO] Set the environment variable IS_BOOT_SNAPSHOT_ID for testing ibm_is_instance_template resource else it is set to default value 'r006-d7fejbe-2dhj-442df-b2iha-ccjbecbjbcejce'
[INFO] Set the environment variable IS_BARE_METAL_SERVER_PROFILE for testing ibm_is_bare_metal_server resource else it is set to default value 'bx2-metal-96x384'
[INFO] Set the environment variable IsBareMetalServerImage for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-55a03390-3245-450f-82c4-0cb47f632b59'
[INFO] Set the environment variable IsBareMetalServerImage2 for testing ibm_is_bare_metal_server resource else it is set to default value 'r006-2d1f36b0-df65-4570-82eb-df7ae5f778b1'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:82df2e3c-53a5-43c6-89ce-dcf78be18668::'
[INFO] Set the environment variable IS_DNS_INSTANCE_CRN1 for testing ibm_is_lb resource else it is set to default value 'crn:v1:staging:public:dns-svcs:global:a/efe5afc483594adaa8325e2b4d1290df:599ae4aa-c554-4a88-8bb2-b199b9a3c046::'
[INFO] Set the environment variable IS_DNS_ZONE_ID for testing ibm_is_lb resource else it is set to default value 'dd501d1d-490b-4bb4-a05d-a31954a1c59e'
[INFO] Set the environment variable IS_DNS_ZONE_ID_1 for testing ibm_is_lb resource else it is set to default value 'b1def78d-51b3-4ea5-a746-1b64c992fcab'
[INFO] Set the environment variable IS_DEDICATED_HOST_NAME for testing ibm_is_instance resource else it is set to default value 'tf-dhost-01'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_ID for testing ibm_is_instance resource else it is set to default value '0717-9104e7b5-77ad-44ad-9eaa-091e6b6efce1'
[INFO] Set the environment variable IS_DEDICATED_HOST_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-host-152x608'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_CLASS for testing ibm_is_instance resource else it is set to default value 'bx2d'
[INFO] Set the environment variable IS_DEDICATED_HOST_GROUP_FAMILY for testing ibm_is_instance resource else it is set to default value 'balanced'
[INFO] Set the environment variable SL_INSTANCE_PROFILE for testing ibm_is_instance resource else it is set to default value 'bx2d-16x64'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value 'tier-3iops'
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_SHARE_PROFILE for testing ibm_is_instance resource else it is set to default value
[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'
[INFO] Set the environment variable IS_VIRTUAL_NETWORK_INTERFACE for testing ibm_is_virtual_network_interface else it is set to default value 'c93dc4c6-e85a-4da2-9ea6-f24576256122'
[INFO] Set the environment variable IS_FLOATING_IP for testing ibm_is_virtual_network_interface else it is set to default value 'r006-9fc3948f-1b01-406c-baa5-e86b185e559f'
[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'
[INFO] Set the environment variable SL_ROUTE_NEXTHOP else it is set to default value '10.0.0.4'
[INFO] Set the environment variable ISSnapshotCRN for ibm_is_snapshot resource else it is set to default value 'crn:v1:bluemix:public:is:ca-tor:a/xxxxxxxx::snapshot:xxxx-xxxxc-xxx-xxxx-xxxx-xxxxxxxxxx'
[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'
[INFO] Set the environment variable ICD_DB_BACKUP_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251:backup:0d862fdb-4faa-42e5-aecb-5057f4d399c3'
[INFO] Set the environment variable ICD_DB_TASK_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:367b0a22-05bb-41e3-a1ed-ded1ff0889e5:task:882013a6-2751-4df7-a77a-98d258638704'
[INFO] Set the environment variable PI_IMAGE for testing ibm_pi_image resource else it is set to default value '7200-03-03'
[INFO] Set the environment variable PI_SAP_IMAGE for testing ibm_pi_image resource else it is set to default value 'Linux-RHEL-SAP-8-2'
[INFO] Set the environment variable PI_IMAGE_BUCKET_NAME for testing ibm_pi_image resource else it is set to default value 'images-public-bucket'
[INFO] Set the environment variable PI_IMAGE_BUCKET_FILE_NAME for testing ibm_pi_image resource else it is set to default value 'rhel.ova.gz'
[INFO] Set the environment variable PI_IMAGE_BUCKET_ACCESS_KEY for testing ibm_pi_image_export resource else it is set to default value 'images-bucket-access-key'
[INFO] Set the environment variable PI_IMAGE_BUCKET_SECRET_KEY for testing ibm_pi_image_export resource else it is set to default value 'PI_IMAGE_BUCKET_SECRET_KEY'
[INFO] Set the environment variable PI_IMAGE_BUCKET_REGION for testing ibm_pi_image resource else it is set to default value 'us-east'
[INFO] Set the environment variable PI_IMAGE_ID for testing ibm_pi_image resource else it is set to default value 'IBMi-72-09-2924-11'
[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_ROUTE_FILTER_ID for testing ibm_pi_network_peer_route_filter resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_INTERFACE_ID for testing ibm_pi_network_interface resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_NETWORK_SECURITY_GROUP_RULE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_NAME for testing ibm_pi_network_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBARDING_SOURCE_CRN for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_AUXILIARY_VOLUME_NAME for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_NAME for testing ibm_pi_volume_group resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_GROUP_ID for testing ibm_pi_volume_group_storage_details data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_VOLUME_ONBOARDING_ID for testing ibm_pi_volume_onboarding resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUDINSTANCE_ID for testing ibm_pi_image resource else it is set to default value 'd16705bd-7f1a-48c9-9e0e-1c17b71e7331'
[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'
[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_DHCP_ID for testing ibm_pi_dhcp resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CLOUD_CONNECTION_NAME for testing ibm_pi_cloud_connection resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'
[WARN] Set the environment variable PI_REMOTE_ID for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_REMOTE_TYPE for testing ibm_pi_network_security_group resource else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_SPP_PLACEMENT_GROUP_ID for testing ibm_pi_spp_placement_group resource else it is set to default value 'tf-pi-spp-placement-group'
[INFO] Set the environment variable PI_STORAGE_POOL for testing ibm_pi_storage_pool_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_STORAGE_TYPE for testing ibm_pi_storage_type_capacity else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_STORAGE_IMAGE_PATH for testing Pi_capture_storage_image_path resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_ACCESS_KEY for testing Pi_capture_cloud_storage_access_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_SECRET_KEY for testing Pi_capture_cloud_storage_secret_key resource else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable PI_CAPTURE_CLOUD_STORAGE_REGION for testing Pi_capture_cloud_storage_region resource else it is set to default value 'us-south'
[WARN] Set the environment variable PI_SHARED_PROCESSOR_POOL_ID for testing ibm_pi_shared_processor_pool resource else it is set to default value 'tf-pi-shared-processor-pool'
[WARN] Set the environment variable PI_STORAGE_CONNECTION for testing pi_storage_connection resource else it is empty
[INFO] Set the environment variable PI_TARGET_STORAGE_TIER for testing Pi_target_storage_tier resource else it is set to default value 'terraform-test-tier'
[INFO] Set the environment variable PI_VOLUME_CLONE_TASK_ID for testing Pi_volume_clone_task_id resource else it is set to default value 'terraform-test-volume-clone-task-id'
[INFO] Set the environment variable PI_VIRTUAL_SERIAL_NUMBER for testing ibm_pi_virtual_serial_number data source else it is set to default value 'terraform-test-power'
[WARN] Set the environment variable PI_RESOURCE_GROUP_ID for testing ibm_pi_workspace resource else it is set to default value ''
[WARN] Set the environment variable PI_ROUTE_ID for testing ibm_pi_route data source else it is set to default value ''
[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''
[WARN] Set the environment variable PI_HOST_ID for testing ibm_pi_host resource else it is set to default value ''
[INFO] Set the environment variable PI_NETWORK_ADDRESS_GROUP_ID for testing ibm_pi_network_address_group data source else it is set to default value 'terraform-test-power'
[INFO] Set the environment variable SCHEMATICS_WORKSPACE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_TEMPLATE_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_ACTION_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_AGENT_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_JOB_ID for testing schematics resources else it is set to default value
[INFO] Set the environment variable SCHEMATICS_REPO_URL for testing schematics resources else tests will fail if this is not set correctly
[INFO] Set the environment variable SCHEMATICS_REPO_BRANCH for testing schematics resources else tests will fail if this is not set correctly
[WARN] Set the environment variable IMAGE_COS_URL with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IS_DELEGATED_VPC with a VALID created vpc name for testing ibm_is_vpc data source on staging/test
[WARN] Set the environment variable IMAGE_COS_URL_ENCRYPTED with a VALID COS Image SQL URL for testing ibm_is_image resources on staging/test
[WARN] Set the environment variable IMAGE_OPERATING_SYSTEM with a VALID Operating system for testing ibm_is_image resources on staging/test
[INFO] Set the environment variable IS_IMAGE_NAME for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-18-04-1-minimal-amd64-2`
[INFO] Set the environment variable IS_IMAGE_NAME2 for testing data source ibm_is_image else it is set to default value `ibm-ubuntu-20-04-6-minimal-amd64-5`
[INFO] Set the environment variable IS_IMAGE_ENCRYPTED_DATA_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IS_IMAGE_ENCRYPTION_KEY for testing resource ibm_is_image else it is set to default value
[INFO] Set the environment variable IBM_FUNCTION_NAMESPACE for testing ibm_function_package, ibm_function_action, ibm_function_rule, ibm_function_trigger resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable HPCS_INSTANCE_ID for testing data_source_ibm_kms_key_test else it is set to default value
[INFO] Set the environment variable HPCS_INSTANCE_NAME for testing data_source_ibm_hpcs_test else it is set to default value
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_ID for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_INSTANCE_REGION for testing Secrets Manager's tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing Event Notifications for Secrets Manager tests else tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_EN_INSTANCE_CRN for testing IAM Credentials secret's tests else tests will assume that IAM Credentials engine is already configured and fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_SERVICE_ID or SECRETS_MANAGER_IAM_CREDENTIALS_SECRET_ACCESS_GROUP for testing IAM Credentials secret's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_ENVIRONMENT for testing public certificate's tests, else it is set to default value ('production'). For public certificate's tests, tests will fail if this is not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_LETS_ENCRYPT_PRIVATE_KEY for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_COMMON_NAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_VALIDATE_MANUAL_DNS_CIS_ZONE_ID for testing validate manual dns' test, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CERTIFICATE_CIS_CRN for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_USERNAME for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PUBLIC_CLASSIC_INFRASTRUCTURE_PASSWORD for testing public certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_IMPORTED_CERTIFICATE_PATH_TO_CERTIFICATE for testing imported certificate's tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_CREDENTIALS_COS_CRN for testing service credentials' tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_IAM_SECRET_SERVICE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_TYPE for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_INSTANCE_CRN for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_PRIVATE_CERTIFICATE_CONFIGURATION_CRYPTO_KEY_PROVIDER_PRIVATE_KEYSTORE_ID for testing private certificate's configuration with crypto key tests, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_CODE_ENGINE_PROJECT_ID for testing custom credential secret, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_CODE_ENGINE_JOB_NAME for testing custom credential secret, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_CODE_ENGINE_RGION for testing custom credential secret, else tests fail if not set correctly
[INFO] Set the environment variable SECRETS_MANAGER_SERVICE_ID_FOR_CUSTOM_CREDENTIALS for testing custom credential secret, else tests fail if not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_API_KEY for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_ACCOUNT_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_CROSS_NETWORK_ID for testing ibm_tg_connection resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_TG_POWER_VS_NETWORK_ID for testing ibm_tg_connection resource else tests will fail if this is not set correctly
[INFO] Set the environment variable ACCOUNT_TO_BE_IMPORTED for testing import enterprise account resource else  tests will fail if this is not set correctly
[INFO] Set the environment variable COS_BUCKET for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_LOCATION for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable COS_BUCKET_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_LOCATION_UPDATE for testing update operation on billing snapshot configuration API
[INFO] Set the environment variable COS_REPORTS_FOLDER for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_FROM for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_DATE_TO for testing CRUD operations on billing snapshot configuration APIs
[INFO] Set the environment variable SNAPSHOT_MONTH for testing CRUD operations on billing snapshot configuration APIs
[WARN] Set the environment variable IBM_HPCS_ADMIN1 with a VALID HPCS Admin Key1 Path
[WARN] Set the environment variable IBM_HPCS_TOKEN1 with a VALID token for HPCS Admin Key1
[WARN] Set the environment variable IBM_HPCS_ADMIN2 with a VALID HPCS Admin Key2 Path
[WARN] Set the environment variable IBM_IAM_REALM_NAME with a VALID realm name for iam trusted profile claim rule
[WARN] Set the environment variable IBM_IAM_IKS_SA with a VALID realm name for iam trusted profile link
[WARN] Set the environment variable IBM_HPCS_TOKEN2 with a VALID token for HPCS Admin Key2
[WARN] Set the environment variable IBM_HPCS_ROOTKEY_CRN with a VALID CRN for a root key created in the HPCS instance
[INFO] Set the environment variable IBM_CLOUD_SHELL_ACCOUNT_ID for ibm-cloud-shell resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CLUSTER_VPC_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_create tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_SUBNET_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[WARN] Set the environment variable IBM_CLUSTER_VPC_RESOURCE_GROUP_ID for testing ibm_container_vpc_alb_create resources, ibm_container_vpc_alb_creates tests will fail if this is not set
[INFO] Set the environment variable IBM_CONTAINER_CLUSTER_NAME for ibm_container_nlb_dns resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_LOCATION_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable SATELLITE_RESOURCE_INSTANCE_ID for ibm_cos_bucket satellite location resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_ENDPOINT with a VALID SCC API ENDPOINT
[WARN] Set the environment variable IBMCLOUD_CONFIG_AGGREGATOR_INSTANCE_ID with a VALID SCC INSTANCE ID
[INFO] Set the environment variable IBM_CONTAINER_DEDICATEDHOST_POOL_ID for ibm_container_vpc_cluster resource to test dedicated host functionality
[INFO] Set the environment variable IBM_KMS_INSTANCE_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CRK_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_KMS_ACCOUNT_ID for ibm_container_vpc_cluster resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_CLUSTER_ID for ibm_container_vpc_worker_pool resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_CD_RESOURCE_GROUP_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_APPCONFIG_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_KEYPROTECT_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SECRETSMANAGER_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_CHANNEL_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_TEAM_NAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SLACK_WEBHOOK for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_PROJECT_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_JIRA_API_TOKEN for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_ACCESS_KEY for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_SAUCELABS_USERNAME for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_BITBUCKET_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITHUB_CONSOLIDATED_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_GITLAB_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_HOSTED_GIT_REPO_URL for testing CD resources, CD tests will fail if this is not set
[WARN] Set the environment variable IBM_CD_EVENTNOTIFICATIONS_INSTANCE_NAME for testing CD resources, CD tests will fail if this is not set
[INFO] Set the environment variable IS_CERTIFICATE_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IS_CLIENT_CA_CRN for testing ibm_is_vpn_server resource
[INFO] Set the environment variable IBM_AccountID_REPL for setting up authorization policy to enable replication feature resource or datasource else tests will fail if this is not set correctly
[WARN] Set the environment variable COS_API_KEY for testing COS targets, the tests will fail if this is not set
[WARN] Set the environment variable INGESTION_KEY for testing Logdna targets, the tests will fail if this is not set
[WARN] Set the environment variable IES_API_KEY for testing Event streams targets, the tests will fail if this is not set
[WARN] Set the environment variable ENTERPRISE_CRN for testing enterprise backup policy, the tests will fail if this is not set
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_GROUP_ID with the resource group for Code Engine
[WARN] Set the environment variable IBM_CODE_ENGINE_PROJECT_INSTANCE_ID with the ID of a Code Engine project instance
[WARN] Set the environment variable IBM_CODE_ENGINE_SERVICE_INSTANCE_ID with the ID of a IBM Cloud service instance, e.g. for COS
[WARN] Set the environment variable IBM_CODE_ENGINE_RESOURCE_KEY_ID with the ID of a resource key to access a service instance
[WARN] Set the environment variable IBM_CODE_ENGINE_DOMAIN_MAPPING_NAME with the name of a domain mapping
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT with the TLS certificate in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_KEY with a TLS key in base64 format
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_KEY_PATH to point to CERT KEY file path
[WARN] Set the environment variable IBM_CODE_ENGINE_TLS_CERT_PATH to point to CERT file path
[WARN] Set the environment variable IBM_SATELLITE_SSH_PUB_KEY with a ssh public key or ibm_satellite_* tests may fail
[INFO] Set the environment variable IBMCLOUD_MQCLOUD_CONFIG_ENDPOINT for ibm_mqcloud service else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_DEPLOYMENT_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_ID for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_KS_CERT_PATH for ibm_mqcloud_keystore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TS_CERT_PATH for ibm_mqcloud_truststore_certificate resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_LOCATION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSION for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_QUEUEMANAGER_VERSIONUPDATE for ibm_mqcloud_queue_manager resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TARGET_CRN for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_MQCLOUD_TRUSTED_PROFILE for ibm_mqcloud_virtual_private_endpoint resource or datasource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_INSTANCE_REGION for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_ID for testing cloud logs related operations
[INFO] Set the environment variable IBMCLOUD_LOGS_SERVICE_EVENT_NOTIFICATIONS_INSTANCE_REGION for testing cloud logs related operations
[WARN] Set the environment variable IBM_PAG_COS_INSTANCE_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_COS_BUCKET_REGION for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_NAME for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_SERVICE_PLAN for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_1 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_PAG_VPC_SUBNET_INS_2 for testing IBM PAG resource, the tests will fail if this is not set
[WARN] Set the environment variable IBM_VMAAS_DS_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_VMAAS_DS_PVDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_VMAAS_EDGE_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_VMAAS_TRANSIT_GATEWAY_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_VMAAS_VDC_ID for testing ibm_vmaas_vdc resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ACCOUNT_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_POLICY_ASSIGNMENT_TARGET_ENTERPRISE_ID for testing ibm_iam_policy_assignment resource else tests will fail if this is not set correctly
[INFO] Set the environment variable IBM_ASSIGNMENT_TARGET_ACCOUNT_GROUP_ID for testing ibm_iam_action_control_assignment resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_REGISTRATION_ACCOUNT_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_APPROVED_PROGRAMMATIC_NAME_2 for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_PRODUCT_WITH_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PRODUCT for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_CATALOG_PLAN for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable PCS_IAM_TEGISTRATION_ID for testing iam_onboarding resource else tests will fail if this is not set correctly
[WARN] Set the environment variable TOOLCHAIN_ID for testing the COS toolchain integration tool else tests will fail if this is not set correctly
[WARN] Set the environment variable IBM_IS_ADMIN_CONFIG for testing ibm_container_cluster_config datasource else tests will fail if this is not set correctly
=== RUN   TestAccIbmProjectConfigDataSourceBasic
--- PASS: TestAccIbmProjectConfigDataSourceBasic (23.93s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigNeedsAttentionStateToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigNeedsAttentionStateToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigOutputValueToMap
--- PASS: TestDataSourceIbmProjectConfigOutputValueToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigReferenceValueToMap
--- PASS: TestDataSourceIbmProjectConfigReferenceValueToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigErrorToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigErrorToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigErrorDetailsToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigErrorDetailsToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectReferenceToMap
--- PASS: TestDataSourceIbmProjectConfigProjectReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectDefinitionReferenceToMap
--- PASS: TestDataSourceIbmProjectConfigProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigSchematicsMetadataToMap
--- PASS: TestDataSourceIbmProjectConfigSchematicsMetadataToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigScriptToMap
--- PASS: TestDataSourceIbmProjectConfigScriptToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigMemberOfDefinitionToMap
--- PASS: TestDataSourceIbmProjectConfigMemberOfDefinitionToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigStackConfigDefinitionSummaryToMap
--- PASS: TestDataSourceIbmProjectConfigStackConfigDefinitionSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigStackMemberToMap
--- PASS: TestDataSourceIbmProjectConfigStackMemberToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectComplianceProfileToMap
--- PASS: TestDataSourceIbmProjectConfigProjectComplianceProfileToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectComplianceProfileNullableObjectToMap
--- PASS: TestDataSourceIbmProjectConfigProjectComplianceProfileNullableObjectToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectComplianceProfileV1ToMap
--- PASS: TestDataSourceIbmProjectConfigProjectComplianceProfileV1ToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigAuthToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigAuthToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseDAConfigDefinitionPropertiesResponseToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseDAConfigDefinitionPropertiesResponseToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseResourceConfigDefinitionPropertiesResponseToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigDefinitionResponseResourceConfigDefinitionPropertiesResponseToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigVersionSummaryToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigVersionSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectConfigProjectConfigVersionDefinitionSummaryToMap
--- PASS: TestDataSourceIbmProjectConfigProjectConfigVersionDefinitionSummaryToMap (0.00s)
=== RUN   TestAccIbmProjectEnvironmentDataSourceBasic
--- PASS: TestAccIbmProjectEnvironmentDataSourceBasic (15.84s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectReferenceToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectDefinitionReferenceToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentEnvironmentDefinitionRequiredPropertiesResponseToMap
--- PASS: TestDataSourceIbmProjectEnvironmentEnvironmentDefinitionRequiredPropertiesResponseToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectConfigAuthToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectConfigAuthToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectComplianceProfileToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectComplianceProfileToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectComplianceProfileNullableObjectToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectComplianceProfileNullableObjectToMap (0.00s)
=== RUN   TestDataSourceIbmProjectEnvironmentProjectComplianceProfileV1ToMap
--- PASS: TestDataSourceIbmProjectEnvironmentProjectComplianceProfileV1ToMap (0.00s)
=== RUN   TestAccIbmProjectDataSourceBasic
--- PASS: TestAccIbmProjectDataSourceBasic (18.20s)
=== RUN   TestDataSourceIbmProjectCumulativeNeedsAttentionToMap
--- PASS: TestDataSourceIbmProjectCumulativeNeedsAttentionToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectConfigSummaryToMap
--- PASS: TestDataSourceIbmProjectProjectConfigSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectConfigVersionSummaryToMap
--- PASS: TestDataSourceIbmProjectProjectConfigVersionSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectConfigVersionDefinitionSummaryToMap
--- PASS: TestDataSourceIbmProjectProjectConfigVersionDefinitionSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectConfigSummaryDefinitionToMap
--- PASS: TestDataSourceIbmProjectProjectConfigSummaryDefinitionToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectReferenceToMap
--- PASS: TestDataSourceIbmProjectProjectReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectDefinitionReferenceToMap
--- PASS: TestDataSourceIbmProjectProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectEnvironmentSummaryToMap
--- PASS: TestDataSourceIbmProjectProjectEnvironmentSummaryToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectEnvironmentSummaryDefinitionToMap
--- PASS: TestDataSourceIbmProjectProjectEnvironmentSummaryDefinitionToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectDefinitionToMap
--- PASS: TestDataSourceIbmProjectProjectDefinitionToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectDefinitionStoreToMap
--- PASS: TestDataSourceIbmProjectProjectDefinitionStoreToMap (0.00s)
=== RUN   TestDataSourceIbmProjectProjectTerraformEngineSettingsToMap
--- PASS: TestDataSourceIbmProjectProjectTerraformEngineSettingsToMap (0.00s)
=== RUN   TestAccIbmProjectConfigBasic
--- PASS: TestAccIbmProjectConfigBasic (20.91s)
=== RUN   TestResourceIbmProjectConfigSchematicsMetadataToMap
--- PASS: TestResourceIbmProjectConfigSchematicsMetadataToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigScriptToMap
--- PASS: TestResourceIbmProjectConfigScriptToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectComplianceProfileToMap
--- PASS: TestResourceIbmProjectConfigProjectComplianceProfileToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectComplianceProfileNullableObjectToMap
--- PASS: TestResourceIbmProjectConfigProjectComplianceProfileNullableObjectToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectComplianceProfileV1ToMap
--- PASS: TestResourceIbmProjectConfigProjectComplianceProfileV1ToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigStackMemberToMap
--- PASS: TestResourceIbmProjectConfigStackMemberToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigAuthToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigAuthToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigDefinitionResponseDAConfigDefinitionPropertiesResponseToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigDefinitionResponseDAConfigDefinitionPropertiesResponseToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigDefinitionResponseResourceConfigDefinitionPropertiesResponseToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigDefinitionResponseResourceConfigDefinitionPropertiesResponseToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigNeedsAttentionStateToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigNeedsAttentionStateToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigOutputValueToMap
--- PASS: TestResourceIbmProjectConfigOutputValueToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigReferenceValueToMap
--- PASS: TestResourceIbmProjectConfigReferenceValueToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigErrorToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigErrorToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigErrorDetailsToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigErrorDetailsToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectReferenceToMap
--- PASS: TestResourceIbmProjectConfigProjectReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectDefinitionReferenceToMap
--- PASS: TestResourceIbmProjectConfigProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigMemberOfDefinitionToMap
--- PASS: TestResourceIbmProjectConfigMemberOfDefinitionToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigStackConfigDefinitionSummaryToMap
--- PASS: TestResourceIbmProjectConfigStackConfigDefinitionSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigVersionSummaryToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigVersionSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigProjectConfigVersionDefinitionSummaryToMap
--- PASS: TestResourceIbmProjectConfigProjectConfigVersionDefinitionSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectComplianceProfile
--- PASS: TestResourceIbmProjectConfigMapToProjectComplianceProfile (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectComplianceProfileNullableObject
--- PASS: TestResourceIbmProjectConfigMapToProjectComplianceProfileNullableObject (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectComplianceProfileV1
--- PASS: TestResourceIbmProjectConfigMapToProjectComplianceProfileV1 (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToStackMember
--- PASS: TestResourceIbmProjectConfigMapToStackMember (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectConfigAuth
--- PASS: TestResourceIbmProjectConfigMapToProjectConfigAuth (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectConfigDefinitionPrototypeResourceConfigDefinitionPropertiesPrototype
--- PASS: TestResourceIbmProjectConfigMapToProjectConfigDefinitionPrototypeResourceConfigDefinitionPropertiesPrototype (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToSchematicsWorkspace
--- PASS: TestResourceIbmProjectConfigMapToSchematicsWorkspace (0.00s)
=== RUN   TestResourceIbmProjectConfigMapToProjectConfigDefinitionPatchResourceConfigDefinitionPropertiesPatch
--- PASS: TestResourceIbmProjectConfigMapToProjectConfigDefinitionPatchResourceConfigDefinitionPropertiesPatch (0.00s)
=== RUN   TestAccIbmProjectEnvironmentBasic
--- PASS: TestAccIbmProjectEnvironmentBasic (18.70s)
=== RUN   TestResourceIbmProjectEnvironmentProjectConfigAuthToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectConfigAuthToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentProjectComplianceProfileToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectComplianceProfileToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentProjectComplianceProfileNullableObjectToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectComplianceProfileNullableObjectToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentProjectComplianceProfileV1ToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectComplianceProfileV1ToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentProjectReferenceToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentProjectDefinitionReferenceToMap
--- PASS: TestResourceIbmProjectEnvironmentProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentMapToProjectConfigAuth
--- PASS: TestResourceIbmProjectEnvironmentMapToProjectConfigAuth (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentMapToProjectComplianceProfile
--- PASS: TestResourceIbmProjectEnvironmentMapToProjectComplianceProfile (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentMapToProjectComplianceProfileNullableObject
--- PASS: TestResourceIbmProjectEnvironmentMapToProjectComplianceProfileNullableObject (0.00s)
=== RUN   TestResourceIbmProjectEnvironmentMapToProjectComplianceProfileV1
--- PASS: TestResourceIbmProjectEnvironmentMapToProjectComplianceProfileV1 (0.00s)
=== RUN   TestAccIbmProjectBasic
--- PASS: TestAccIbmProjectBasic (16.21s)
=== RUN   TestResourceIbmProjectProjectConfigSummaryToMap
--- PASS: TestResourceIbmProjectProjectConfigSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectConfigVersionSummaryToMap
--- PASS: TestResourceIbmProjectProjectConfigVersionSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectConfigVersionDefinitionSummaryToMap
--- PASS: TestResourceIbmProjectProjectConfigVersionDefinitionSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectConfigSummaryDefinitionToMap
--- PASS: TestResourceIbmProjectProjectConfigSummaryDefinitionToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectReferenceToMap
--- PASS: TestResourceIbmProjectProjectReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectDefinitionReferenceToMap
--- PASS: TestResourceIbmProjectProjectDefinitionReferenceToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectEnvironmentSummaryToMap
--- PASS: TestResourceIbmProjectProjectEnvironmentSummaryToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectEnvironmentSummaryDefinitionToMap
--- PASS: TestResourceIbmProjectProjectEnvironmentSummaryDefinitionToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectDefinitionToMap
--- PASS: TestResourceIbmProjectProjectDefinitionToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectDefinitionStoreToMap
--- PASS: TestResourceIbmProjectProjectDefinitionStoreToMap (0.00s)
=== RUN   TestResourceIbmProjectProjectTerraformEngineSettingsToMap
--- PASS: TestResourceIbmProjectProjectTerraformEngineSettingsToMap (0.00s)
=== RUN   TestResourceIbmProjectCumulativeNeedsAttentionToMap
--- PASS: TestResourceIbmProjectCumulativeNeedsAttentionToMap (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectPrototypeDefinition
--- PASS: TestResourceIbmProjectMapToProjectPrototypeDefinition (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectDefinitionStore
--- PASS: TestResourceIbmProjectMapToProjectDefinitionStore (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectTerraformEngineSettings
--- PASS: TestResourceIbmProjectMapToProjectTerraformEngineSettings (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectComplianceProfile
--- PASS: TestResourceIbmProjectMapToProjectComplianceProfile (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectComplianceProfileNullableObject
--- PASS: TestResourceIbmProjectMapToProjectComplianceProfileNullableObject (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectComplianceProfileV1
--- PASS: TestResourceIbmProjectMapToProjectComplianceProfileV1 (0.00s)
=== RUN   TestResourceIbmProjectMapToStackMember
--- PASS: TestResourceIbmProjectMapToStackMember (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectConfigAuth
--- PASS: TestResourceIbmProjectMapToProjectConfigAuth (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectConfigDefinitionPrototypeResourceConfigDefinitionPropertiesPrototype
--- PASS: TestResourceIbmProjectMapToProjectConfigDefinitionPrototypeResourceConfigDefinitionPropertiesPrototype (0.00s)
=== RUN   TestResourceIbmProjectMapToSchematicsWorkspace
--- PASS: TestResourceIbmProjectMapToSchematicsWorkspace (0.00s)
=== RUN   TestResourceIbmProjectMapToProjectDefinitionPatch
--- PASS: TestResourceIbmProjectMapToProjectDefinitionPatch (0.00s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/project	115.873s
rangelil@Riccardos-MacBook-Pro terraform-provider-ibm % date
Thu Oct  2 10:50:02 CEST 2025
rangelil@Riccardos-MacBook-Pro terraform-provider-ibm % 
```
