### PR TITLE
fix: only set rev field if it exists

### DIFF
--- a/ibm/service/catalogmanagement/resource_ibm_cm_account.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_account.go
@@ -382,7 +382,9 @@ func resourceIBMCmAccountUpdate(context context.Context, d *schema.ResourceData,
 
 	updateCatalogAccountOptions := &catalogmanagementv1.UpdateCatalogAccountOptions{}
 	updateCatalogAccountOptions.SetID(*account.ID)
-	updateCatalogAccountOptions.SetRev(*account.Rev)
+	if account.Rev != nil {
+		updateCatalogAccountOptions.SetRev(*account.Rev)
+	}
 
 	if d.HasChange("hide_ibm_cloud_catalog") {
 		if v, ok := d.GetOk("hide_ibm_cloud_catalog"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

This fixes an edge case bug in the `cm_account` resource. If a user's catalog account does not exist yet, there is no `Rev` field in the GET response. However, they should still be able to perform an update on the catalog account without the `Rev`. The backend API handles this and creates the catalog account.

___

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIBMCmAccountBasic -timeout 700m 
=== RUN   TestAccIBMCmAccountBasic
--- PASS: TestAccIBMCmAccountBasic (30.68s)
```
