### PR TITLE
Support Schematics replatform for COS resources

### DIFF
--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -1791,7 +1792,13 @@ func parseBucketId(id string, info string) string {
 	if info == "endpointType" {
 		s := strings.Split(meta, ":")
 		if len(s) > 2 {
-			return strings.Split(meta, ":")[2]
+			eType := strings.Split(meta, ":")[2]
+			// This changes is only for Schematics
+			schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+			if eType != "" && eType == "private" && schET != "" {
+				return schET
+			}
+			return eType
 		}
 		return ""
 

--- a/ibm/service/cos/resource_ibm_cos_bucket_lifecycle_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_lifecycle_configuration.go
@@ -4,6 +4,7 @@ import (
 	// "encoding/json"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -649,7 +650,13 @@ func parseLifecycleId(id string, info string) string {
 		return strings.Split(meta, ":")[0]
 	}
 	if info == "endpointType" {
-		return strings.Split(meta, ":")[1]
+		eType := strings.Split(meta, ":")[1]
+		// This changes is only for Schematics
+		schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+		if eType != "" && eType == "private" && schET != "" {
+			return schET
+		}
+		return eType
 	}
 	if info == "keyName" {
 		return strings.Split(meta, ":key:")[1]

--- a/ibm/service/cos/resource_ibm_cos_bucket_object.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object.go
@@ -262,6 +262,10 @@ func resourceIBMCOSBucketObjectRead(ctx context.Context, d *schema.ResourceData,
 	bucketLocation := parseObjectId(objectID, "bucketLocation")
 	instanceCRN := parseObjectId(objectID, "instanceCRN")
 	endpointType := d.Get("endpoint_type").(string)
+	schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+	if endpointType != "" && endpointType == "private" && schET != "" {
+		endpointType = schET
+	}
 
 	d.Set("bucket_crn", bucketCRN)
 	d.Set("bucket_location", bucketLocation)
@@ -353,6 +357,10 @@ func resourceIBMCOSBucketObjectUpdate(ctx context.Context, d *schema.ResourceDat
 	objectKey := d.Get("key").(string)
 	bucketLocation := d.Get("bucket_location").(string)
 	endpointType := d.Get("endpoint_type").(string)
+	schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+	if endpointType != "" && endpointType == "private" && schET != "" {
+		endpointType = schET
+	}
 	bxSession, err := m.(conns.ClientSession).BluemixSession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -452,6 +460,10 @@ func resourceIBMCOSBucketObjectDelete(ctx context.Context, d *schema.ResourceDat
 
 	bucketLocation := d.Get("bucket_location").(string)
 	endpointType := d.Get("endpoint_type").(string)
+	schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+	if endpointType != "" && endpointType == "private" && schET != "" {
+		endpointType = schET
+	}
 
 	bxSession, err := m.(conns.ClientSession).BluemixSession()
 	if err != nil {

--- a/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration.go
@@ -2,6 +2,7 @@ package cos
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -260,7 +261,13 @@ func parseObjectLockId(id string, info string) string {
 		return strings.Split(meta, ":")[0]
 	}
 	if info == "endpointType" {
-		return strings.Split(meta, ":")[1]
+		eType := strings.Split(meta, ":")[1]
+		// This changes is only for Schematics
+		schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+		if eType != "" && eType == "private" && schET != "" {
+			return schET
+		}
+		return eType
 	}
 	if info == "keyName" {
 		return strings.Split(meta, ":key:")[1]

--- a/ibm/service/cos/resource_ibm_cos_bucket_website_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_website_configuration.go
@@ -3,6 +3,7 @@ package cos
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -494,7 +495,13 @@ func parseWebsiteId(id string, info string) string {
 		return strings.Split(meta, ":")[0]
 	}
 	if info == "endpointType" {
-		return strings.Split(meta, ":")[1]
+		eType := strings.Split(meta, ":")[1]
+		// This changes is only for Schematics
+		schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+		if eType != "" && eType == "private" && schET != "" {
+			return schET
+		}
+		return eType
 	}
 	if info == "keyName" {
 		return strings.Split(meta, ":key:")[1]

--- a/ibm/service/cos/resource_ibm_cos_replication_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_replication_configuration.go
@@ -3,6 +3,7 @@ package cos
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -328,7 +329,13 @@ func parseBucketReplId(id string, info string) string {
 		return strings.Split(meta, ":")[0]
 	}
 	if info == "endpointType" {
-		return strings.Split(meta, ":")[1]
+		eType := strings.Split(meta, ":")[1]
+		// This changes is only for Schematics
+		schET := os.Getenv("IBMCLOUD_ENV_SCH_COS_ENDPOINT_OVERRIDE")
+		if eType != "" && eType == "private" && schET != "" {
+			return schET
+		}
+		return eType
 	}
 
 	return parseBucketId(bucketCRN, info)


### PR DESCRIPTION
Due to the ongoing replatforming process, Schematics will no longer be able to access resources via private endpoints. To prevent execution failures for users relying on this setup, we need to implement special handling specifically for Schematics. This change is required only for Schematics to ensure continuity and avoid disruption.