### PR TITLE
Fix ibm_pi_key data source to use id

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3bt
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
-github.com/IBM/go-sdk-core/v5 v5.20.1 h1:dzeyifh1kfRLw8VfAIIS5okZYuqLTqplPZP/Kcsgdlo=
-github.com/IBM/go-sdk-core/v5 v5.20.1/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
 github.com/IBM/go-sdk-core/v5 v5.21.0 h1:DUnYhvC4SoC8T84rx5omnhY3+xcQg/Whyoa3mDPIMkk=
 github.com/IBM/go-sdk-core/v5 v5.21.0/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
 github.com/IBM/ibm-backup-recovery-sdk-go v1.0.3 h1:9TZHocmCfgmF8TGVrpP1kFyQbjcqLNW7+bM07lefpKQ=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -259,6 +259,7 @@ var (
 	Pi_shared_processor_pool_id       string
 	Pi_snapshot_id                    string
 	Pi_spp_placement_group_id         string
+	Pi_ssh_key_id                     string
 	Pi_storage_connection             string
 	Pi_target_storage_tier            string
 	Pi_virtual_serial_number          string
@@ -1195,7 +1196,13 @@ func init() {
 	Pi_key_name = os.Getenv("PI_KEY_NAME")
 	if Pi_key_name == "" {
 		Pi_key_name = "terraform-test-power"
-		fmt.Println("[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key_name resource else it is set to default value 'terraform-test-power'")
+		fmt.Println("[INFO] Set the environment variable PI_KEY_NAME for testing ibm_pi_key resource else it is set to default value 'terraform-test-power'")
+	}
+
+	Pi_ssh_key_id = os.Getenv("PI_SSH_KEY_ID")
+	if Pi_ssh_key_id == "" {
+		Pi_ssh_key_id = "terraform-test-power"
+		fmt.Println("[INFO] Set the environment variable PI_SSH_KEY_ID for testing ibm_pi_key resource else it is set to default value 'terraform-test-power'")
 	}
 
 	Pi_network_name = os.Getenv("PI_NETWORK_NAME")

--- a/ibm/service/power/data_source_ibm_pi_key_test.go
+++ b/ibm/service/power/data_source_ibm_pi_key_test.go
@@ -30,7 +30,7 @@ func TestAccIBMPIKeyDataSource_basic(t *testing.T) {
 func testAccCheckIBMPIKeyDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_key" "testacc_ds_key" {
-			pi_key_name = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_key_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_ssh_key_id        = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_ssh_key_id)
 }

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -160,6 +160,7 @@ const (
 	Arg_SPPPlacementGroupName                = "pi_spp_placement_group_name"
 	Arg_SPPPlacementGroupPolicy              = "pi_spp_placement_group_policy"
 	Arg_SSHKey                               = "pi_ssh_key"
+	Arg_SSHKeyID                             = "pi_ssh_key_id"
 	Arg_StartingIPAddress                    = "pi_starting_ip_address"
 	Arg_StorageConnection                    = "pi_storage_connection"
 	Arg_StoragePool                          = "pi_storage_pool"

--- a/website/docs/d/pi_key.html.markdown
+++ b/website/docs/d/pi_key.html.markdown
@@ -40,7 +40,8 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_key_name`  - (Required, String) User defined name for the SSH key or SSH key ID.
+- `pi_key_name`  - (Deprecated, Optional, String) User defined name for the SSH key or SSH key ID. Passing the name of the instance could fail or fetch stale data. Please pass an id and use `pi_ssh_key_id` instead.
+- `pi_ssh_key_id` - (Optional, String) The SSH key ID.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This pull request deprecates name fields for id fields. In either case (before and after this change), the user can put either the name or id and resource will be fetched. The reason for this change is that APP Config team is fetching tons of resources and sometimes if you use the name the cache could fail or fetch stale data. The ID is more reliable. This change is to encourage the user to use IDs instead of names.

Output from acceptance testing:

```
--- PASS: TestAccIBMPIKeyDataSource_basic (11.29s)
PASS
```