### PR TITLE
Fix ibm_pi_placement_group data source to use id

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/IBM/go-sdk-core/v5 v5.6.3/go.mod h1:tt/B9rxLkRtglE7pvqLuYikgCXaZFL3bt
 github.com/IBM/go-sdk-core/v5 v5.9.5/go.mod h1:YlOwV9LeuclmT/qi/LAK2AsobbAP42veV0j68/rlZsE=
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
-github.com/IBM/go-sdk-core/v5 v5.20.1 h1:dzeyifh1kfRLw8VfAIIS5okZYuqLTqplPZP/Kcsgdlo=
-github.com/IBM/go-sdk-core/v5 v5.20.1/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
 github.com/IBM/go-sdk-core/v5 v5.21.0 h1:DUnYhvC4SoC8T84rx5omnhY3+xcQg/Whyoa3mDPIMkk=
 github.com/IBM/go-sdk-core/v5 v5.21.0/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
 github.com/IBM/ibm-backup-recovery-sdk-go v1.0.3 h1:9TZHocmCfgmF8TGVrpP1kFyQbjcqLNW7+bM07lefpKQ=

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -247,7 +247,7 @@ var (
 	Pi_network_security_group_id      string
 	Pi_network_security_group_rule_id string
 	Pi_peer_interface_id              string
-	Pi_placement_group_name           string
+	Pi_placement_group_id             string
 	Pi_remote_id                      string
 	Pi_remote_type                    string
 	Pi_replication_volume_name        string
@@ -1339,10 +1339,10 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable PI_SAP_PROFILE_ID for testing ibm_pi_sap_profile resource else it is set to default value 'terraform-test-power'")
 	}
 
-	Pi_placement_group_name = os.Getenv("PI_PLACEMENT_GROUP_NAME")
-	if Pi_placement_group_name == "" {
-		Pi_placement_group_name = "tf-pi-placement-group"
-		fmt.Println("[WARN] Set the environment variable PI_PLACEMENT_GROUP_NAME for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'")
+	Pi_placement_group_id = os.Getenv("PI_PLACEMENT_GROUP_ID")
+	if Pi_placement_group_id == "" {
+		Pi_placement_group_id = "tf-pi-placement-group"
+		fmt.Println("[WARN] Set the environment variable PI_PLACEMENT_GROUP_ID for testing ibm_pi_placement_group resource else it is set to default value 'tf-pi-placement-group'")
 	}
 
 	Pi_remote_id = os.Getenv("PI_REMOTE_ID")

--- a/ibm/service/power/data_source_ibm_pi_placement_group_test.go
+++ b/ibm/service/power/data_source_ibm_pi_placement_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMPIPlacementGroupDataSource_basic(t *testing.T) {
+func TestAccIBMPIPlacementGroupDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -29,7 +29,7 @@ func TestAccIBMPIPlacementGroupDataSource_basic(t *testing.T) {
 func testAccCheckIBMPIPlacementGroupDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_placement_group" "testacc_ds_placement_group" {
-			pi_placement_group_name = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_placement_group_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_placement_group_id = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_placement_group_id)
 }

--- a/ibm/service/power/data_source_ibm_pi_placement_groups_test.go
+++ b/ibm/service/power/data_source_ibm_pi_placement_groups_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMPIPlacementGrousDataSourceBasic(t *testing.T) {
+func TestAccIBMPIPlacementGroupsDataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIPlacementGrousDataSourceConfig(),
+				Config: testAccCheckIBMPIPlacementGroupsDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_pi_placement_groups.test", "id"),
 				),
@@ -26,7 +26,7 @@ func TestAccIBMPIPlacementGrousDataSourceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMPIPlacementGrousDataSourceConfig() string {
+func testAccCheckIBMPIPlacementGroupsDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_placement_groups" "test" {
 			pi_cloud_instance_id = "%s"

--- a/website/docs/d/pi_placement_group.html.markdown
+++ b/website/docs/d/pi_placement_group.html.markdown
@@ -14,8 +14,8 @@ Retrieve information about a placement group. For more information, about placem
 
 ```terraform
 data "ibm_pi_placement_group" "ds_placement_group" {
-  pi_placement_group_name   = "my-pg"
-  pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
+  pi_cloud_instance_id      = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
+  pi_placement_group_id     = "7f8e2a9d-3b4c-4e4f-8e8d-f7e7e1e23456"
 }
 ```
 
@@ -40,7 +40,8 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_placement_group_name` - (Required, String) The name of the placement group.
+- `pi_placement_group_id` - (Optional, String) The placement group ID.
+- `pi_placement_group_name` - (Deprecated, Optional, String) The id of the placement group. Passing the name of the placement group could fail or fetch stale data. Please pass an id and use `pi_placement_group_id` instead.
 
 ## Attribute Reference
 
@@ -49,5 +50,6 @@ In addition to all argument reference list, you can access the following attribu
 - `crn` - (String) The CRN of this resource.
 - `id` - (String) The ID of the placement group.
 - `members` - (List) List of server instances IDs that are members of the placement group.
+- `name` - (String) The name of the placement group.
 - `policy` - (String) The value of the group's affinity policy. Valid values are affinity and anti-affinity.
 - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/d/pi_placement_groups.html.markdown
+++ b/website/docs/d/pi_placement_groups.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about all placement groups. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_placement_groups" "example" {


### PR DESCRIPTION
This pull request deprecates name fields for id fields. In either case (before and after this change), the user can put either the name or id and resource will be fetched. The reason for this change is that APP Config team is fetching tons of resources and sometimes if you use the name the cache could fail or fetch stale data. The ID is more reliable. This change is to encourage the user to use IDs instead of names.

Output of acceptance testing:
```
--- PASS: TestAccIBMPIPlacementGroupsDataSourceBasic (17.84s)
PASS
--- PASS: TestAccIBMPIPlacementGroupDataSource_basic (16.48s)
PASS
```