### PR TITLE
Fix ibm_pi_volume data source to use id

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -250,7 +250,7 @@ var (
 	Pi_placement_group_id             string
 	Pi_remote_id                      string
 	Pi_remote_type                    string
-	Pi_replication_volume_name        string
+	Pi_replication_volume_id          string
 	Pi_resource_group_id              string
 	Pi_route_filter_id                string
 	Pi_route_id                       string
@@ -1274,10 +1274,10 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable PI_VOLUME_ID for testing ibm_pi_volume_flash_copy_mappings resource else it is set to default value 'terraform-test-power'")
 	}
 
-	Pi_replication_volume_name = os.Getenv("PI_REPLICATION_VOLUME_NAME")
-	if Pi_replication_volume_name == "" {
-		Pi_replication_volume_name = "terraform-test-power"
-		fmt.Println("[INFO] Set the environment variable PI_REPLICATION_VOLUME_NAME for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'")
+	Pi_replication_volume_id = os.Getenv("PI_REPLICATION_VOLUME_ID")
+	if Pi_replication_volume_id == "" {
+		Pi_replication_volume_id = "terraform-test-power"
+		fmt.Println("[INFO] Set the environment variable PI_REPLICATION_VOLUME_ID for testing ibm_pi_volume resource else it is set to default value 'terraform-test-power'")
 	}
 
 	Pi_volume_onboarding_source_crn = os.Getenv("PI_VOLUME_ONBARDING_SOURCE_CRN")

--- a/ibm/service/power/data_source_ibm_pi_volume_test.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_test.go
@@ -31,9 +31,9 @@ func TestAccIBMPIVolumeDataSource_basic(t *testing.T) {
 func testAccCheckIBMPIVolumeDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_volume" "testacc_ds_volume" {
-			pi_volume_name       = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_volume_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_volume_id         = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_volume_id)
 }
 
 func TestAccIBMPIVolumeDataSource_replication(t *testing.T) {
@@ -56,7 +56,7 @@ func TestAccIBMPIVolumeDataSource_replication(t *testing.T) {
 func testAccCheckIBMPIVolumeDataSourceReplicationConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_volume" "testacc_ds_volume" {
-			pi_volume_name       = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_replication_volume_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_volume_id         = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_replication_volume_id)
 }

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -556,6 +556,7 @@ const (
 	Attr_VolumeSnapshots                     = "volume_snapshots"
 	Attr_VolumesSnapshots                    = "volume_snapshots"
 	Attr_VolumeStatus                        = "volume_status"
+	Attr_VolumeType                          = "volume_type"
 	Attr_VPCCRNs                             = "vpc_crns"
 	Attr_VPCEnabled                          = "vpc_enabled"
 	Attr_WorkloadType                        = "workload_type"

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -1,14 +1,14 @@
 ---
 subcategory: "Power Systems"
 layout: "ibm"
-page_title: "IBM: pi_volume"
+page_title: "IBM: ibm_pi_volume"
 description: |-
   Manages a volume in the Power Virtual Server cloud.
 ---
 
 # ibm_pi_volume
 
-Retrieves information about a persistent storage volume that is mounted to a Power Systems Virtual Server instance. For more information, about managin a volume, see [moving data to the cloud](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-moving-data-to-the-cloud).
+Retrieves information about a persistent storage volume that is mounted to a Power Systems Virtual Server instance. For more information, about managing a volume, see [moving data to the cloud](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-moving-data-to-the-cloud).
 
 ## Example Usage
 
@@ -16,8 +16,8 @@ The following example retrieves information about the `volume_1` volume that is 
 
 ```terraform
 data "ibm_pi_volume" "ds_volume" {
-  pi_volume_name       = "volume_1"
   pi_cloud_instance_id = "49fba6c9-23f8-40bc-9899-aca322ee7d5b"
+  pi_volume_id         = "7f8e2a9d-3b4c-4e4f-8e8d-f7e7e1e23456"
 }
 ```
 
@@ -42,14 +42,15 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_volume_name` - (Required, String) The name of the volume for which you want to retrieve detailed information.
+- `pi_volume_id` - (Optional, String) The volume ID.
+- `pi_volume_name` - (Deprecated, Optional, String) The id of the volume. Passing the name of the volume could fail or fetch stale data. Please pass an id and use `pi_volume_id` instead.
 
 ## Attribute Reference
 
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
-- `auxiliary` - (Boolean) Indicates if the volume is auxiliary.
 - `auxiliary_volume_name` - (String) The auxiliary volume name.
+- `auxiliary` - (Boolean) Indicates if the volume is auxiliary.
 - `bootable` -  (Boolean) Indicates if the volume is boot capable.
 - `consistency_group_name` - (String) Consistency group name if volume is a part of volume group.
 - `creation_date` - (String) Date of volume creation.
@@ -62,6 +63,7 @@ In addition to all argument reference list, you can access the following attribu
 - `last_update_date` - (String) The date when the volume last updated.
 - `master_volume_name` - (String) The master volume name.
 - `mirroring_state` - (String) Mirroring state for replication enabled volume.
+- `name` - (String) The name of the volume.
 - `out_of_band_deleted` - (Bool) Indicates if the volume does not exist on storage controller.
 - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
 - `replication_enabled` - (Boolean) Indicates if the volume should be replication enabled or not.
@@ -72,5 +74,6 @@ In addition to all argument reference list, you can access the following attribu
 - `size` - (Integer) The size of the volume in GB.
 - `state` - (String) The state of the volume.
 - `user_tags` - (List) List of user tags attached to the resource.
-- `volume_pool` - (String) Volume pool, name of storage pool where the volume is located.
+- `volume_pool` - (String) The name of storage pool where the volume is located.
+- `volume_type` - (String) The name of storage template used to create the volume.
 - `wwn` - (String) The world wide name of the volume.


### PR DESCRIPTION
This pull request deprecates name fields for id fields. In either case (before and after this change), the user can put either the name or id and resource will be fetched. The reason for this change is that APP Config team is fetching tons of resources and sometimes if you use the name the cache could fail or fetch stale data. The ID is more reliable. This change is to encourage the user to use IDs instead of names.

Output of acceptance testing:


```
--- PASS: TestAccIBMPIVolumeDataSource_basic (17.51s)
PASS

--- PASS: TestAccIBMPIVolumeDataSource_replication (19.34s)
PASS
```