### PR TITLE
remove account_id from account section of effective settings datasource

### DIFF
--- a/ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings.go
@@ -146,11 +146,6 @@ func DataSourceIBMIamEffectiveAccountSettings() *schema.Resource {
 				Description: "Input body parameters for the Account Settings REST request.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"account_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Unique ID of the account.",
-						},
 						"entity_tag": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -541,7 +536,7 @@ func DataSourceIBMIamEffectiveAccountSettingsAccountSettingsEffectiveSectionToMa
 
 func DataSourceIBMIamEffectiveAccountSettingsAccountSettingsAccountSectionToMap(model *iamidentityv1.AccountSettingsResponse) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
-	modelMap["account_id"] = *model.AccountID
+
 	modelMap["entity_tag"] = *model.EntityTag
 	if model.History != nil {
 		var history []map[string]interface{}

--- a/website/docs/d/iam_effective_account_settings.html.markdown
+++ b/website/docs/d/iam_effective_account_settings.html.markdown
@@ -35,7 +35,6 @@ After your data source is created, you can read values from the following attrib
 * `id` - The unique identifier of the iam_effective_account_settings.
 * `account` - (List) Input body parameters for the Account Settings REST request.
 Nested schema for **account**:
-	* `account_id` - (String) Unique ID of the account.
 	* `allowed_ip_addresses` - (String) Defines the IP addresses and subnets from which IAM tokens can be created for the account.
 	* `entity_tag` - (String) Version of the account settings.
 	* `history` - (List) History of the Account Settings.


### PR DESCRIPTION
This `account_id` attribute will no longer be returned in this section of the response. 

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  make testacc TEST=./ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings_test.go                                                                                                                                                                           ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings_test.go -v  -timeout 700m 
=== RUN   TestAccIBMIamEffectiveAccountSettingsDataSourceBasic
--- PASS: TestAccIBMIamEffectiveAccountSettingsDataSourceBasic (26.60s)
=== RUN   TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsEffectiveSectionToMap
--- PASS: TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsEffectiveSectionToMap (0.00s)
=== RUN   TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsResponseToMap
--- PASS: TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsResponseToMap (0.00s)
=== RUN   TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsAssignedTemplatesSectionToMap
--- PASS: TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsAssignedTemplatesSectionToMap (0.00s)
PASS
ok      command-line-arguments  28.976s

...
```
