### PR TITLE
fix: support boot volume profile configuration for is_instance creation

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -3110,6 +3110,11 @@ func instanceCreateByCatalogOffering(context context.Context, d *schema.Resource
 		}
 
 		volprof := "general-purpose"
+		// profile changes
+		bootvolProfileOk, ok := bootvol["profile"]
+		if ok && bootvolProfileOk.(string) != "" {
+			volprof = bootvolProfileOk.(string)
+		}
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}
@@ -3676,7 +3681,11 @@ func instanceCreateByTemplate(context context.Context, d *schema.ResourceData, m
 		}
 
 		volprof := "general-purpose"
-
+		// profile changes
+		bootvolProfileOk, ok := bootvol["profile"]
+		if ok && bootvolProfileOk.(string) != "" {
+			volprof = bootvolProfileOk.(string)
+		}
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}
@@ -4237,6 +4246,11 @@ func instanceCreateBySnapshot(context context.Context, d *schema.ResourceData, m
 			}
 		}
 		volprof := "general-purpose"
+		// profile changes
+		bootvolProfileOk, ok := bootvol["profile"]
+		if ok && bootvolProfileOk.(string) != "" {
+			volprof = bootvolProfileOk.(string)
+		}
 		volTemplate.Profile = &vpcv1.VolumeProfileIdentity{
 			Name: &volprof,
 		}

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -633,6 +633,7 @@ Review the argument references that you can specify for your resource.
   - `bandwidth` - (Optional, Integer) The maximum bandwidth (in megabits per second) for the volume. For this property to be specified, the volume storage_generation must be 2.
   - `encryption` - (Optional, String) The type of encryption to use for the boot volume.
   - `name` - (Optional, String) The name of the boot volume.
+  - `profile` - (Optional, String) The name of the profile for this boot volume(not applicable for creating VSI with `volume_id`).
   - `size` - (Optional, Integer) The size of the boot volume.(The capacity of the volume in gigabytes. This defaults to minimum capacity of the image and maximum to `250`.)
 
     ~> **NOTE:**


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISInstance_BootVolumeVariations (198.08s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     200.515s

```
