### PR TITLE
Update trusted profile ID policies to always use iam_id instead of profile_id

### DIFF
--- a/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy_test.go
+++ b/ibm/service/iampolicy/data_source_ibm_iam_trusted_profile_policy_test.go
@@ -187,7 +187,7 @@ resource "ibm_iam_trusted_profile_policy" "policy1" {
 
 data "ibm_iam_trusted_profile_policy" "policy" {
   profile_id = ibm_iam_trusted_profile_policy.policy.profile_id
-  sort = "id"
+  sort = "created_at"
 }`, name, name)
 
 }

--- a/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_trusted_profile_policy.go
@@ -41,6 +41,7 @@ func ResourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 			"profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "UUID of Trusted Profile",
 				ForceNew:    true,
 				Deprecated:  "This field is deprecated and will be removed starting with this 1.82.0 release. Please use iam_id field instead.",
@@ -50,6 +51,7 @@ func ResourceIBMIAMTrustedProfilePolicy() *schema.Resource {
 			"iam_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "IAM ID of Trusted Profile",
 				ForceNew:    true,
 			},
@@ -452,8 +454,7 @@ func resourceIBMIAMTrustedProfilePolicyCreate(d *schema.ResourceData, meta inter
 	}
 	if err != nil {
 		if v, ok := d.GetOk("profile_id"); ok && v != nil {
-			profileIDUUID := v.(string)
-			d.SetId(fmt.Sprintf("%s/%s", profileIDUUID, policyID))
+			d.SetId(fmt.Sprintf("%s/%s", "iam-"+v.(string), policyID))
 		} else if v, ok := d.GetOk("iam_id"); ok && v != nil {
 			iamID := v.(string)
 			d.SetId(fmt.Sprintf("%s/%s", iamID, policyID))
@@ -461,8 +462,7 @@ func resourceIBMIAMTrustedProfilePolicyCreate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("[ERROR] Error fetching trusted profile policy: %s", err)
 	}
 	if v, ok := d.GetOk("profile_id"); ok && v != nil {
-		profileIDUUID := v.(string)
-		d.SetId(fmt.Sprintf("%s/%s", profileIDUUID, policyID))
+		d.SetId(fmt.Sprintf("%s/%s", "iam-"+v.(string), policyID))
 	} else if v, ok := d.GetOk("iam_id"); ok && v != nil {
 		iamID := v.(string)
 		d.SetId(fmt.Sprintf("%s/%s", iamID, policyID))
@@ -514,8 +514,12 @@ func resourceIBMIAMTrustedProfilePolicyRead(d *schema.ResourceData, meta interfa
 	}
 	if strings.HasPrefix(profileIDUUID, "iam-") {
 		d.Set("iam_id", profileIDUUID)
+		d.Set("profile_id", strings.TrimPrefix(profileIDUUID, "iam-"))
+		d.SetId(fmt.Sprintf("%s/%s", profileIDUUID, trustedProfilePolicyID))
 	} else {
 		d.Set("profile_id", profileIDUUID)
+		d.Set("iam_id", fmt.Sprintf("iam-%s", profileIDUUID))
+		d.SetId(fmt.Sprintf("%s/%s", fmt.Sprintf("iam-%s", profileIDUUID), trustedProfilePolicyID))
 	}
 
 	roles, err := flex.GetRoleNamesFromPolicyResponse(*trustedProfilePolicy, d, meta)
@@ -569,22 +573,6 @@ func resourceIBMIAMTrustedProfilePolicyUpdate(d *schema.ResourceData, meta inter
 		trustedProfilePolicyID := parts[1]
 
 		var iamID string
-		if v, ok := d.GetOk("profile_id"); ok && v != nil {
-			profileIDUUID := v.(string)
-
-			iamClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
-			if err != nil {
-				return err
-			}
-			getProfileIDOptions := iamidentityv1.GetProfileOptions{
-				ProfileID: &profileIDUUID,
-			}
-			profileID, resp, err := iamClient.GetProfile(&getProfileIDOptions)
-			if err != nil {
-				return fmt.Errorf("[ERROR] Error] Error getting trusted profile ID %s %s", err, resp)
-			}
-			iamID = *profileID.IamID
-		}
 		if v, ok := d.GetOk("iam_id"); ok && v != nil {
 			iamID = v.(string)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iampolicy TESTARGS="-run TestAccIBMIAMTrustedProfile"
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Basic
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Basic (58.46s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Multiple_Policies (58.89s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSourceServiceSpecificAttributesConfig
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSourceServiceSpecificAttributesConfig (32.96s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Weekly
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Weekly (32.55s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Custom
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_Time_Based_Conditions_Custom (33.26s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyDataSource_ServiceGroupID
--- PASS: TestAccIBMIAMTrustedProfilePolicyDataSource_ServiceGroupID (31.68s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyBasic
--- PASS: TestAccIBMIAMTrustedProfilePolicyBasic (48.50s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Service
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Service (48.43s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ServiceType
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ServiceType (27.10s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ResourceInstance (51.64s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Group (28.73s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Type (28.98s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_import
--- PASS: TestAccIBMIAMTrustedProfilePolicy_import (32.86s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_account_management
--- PASS: TestAccIBMIAMTrustedProfilePolicy_account_management (29.03s)
=== RUN   TestAccIBMIAMTrustedProfilePolicyWithCustomRole
--- PASS: TestAccIBMIAMTrustedProfilePolicyWithCustomRole (24.02s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes (45.41s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Attributes_Without_Wildcard (25.42s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Resource_Tags (42.73s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Transaction_Id
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Transaction_Id (25.06s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_Custom
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_Custom (43.03s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_All_Day
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Weekly_All_Day (23.66s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Once
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Time_Based_Conditions_Once (24.09s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Update_To_Time_Based_Conditions (33.67s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_ServiceGroupID
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_ServiceGroupID (45.30s)
=== RUN   TestAccIBMIAMTrustedProfilePolicy_With_Attribute_Based_Condition
--- PASS: TestAccIBMIAMTrustedProfilePolicy_With_Attribute_Based_Condition (49.57s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy	926.971s
...
```
