### PR TITLE
renamed error variable for GlobalSearchV2

### DIFF
--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2297,7 +2297,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 	}
 	globalSearchAPIV2, err := searchv2.NewGlobalSearchV2(globalSearchV2Options)
 	if err != nil {
-		session.globalTaggingConfigErrV1 = fmt.Errorf("[ERROR] Error occured while configuring Global Search: %q", err)
+		session.globalSearchConfigErrV2 = fmt.Errorf("[ERROR] Error occured while configuring Global Search: %q", err)
 	}
 	if globalSearchAPIV2 != nil && globalSearchAPIV2.Service != nil {
 		session.globalSearchServiceAPIV2 = *globalSearchAPIV2


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
