### PR TITLE
Fix the attribute in backup_id parameter

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -267,9 +267,10 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_database", "service_endpoints"),
 			},
 			"backup_id": {
-				Description: "The CRN of backup source database",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "The CRN of backup source database",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: flex.ApplyOnce,
 			},
 			"remote_leader_id": {
 				Description: "The CRN of leader database",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

**Proposed changes**
https://github.ibm.com/compose/App/issues/2508
added `DiffSuppressFunc: flex.ApplyOnce` attribute in `backup_id` parameter

Output from acceptance testing:


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstancePostgresBasic'
=== RUN   TestAccIBMDatabaseInstancePostgresBasic
=== PAUSE TestAccIBMDatabaseInstancePostgresBasic
=== CONT  TestAccIBMDatabaseInstancePostgresBasic
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (17.30s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        20.259s



$  make testacc TEST=./ibm/service/database TESTARGS='run=TestAccIBMDatabaseInstancePostgresReadReplicaPromotion'
=== RUN   TestAccIBMDatabaseInstancePostgresReadReplicaPromotion
=== PAUSE TestAccIBMDatabaseInstancePostgresReadReplicaPromotion
=== CONT  TestAccIBMDatabaseInstancePostgresReadReplicaPromotion
--- PASS: TestAccIBMDatabaseInstancePostgresReadReplicaPromotion (318.99s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        321.542s
```

