### PR TITLE
Increase NSG action timeout

### DIFF
--- a/ibm/service/power/resource_ibm_pi_network_security_group_action.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_action.go
@@ -28,8 +28,8 @@ func ResourceIBMPINetworkSecurityGroupAction() *schema.Resource {
 		Importer:      &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(50 * time.Minute),
+			Update: schema.DefaultTimeout(50 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/pi_network_security_group_action.html.markdown
+++ b/website/docs/r/pi_network_security_group_action.html.markdown
@@ -39,8 +39,8 @@ Example usage:
 
 The `ibm_pi_network_security_group_action` provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html) configuration options:
 
-- **create** - (Default 5 minutes) Used for enabling a network security group.
-- **update** - (Default 5 minutes) Used for disabling a network security group.
+- **create** - (Default 50 minutes) Used for enabling a network security group.
+- **update** - (Default 50 minutes) Used for disabling a network security group.
 
 ## Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note
There are edge cases requiring more time to enable a network security group in a workspace
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPINetworkSecurityGroupActionBasic
--- PASS: TestAccIBMPINetworkSecurityGroupActionBasic (439.74s)
PASS
...
```
