### PR TITLE
fix: prevent panic when before list contains nil element

### DIFF
--- a/ibm/service/logs/resource_ibm_logs_policy.go
+++ b/ibm/service/logs/resource_ibm_logs_policy.go
@@ -553,7 +553,7 @@ func ResourceIbmLogsPolicyMapToQuotaV1LogRules(modelMap map[string]interface{}) 
 func ResourceIbmLogsPolicyMapToPolicyPrototype(modelMap map[string]interface{}) (logsv0.PolicyPrototypeIntf, error) {
 	model := &logsv0.PolicyPrototype{}
 	model.Name = core.StringPtr(modelMap["name"].(string))
-	if modelMap["before"] != nil && len(modelMap["before"].([]interface{})) > 0 {
+	if modelMap["before"] != nil && len(modelMap["before"].([]interface{})) > 0 && modelMap["before"].([]interface{})[0] != nil {
 		BeforeModel, err := ResourceIbmLogsPolicyMapToPolicyBeforePrototype(modelMap["before"].([]interface{})[0].(map[string]interface{}))
 		if err != nil {
 			return model, err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
