### PR TITLE
Fix policy creation when resourceType is set to 'resource-group'

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -4124,6 +4124,7 @@ func GeneratePolicyOptions(d *schema.ResourceData, meta interface{}) (iampolicym
 			}
 
 			if r, ok := r["resource_type"]; ok {
+				resourceType = r.(string)
 				if r.(string) != "" {
 					resourceAttr := iampolicymanagementv1.ResourceAttribute{
 						Name:     core.StringPtr("resourceType"),
@@ -4186,6 +4187,9 @@ func GeneratePolicyOptions(d *schema.ResourceData, meta interface{}) (iampolicym
 			if name == "service_group_id" {
 				serviceGroupID = value
 			}
+			if name == "resourceType" {
+				resourceType = value
+			}
 			at := iampolicymanagementv1.ResourceAttribute{
 				Name:     &name,
 				Value:    &value,
@@ -4233,6 +4237,11 @@ func GeneratePolicyOptions(d *schema.ResourceData, meta interface{}) (iampolicym
 	listRoleOptions := &iampolicymanagementv1.ListRolesOptions{
 		AccountID: &userDetails.UserAccount,
 	}
+
+	if serviceName == "" && resourceType == "resource-group" {
+		serviceName = "resource-controller"
+	}
+
 	if serviceName == "" && // no specific service specified
 		!d.Get("account_management").(bool) && // not all account management services
 		resourceType != "resource-group" && // not to a resource group
@@ -4319,6 +4328,7 @@ func GenerateV2PolicyOptions(d *schema.ResourceData, meta interface{}) (iampolic
 			}
 
 			if r, ok := r["resource_type"]; ok {
+				resourceType = r.(string)
 				if r.(string) != "" {
 					resourceAttr := iampolicymanagementv1.V2PolicyResourceAttribute{
 						Key:      core.StringPtr("resourceType"),
@@ -4381,6 +4391,9 @@ func GenerateV2PolicyOptions(d *schema.ResourceData, meta interface{}) (iampolic
 			if name == "service_group_id" {
 				serviceGroupID = value
 			}
+			if name == "resourceType" {
+				resourceType = value
+			}
 			at := iampolicymanagementv1.V2PolicyResourceAttribute{
 				Key:      &name,
 				Value:    &value,
@@ -4427,6 +4440,10 @@ func GenerateV2PolicyOptions(d *schema.ResourceData, meta interface{}) (iampolic
 
 	listRoleOptions := &iampolicymanagementv1.ListRolesOptions{
 		AccountID: &userDetails.UserAccount,
+	}
+
+	if serviceName == "" && resourceType == "resource-group" {
+		serviceName = "resource-controller"
 	}
 
 	if serviceName == "" && // no specific service specified

--- a/ibm/service/iampolicy/resource_ibm_iam_access_group_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_access_group_policy_test.go
@@ -158,7 +158,7 @@ func TestAccIBMIAMAccessGroupPolicy_With_Resource_Type(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIAMAccessGroupPolicyExists("ibm_iam_access_group_policy.policy", conf),
 					resource.TestCheckResourceAttr("ibm_iam_access_group.accgrp", "name", name),
-					resource.TestCheckResourceAttr("ibm_iam_access_group_policy.policy", "roles.#", "1"),
+					resource.TestCheckResourceAttr("ibm_iam_access_group_policy.policy", "roles.#", "2"),
 				),
 			},
 		},
@@ -787,7 +787,7 @@ func testAccCheckIBMIAMAccessGroupPolicyResourceType(name string) string {
 	  
 	  	resource "ibm_iam_access_group_policy" "policy" {
 			access_group_id = ibm_iam_access_group.accgrp.id
-			roles           = ["Administrator"]
+			roles           = ["Administrator", "Key Manager"]
 	  
 			resources {
 		  		resource_type = "resource-group"

--- a/ibm/service/iampolicy/resource_ibm_iam_service_policy_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_service_policy_test.go
@@ -161,7 +161,7 @@ func TestAccIBMIAMServicePolicy_With_Resource_Type(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIAMServicePolicyExists("ibm_iam_service_policy.policy", conf),
 					resource.TestCheckResourceAttr("ibm_iam_service_id.serviceID", "name", name),
-					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "1"),
+					resource.TestCheckResourceAttr("ibm_iam_service_policy.policy", "roles.#", "2"),
 				),
 			},
 		},
@@ -749,11 +749,15 @@ func testAccCheckIBMIAMServicePolicyResourceType(name string) string {
 	  
 	  	resource "ibm_iam_service_policy" "policy" {
 			iam_service_id = ibm_iam_service_id.serviceID.id
-			roles          = ["Administrator"]
-	  
-			resources {
-		  		resource_type = "resource-group"
-		  		resource      = data.ibm_resource_group.group.id
+			roles          = ["Administrator", "Service Configuration Reader"]
+	
+			resource_attributes {
+				name   = "resourceType"
+				value  = "resource-group"
+			}
+			resource_attributes {
+				name   = "resource"
+				value  = data.ibm_resource_group.group.id
 			}
 	  	}
 	`, name)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #https://github.ibm.com/IAM/AM-issues/issues/3761

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iampolicy TESTARGS="-run TestAccIBMIAMServicePolicy"
```
<img width="628" height="787" alt="image" src="https://github.com/user-attachments/assets/28a79440-9c97-4432-b419-a3cdf99ab60d" />


**Trusted-profile**
```
make testacc TEST=./ibm/service/iampolicy TESTARGS="-run TestAccIBMIAMTrustedProfilePolicy"
```
<img width="668" height="792" alt="image" src="https://github.com/user-attachments/assets/882a3e43-0ca0-4953-a81a-015af001a42d" />

**Access Group**
DataSource
<img width="623" height="211" alt="image" src="https://github.com/user-attachments/assets/0652e609-bec9-4c8d-8195-73069f4662f3" />

<img width="638" height="664" alt="image" src="https://github.com/user-attachments/assets/807c6304-7d12-487c-809a-76e65d11e4ab" />




