### PR TITLE
fix the redhat regex length range and add "-" to the allowed strings

### DIFF
--- a/ibm/service/enterprise/resource_ibm_enterprise.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise.go
@@ -46,7 +46,7 @@ func ResourceIBMEnterprise() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "The IAM ID of the enterprise primary contact, such as `IBMid-0123ABC`. The IAM ID must already exist.",
-				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9]{10}$"),
+				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9,-]{1,10}$"),
 			},
 			"domain": {
 				Type:        schema.TypeString,

--- a/ibm/service/enterprise/resource_ibm_enterprise_account.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account.go
@@ -52,7 +52,7 @@ func ResourceIBMEnterpriseAccount() *schema.Resource {
 				Computed:     true,
 				Description:  "The IAM ID of the account owner, such as `IBMid-0123ABC`. The IAM ID must already exist.",
 				ForceNew:     true,
-				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9]{10}$"),
+				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9,-]{1,10}$"),
 			},
 			"traits": {
 				Type:             schema.TypeSet,

--- a/ibm/service/enterprise/resource_ibm_enterprise_account_group.go
+++ b/ibm/service/enterprise/resource_ibm_enterprise_account_group.go
@@ -45,7 +45,7 @@ func ResourceIBMEnterpriseAccountGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "The IAM ID of the primary contact for this account group, such as `IBMid-0123ABC`. The IAM ID must already exist.",
-				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9]{10}$"),
+				ValidateFunc: validate.ValidateRegexps("^IBMid\\-[A-Z,0-9]{10}$", "^RedHat\\-[A-Z,0-9,-]{1,10}$"),
 			},
 			"url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6616
This is an additional PR to fix the regex eval length range and add "-" to the allowed strings #6623
Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
N/A

