### PR TITLE
Refactor ssh-key resource

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_key.go
+++ b/ibm/service/power/data_source_ibm_pi_key.go
@@ -85,7 +85,7 @@ func DataSourceIBMPIKey() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_key", "read")


### PR DESCRIPTION
Refactors error handling to use new style
Replaces interface{} with any
Adds check to setID to "" if resource is not found after reading, so that it can be recreated on subsequent terraform apply.

```
Output of acceptance testing:

--- PASS: TestAccIBMPIKey_basic (13.74s)
PASS

--- PASS: TestAccIBMPIKeyAccount (12.23s)
PASS

--- PASS: TestAccIBMPIKeyUpdate (22.22s)
PASS
```