### PR TITLE
chore: cleanup managed_by from examples

### DIFF
--- a/website/docs/r/atracker_route.html.markdown
+++ b/website/docs/r/atracker_route.html.markdown
@@ -14,7 +14,6 @@ Create, update, and delete atracker_routes with this resource.
 
 ```hcl
 resource "ibm_atracker_route" "atracker_route_instance" {
-  managed_by = "enterprise"
   name = "my-route"
   rules {
 		target_ids = [ "c3af557f-fb0e-4476-85c3-0889e7fe7bc4" ]

--- a/website/docs/r/metrics_router_route.html.markdown
+++ b/website/docs/r/metrics_router_route.html.markdown
@@ -14,7 +14,6 @@ Create, update, and delete metrics_router_routes with this resource.
 
 ```hcl
 resource "ibm_metrics_router_route" "metrics_router_route_instance" {
-  managed_by = "enterprise"
   name = "my-route"
   rules {
 		action = "send"


### PR DESCRIPTION
We are just cleanup the usage of `managed_by: enterprise` to avoid confusion for users. The default value will be applied which the common usage.