### PR TITLE
feat: added support for id input in resource group data source

### DIFF
--- a/ibm/service/resourcemanager/data_source_ibm_resource_group_test.go
+++ b/ibm/service/resourcemanager/data_source_ibm_resource_group_test.go
@@ -27,6 +27,13 @@ func TestAccIBMResourceGroupDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.ibm_resource_group.testacc_ds_resource_group_name", "name", "default"),
 				),
 			},
+			{
+				Config: testAccCheckIBMResourceGroupDataSourceConfigWithID(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ibm_resource_group.testacc_ds_id", "name", "default"),
+					resource.TestCheckResourceAttrSet("data.ibm_resource_group.testacc_ds_id", "id"),
+				),
+			},
 		},
 	})
 }
@@ -39,7 +46,7 @@ func TestAccIBMResourceGroupDataSource_Default_false(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckIBMResourceGroupDataSourceDefaultFalse(),
-				ExpectError: regexp.MustCompile(`Missing required properties. Need a resource group name, or the is_default true`),
+				ExpectError: regexp.MustCompile(`Missing required properties. Need a resource group name, resource group ID, or the is_default true`),
 			},
 		},
 	})
@@ -68,6 +75,19 @@ func testAccCheckIBMResourceGroupDataSourceDefaultFalse() string {
 	
 data "ibm_resource_group" "testacc_ds_resource_group" {
 	is_default = "false"
+}`
+
+}
+
+func testAccCheckIBMResourceGroupDataSourceConfigWithID() string {
+	return `
+
+data "ibm_resource_group" "testacc_ds_resource_group_default" {
+	is_default = "true"
+}
+
+data "ibm_resource_group" "testacc_ds_id" {
+	id = data.ibm_resource_group.testacc_ds_resource_group_default.id
 }`
 
 }

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -27,16 +27,25 @@ data "ibm_resource_group" "group" {
 }
 ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+### Example to import a resource group by ID
 
-- `is_default` - (Optional, Bool) Specifies whether you want to import default resource group.  **Note**: Conflicts with the  `name`.
-- `name` - (Optional, String) The name of an IBM Cloud resource group. You can retrieve the value by running the `ibmcloud resource groups` command in the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cloud-cli-getting-started).  **Note**: Conflicts with `is_default`.
+```terraform
+data "ibm_resource_group" "group" {
+  id = "5ffda12064634723b079acdb018ef308"
+}
+```
+
+## Argument reference
+Review the argument references that you can specify for your data source.
+
+- `is_default` - (Optional, Bool) Specifies whether you want to import default resource group.  **Note**: Conflicts with `name` and `id`.
+- `name` - (Optional, String) The name of an IBM Cloud resource group. You can retrieve the value by running the `ibmcloud resource groups` command in the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cloud-cli-getting-started).  **Note**: Conflicts with `is_default` and `id`.
+- `id` - (Optional, String) The ID of the resource group. You can retrieve the value by running the `ibmcloud resource groups` command in the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cloud-cli-getting-started).  **Note**: Conflicts with `is_default` and `name`.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
-- `account_id` - (String) Account ID.  
+- `account_id` - (String) Account ID.
 - `crn` - (String) The full CRN associated with the resource group.
 - `created_at` - (Timestamp) The date when the resource group initially created.
 - `id` - (String) The unique identifier of the new resource group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6615

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMResourceGroupDataSource_Basic
--- PASS: TestAccIBMResourceGroupDataSource_Basic (55.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcemanager 57.613s
```
