### PR TITLE
fix: issue 6085 - fix import of ibm_cm_offering

### DIFF
--- a/website/docs/r/cm_offering.html.markdown
+++ b/website/docs/r/cm_offering.html.markdown
@@ -590,7 +590,8 @@ For more informaton, see [here](https://registry.terraform.io/providers/IBM-Clou
 ## Import
 
 You can import the `ibm_cm_offering` resource by using `id`.
-The `id` property is just the `offering_id`.
+The `id` value specified should be a combination of the `catalog_id` and the `offering_id` separated by a `:`.  For example 
+`00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111` .
 
 * `offering_id`: A string. Offering identification.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

Includes a Doc update to describe the import for a cm_offering resource.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
```
=== RUN   TestAccIBMCmOfferingImport
--- PASS: TestAccIBMCmOfferingImport (21.02s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/catalogmanagement	23.036s
```
