### PR TITLE
feat(identity): add api key expiration field

### DIFF
--- a/ibm/service/iamidentity/data_source_ibm_iam_api_key.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_api_key.go
@@ -75,6 +75,11 @@ func DataSourceIBMIamApiKey() *schema.Resource {
 				Computed:    true,
 				Description: "ID of the account that this API key authenticates for.",
 			},
+			"expires_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'.",
+			},
 		},
 	}
 }
@@ -126,6 +131,9 @@ func dataSourceIbmIamApiKeyRead(context context.Context, d *schema.ResourceData,
 	}
 	if err = d.Set("account_id", apiKey.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error setting account_id: %s", err))
+	}
+	if err = d.Set("expires_at", apiKey.ExpiresAt); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting expires_at: %s", err))
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings_test.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_effective_account_settings_test.go
@@ -133,7 +133,6 @@ func TestDataSourceIBMIamEffectiveAccountSettingsAccountSettingsResponseToMap(t 
 		accountSettingsUserMfaResponseModel["description"] = "testString"
 
 		model := make(map[string]interface{})
-		model["account_id"] = "testString"
 		model["entity_tag"] = "testString"
 		model["history"] = []map[string]interface{}{enityHistoryRecordModel}
 		model["restrict_create_service_id"] = "NOT_SET"

--- a/ibm/service/iamidentity/resource_ibm_iam_api_key.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_api_key.go
@@ -89,6 +89,11 @@ func ResourceIBMIAMApiKey() *schema.Resource {
 				Computed:    true,
 				Description: "The API key cannot be changed if set to true.",
 			},
+			"expires_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'.",
+			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -138,6 +143,9 @@ func resourceIbmIamApiKeyCreate(context context.Context, d *schema.ResourceData,
 	}
 	if _, ok := d.GetOk("locked"); ok {
 		createApiKeyOptions.SetEntityLock(d.Get("locked").(string))
+	}
+	if _, ok := d.GetOk("expires_at"); ok {
+		createApiKeyOptions.SetExpiresAt(d.Get("expires_at").(string))
 	}
 
 	apiKey, response, err := iamIdentityClient.CreateAPIKey(createApiKeyOptions)
@@ -193,6 +201,9 @@ func resourceIbmIamApiKeyRead(context context.Context, d *schema.ResourceData, m
 	if err = d.Set("locked", apiKey.Locked); err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error setting entity_lock: %s", err))
 	}
+	if err = d.Set("expires_at", apiKey.ExpiresAt); err != nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error setting expires_at: %s", err))
+	}
 	if err = d.Set("apikey_id", apiKey.ID); err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error setting id: %s", err))
 	}
@@ -228,6 +239,9 @@ func resourceIbmIamApiKeyUpdate(context context.Context, d *schema.ResourceData,
 	updateApiKeyOptions.SetName(d.Get("name").(string))
 	if _, ok := d.GetOk("description"); ok {
 		updateApiKeyOptions.SetDescription(d.Get("description").(string))
+	}
+	if _, ok := d.GetOk("expires_at"); ok {
+		updateApiKeyOptions.SetExpiresAt(d.Get("expires_at").(string))
 	}
 	_, response, err := iamIdentityClient.UpdateAPIKey(updateApiKeyOptions)
 	if err != nil {

--- a/website/docs/d/iam_api_key.html.markdown
+++ b/website/docs/d/iam_api_key.html.markdown
@@ -39,5 +39,6 @@ In addition to the argument reference list, you can access the following attribu
 - `entity_tag` - (String) Version of the API Key details object. You need to specify this value when updating the API key to avoid stale updates.
 - `iam_id` - (String) The `iam_id` that this API key authenticates.
 - `locked` - (Bool) The API key cannot be changed if set to true.
+- `expires_at` - (String) Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'. WARNING An API key will be permanently and irrevocably deleted when both the expires_at and modified_at timestamps are more than ninety (90) days in the past, regardless of the key's locked status or any other state.
 - `modified_at` - (Timestamp) If set contains a date time string of the last modification date in ISO format.
 - `name` - (String) Name of the API key. The name is not checked for uniqueness. Therefore, multiple names with the same value can exist. Access is done by using the UUID of the API key.

--- a/website/docs/r/iam_api_key.html.markdown
+++ b/website/docs/r/iam_api_key.html.markdown
@@ -25,6 +25,7 @@ Review the argument references that you can specify for your resource.
 
 - `apikey` - (Optional, String) You can passthrough an API key value for this API key. If passed, that API key value is not validated, means, the value can be non URL safe. If omitted, the API key management creates an URL safe opaque API key value. The value of the API key is checked for uniqueness. Please ensure enough variations when passing the value.
 - `description` - (Optional, String) The description of the API key. The `description` property is only available if a description was provided during API key creation.
+- `expires_at` - (Optional, String) Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'. WARNING An API key will be permanently and irrevocably deleted when both the expires_at and modified_at timestamps are more than ninety (90) days in the past, regardless of the key's locked status or any other state.
 - `entity_lock` - (Optional, Bool) Indicates the API key is locked for further write operations. Default value is `false`.
 - `file` - (Optional, String) The file name where API key is to be stored.
 - `name` - (Required, String) The name of the API key. The name is not checked for uniqueness. Therefore, multiple names with the same value can exist. Access is done through the UUID of the API key.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<img width="1669" height="68" alt="Screenshot 2026-01-28 at 3 37 31 PM" src="https://github.com/user-attachments/assets/fac47bc3-34a2-4adf-89b9-7ff5d08d89c5" />
<img width="1669" height="219" alt="Screenshot 2026-01-28 at 3 39 23 PM" src="https://github.com/user-attachments/assets/820c8a4e-3658-4914-a946-22f9b4d10c1a" />

