### PR TITLE
fix(logs-router) change inclusion_filters to optional

### DIFF
--- a/ibm/service/logsrouter/resource_ibm_logs_router_route.go
+++ b/ibm/service/logsrouter/resource_ibm_logs_router_route.go
@@ -64,7 +64,7 @@ func ResourceIBMLogsRouterRoute() *schema.Resource {
 						},
 						"inclusion_filters": &schema.Schema{
 							Type:        schema.TypeList,
-							Required:    true,
+							Optional:    true,
 							Description: "A list of conditions to be satisfied for routing platform logs to pre-defined target.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -333,12 +333,14 @@ func ResourceIBMLogsRouterRouteMapToRulePrototype(modelMap map[string]interface{
 	}
 	model.Targets = targets
 	inclusionFilters := []logsrouterv3.InclusionFilterPrototype{}
-	for _, inclusionFiltersItem := range modelMap["inclusion_filters"].([]interface{}) {
-		inclusionFiltersItemModel, err := ResourceIBMLogsRouterRouteMapToInclusionFilterPrototype(inclusionFiltersItem.(map[string]interface{}))
-		if err != nil {
-			return model, err
+	if modelMap["inclusion_filters"] != nil {
+		for _, inclusionFiltersItem := range modelMap["inclusion_filters"].([]interface{}) {
+			inclusionFiltersItemModel, err := ResourceIBMLogsRouterRouteMapToInclusionFilterPrototype(inclusionFiltersItem.(map[string]interface{}))
+			if err != nil {
+				return model, err
+			}
+			inclusionFilters = append(inclusionFilters, *inclusionFiltersItemModel)
 		}
-		inclusionFilters = append(inclusionFilters, *inclusionFiltersItemModel)
 	}
 	model.InclusionFilters = inclusionFilters
 	return model, nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/logsrouter TESTARGS='-run=TestAccIBMLogsRouter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/logsrouter -v -run=TestAccIBMLogsRouter -timeout 700m

=== RUN   TestAccIBMLogsRouterRoutesDataSourceBasic
--- PASS: TestAccIBMLogsRouterRoutesDataSourceBasic (15.72s)
=== RUN   TestAccIBMLogsRouterRoutesDataSourceAllArgs
--- PASS: TestAccIBMLogsRouterRoutesDataSourceAllArgs (8.37s)
=== RUN   TestAccIBMLogsRouterTargetsDataSourceBasic
--- PASS: TestAccIBMLogsRouterTargetsDataSourceBasic (8.37s)
=== RUN   TestAccIBMLogsRouterTargetsDataSourceAllArgs
--- PASS: TestAccIBMLogsRouterTargetsDataSourceAllArgs (8.33s)
=== RUN   TestAccIBMLogsRouterRouteBasic
--- PASS: TestAccIBMLogsRouterRouteBasic (14.58s)
=== RUN   TestAccIBMLogsRouterRouteAllArgs
--- PASS: TestAccIBMLogsRouterRouteAllArgs (16.45s)
=== RUN   TestAccIBMLogsRouterSettingsBasic
--- PASS: TestAccIBMLogsRouterSettingsBasic (7.63s)
=== RUN   TestAccIBMLogsRouterSettingsAllArgs
--- PASS: TestAccIBMLogsRouterSettingsAllArgs (16.49s)
=== RUN   TestAccIBMLogsRouterTargetBasic
--- PASS: TestAccIBMLogsRouterTargetBasic (14.44s)
=== RUN   TestAccIBMLogsRouterTargetAllArgs
--- PASS: TestAccIBMLogsRouterTargetAllArgs (18.79s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logsrouter	131.098s
```
