### PR TITLE
Update unit wording to conform to new standard (#285)

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_available_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_available_hosts.go
@@ -42,7 +42,7 @@ func DataSourceIBMPIAvailableHosts() *schema.Resource {
 						},
 						Attr_AvailableMemory: {
 							Computed:    true,
-							Description: "Memory capacity of the host (in GB).",
+							Description: "Memory capacity of the host (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_Count: {

--- a/ibm/service/power/data_source_ibm_pi_host.go
+++ b/ibm/service/power/data_source_ibm_pi_host.go
@@ -47,7 +47,7 @@ func DataSourceIBMPIHost() *schema.Resource {
 						},
 						Attr_AvailableMemory: {
 							Computed:    true,
-							Description: "Amount of memory currently available (in GB).",
+							Description: "Amount of memory currently available (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_ReservedCore: {
@@ -57,7 +57,7 @@ func DataSourceIBMPIHost() *schema.Resource {
 						},
 						Attr_ReservedMemory: {
 							Computed:    true,
-							Description: "Amount of memory reserved for system use (in GB).",
+							Description: "Amount of memory reserved for system use (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_TotalCore: {
@@ -67,7 +67,7 @@ func DataSourceIBMPIHost() *schema.Resource {
 						},
 						Attr_TotalMemory: {
 							Computed:    true,
-							Description: "Total amount of memory of the host (in GB).",
+							Description: "Total amount of memory of the host (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_UsedCore: {
@@ -77,7 +77,7 @@ func DataSourceIBMPIHost() *schema.Resource {
 						},
 						Attr_UsedMemory: {
 							Computed:    true,
-							Description: "Amount of memory used on the host (in GB).",
+							Description: "Amount of memory used on the host (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 					},

--- a/ibm/service/power/data_source_ibm_pi_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_hosts.go
@@ -47,7 +47,7 @@ func DataSourceIBMPIHosts() *schema.Resource {
 									},
 									Attr_AvailableMemory: {
 										Computed:    true,
-										Description: "Amount of memory currently available (in GB).",
+										Description: "Amount of memory currently available (in GiB).",
 										Type:        schema.TypeFloat,
 									},
 									Attr_ReservedCore: {
@@ -57,7 +57,7 @@ func DataSourceIBMPIHosts() *schema.Resource {
 									},
 									Attr_ReservedMemory: {
 										Computed:    true,
-										Description: "Amount of memory reserved for system use (in GB).",
+										Description: "Amount of memory reserved for system use (in GiB).",
 										Type:        schema.TypeFloat,
 									},
 									Attr_TotalCore: {
@@ -67,7 +67,7 @@ func DataSourceIBMPIHosts() *schema.Resource {
 									},
 									Attr_TotalMemory: {
 										Computed:    true,
-										Description: "Total amount of memory of the host (in GB).",
+										Description: "Total amount of memory of the host (in GiB).",
 										Type:        schema.TypeFloat,
 									},
 									Attr_UsedCore: {
@@ -77,7 +77,7 @@ func DataSourceIBMPIHosts() *schema.Resource {
 									},
 									Attr_UsedMemory: {
 										Computed:    true,
-										Description: "Amount of memory used on the host (in GB).",
+										Description: "Amount of memory used on the host (in GiB).",
 										Type:        schema.TypeFloat,
 									},
 								},

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -98,7 +98,7 @@ func DataSourceIBMPIImage() *schema.Resource {
 			},
 			Attr_Size: {
 				Computed:    true,
-				Description: "The size of the image in megabytes.",
+				Description: "The size of the image in mebibytes.",
 				Type:        schema.TypeInt,
 			},
 			Attr_SourceChecksum: {

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -96,7 +96,7 @@ func DataSourceIBMPIInstance() *schema.Resource {
 			},
 			Attr_LicenseRepositoryCapacity: {
 				Computed:    true,
-				Description: "The VTL license repository capacity TB value.",
+				Description: "The VTL license repository capacity TiB value.",
 				Type:        schema.TypeInt,
 			},
 			Attr_MaxMem: {

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -179,7 +179,7 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 						},
 						Attr_Size: {
 							Computed:    true,
-							Description: "The size of this volume in GB.",
+							Description: "The size of this volume in GiB.",
 							Type:        schema.TypeFloat,
 						},
 						Attr_State: {

--- a/ibm/service/power/data_source_ibm_pi_instances.go
+++ b/ibm/service/power/data_source_ibm_pi_instances.go
@@ -64,7 +64,7 @@ func DataSourceIBMPIInstances() *schema.Resource {
 						},
 						Attr_LicenseRepositoryCapacity: {
 							Computed:    true,
-							Description: "The VTL license repository capacity TB value.",
+							Description: "The VTL license repository capacity TiB value.",
 							Type:        schema.TypeInt,
 						},
 						Attr_MaxMem: {

--- a/ibm/service/power/data_source_ibm_pi_sap_profile.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profile.go
@@ -58,7 +58,7 @@ func DataSourceIBMPISAPProfile() *schema.Resource {
 			},
 			Attr_Memory: {
 				Computed:    true,
-				Description: "Amount of memory (in GB).",
+				Description: "Amount of memory (in GiB).",
 				Type:        schema.TypeInt,
 			},
 			Attr_SAPS: {

--- a/ibm/service/power/data_source_ibm_pi_sap_profiles.go
+++ b/ibm/service/power/data_source_ibm_pi_sap_profiles.go
@@ -69,7 +69,7 @@ func DataSourceIBMPISAPProfiles() *schema.Resource {
 						},
 						Attr_Memory: {
 							Computed:    true,
-							Description: "Amount of memory (in GB).",
+							Description: "Amount of memory (in GiB).",
 							Type:        schema.TypeInt,
 						},
 						Attr_ProfileID: {

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -147,7 +147,7 @@ func DataSourceIBMPIVolume() *schema.Resource {
 			},
 			Attr_Size: {
 				Computed:    true,
-				Description: "The size of the volume in GB.",
+				Description: "The size of the volume in GiB.",
 				Type:        schema.TypeInt,
 			},
 			Attr_State: {

--- a/ibm/service/power/data_source_ibm_pi_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_volumes.go
@@ -149,7 +149,7 @@ func DataSourceIBMPIVolumes() *schema.Resource {
 						},
 						Attr_Size: {
 							Computed:    true,
-							Description: "The size of the volume in GB.",
+							Description: "The size of the volume in GiB.",
 							Type:        schema.TypeInt,
 						},
 						Attr_State: {

--- a/ibm/service/power/resource_ibm_pi_host.go
+++ b/ibm/service/power/resource_ibm_pi_host.go
@@ -99,7 +99,7 @@ func ResourceIBMPIHost() *schema.Resource {
 						},
 						Attr_AvailableMemory: {
 							Computed:    true,
-							Description: "Amount of memory currently available (in GB).",
+							Description: "Amount of memory currently available (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_ReservedCore: {
@@ -109,7 +109,7 @@ func ResourceIBMPIHost() *schema.Resource {
 						},
 						Attr_ReservedMemory: {
 							Computed:    true,
-							Description: "Amount of memory reserved for system use (in GB).",
+							Description: "Amount of memory reserved for system use (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_TotalCore: {
@@ -119,7 +119,7 @@ func ResourceIBMPIHost() *schema.Resource {
 						},
 						Attr_TotalMemory: {
 							Computed:    true,
-							Description: "Total amount of memory of the host (in GB).",
+							Description: "Total amount of memory of the host (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 						Attr_UsedCore: {
@@ -129,7 +129,7 @@ func ResourceIBMPIHost() *schema.Resource {
 						},
 						Attr_UsedMemory: {
 							Computed:    true,
-							Description: "Amount of memory used on the host (in GB).",
+							Description: "Amount of memory used on the host (in GiB).",
 							Type:        schema.TypeFloat,
 						},
 					},

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -160,7 +160,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 			},
 			Arg_LicenseRepositoryCapacity: {
 				Computed:    true,
-				Description: "The VTL license repository capacity TB value",
+				Description: "The VTL license repository capacity TiB value",
 				Optional:    true,
 				Type:        schema.TypeInt,
 			},

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -130,7 +130,7 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Type:        schema.TypeBool,
 			},
 			Arg_VolumeSize: {
-				Description:  "The size of the volume in GB.",
+				Description:  "The size of the volume in GiB.",
 				Required:     true,
 				Type:         schema.TypeFloat,
 				ValidateFunc: validation.NoZeroValues,

--- a/website/docs/d/pi_available_hosts.html.markdown
+++ b/website/docs/d/pi_available_hosts.html.markdown
@@ -50,7 +50,7 @@ In addition to the argument reference list, you can access the following attribu
 
     Nested scheme for `available_hosts`:
        - `available_cores`- (Float) Core capacity of the host.
-       - `available_memory`- (Float) Memory capacity of the host (in GB).
+       - `available_memory`- (Float) Memory capacity of the host (in GiB).
        - `count`- (int) The number of hosts with similar types/capacities that are available.
        - `sys_type`- (String) System type.
   

--- a/website/docs/d/pi_host.html.markdown
+++ b/website/docs/d/pi_host.html.markdown
@@ -51,13 +51,13 @@ After your data source is created, you can read values from the following attrib
   
     Nested schema for `capacity`:
       - `available_core` - (Float) Number of cores currently available.
-      - `available_memory` - (Float) Amount of memory currently available (in GB).
+      - `available_memory` - (Float) Amount of memory currently available (in GiB).
       - `reserved_core` - (Float) Number of cores reserved for system use.
-      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
+      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GiB).
       - `total_core` - (Float) Total number of cores of the host.
-      - `total_memory` - (Float) Total amount of memory of the host (in GB).
+      - `total_memory` - (Float) Total amount of memory of the host (in GiB).
       - `used_core` - (Float) Number of cores in use on the host.
-      - `used_memory` - (Float) Amount of memory used on the host (in GB).
+      - `used_memory` - (Float) Amount of memory used on the host (in GiB).
 
 - `crn` - (String) The CRN of this resource.
 - `display_name` - (String) Name of the host.

--- a/website/docs/d/pi_hosts.html.markdown
+++ b/website/docs/d/pi_hosts.html.markdown
@@ -52,13 +52,13 @@ After your data source is created, you can read values from the following attrib
   
      Nested schema for `capacity`:
         - `available_core` - (Float) Number of cores currently available.
-        - `available_memory` - (Float) Amount of memory currently available (in GB).
+        - `available_memory` - (Float) Amount of memory currently available (in GiB).
         - `reserved_core` - (Float) Number of cores reserved for system use.
-        - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
+        - `reserved_memory` - (Float) Amount of memory reserved for system use (in GiB).
         - `total_core` - (Float) Total number of cores of the host.
-        - `total_memory` - (Float) Total amount of memory of the host (in GB).
+        - `total_memory` - (Float) Total amount of memory of the host (in GiB).
         - `used_core` - (Float) Number of cores in use on the host.
-        - `used_memory` - (Float) Amount of memory used on the host (in GB).
+        - `used_memory` - (Float) Amount of memory used on the host (in GiB).
 
   - `crn` - (String) The CRN of this resource.
   - `display_name` - (String) Name of the host.

--- a/website/docs/d/pi_image.html.markdown
+++ b/website/docs/d/pi_image.html.markdown
@@ -58,7 +58,7 @@ In addition to all argument reference list, you can access the following attribu
 - `name`-  (String) The name of an image.
 - `operating_system` - (String) The operating system that is installed with the image.
 - `shared` - (String) Indicates whether the image is shared.
-- `size` - (String) The size of the image in megabytes.
+- `size` - (String) The size of the image in mebibytes.
 - `source_checksum` - (String) Checksum of the image.
 - `state` - (String) The state for this image.
 - `storage_pool` - (String) Storage pool where image resides.

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -68,7 +68,7 @@ In addition to all argument reference list, you can access the following attribu
 - `ibmi_rds` - (Boolean) IBM i Rational Dev Studio.
 - `ibmi_rds_users` - (Integer) IBM i Rational Dev Studio Number of User Licenses.
 - `id` - (String) The unique identifier of the instance.
-- `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+- `license_repository_capacity` - (Integer) The VTL license repository capacity TiB value. Only available with VTL instances.
 - `maxmem`- (Float) The maximum amount of memory that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.
 - `max_virtual_cores` - (Integer) The maximum number of virtual cores that can be assigned without rebooting the instance.

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -77,7 +77,7 @@ In addition to all argument reference list, you can access the following attribu
   - `replication_status` - (String) The replication status of the volume.
   - `replication_type` - (String) The replication type of the volume, `metro` or `global`.
   - `shareable` - (Boolean) Indicates if the volume is shareable between VMs.
-  - `size` - (Integer) The size of this volume in GB.
+  - `size` - (Integer) The size of this volume in GiB.
   - `state` - (String) The state of the volume.
   - `type` - (String) The disk type that is used for this volume.
   - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/d/pi_instances.html.markdown
+++ b/website/docs/d/pi_instances.html.markdown
@@ -59,7 +59,7 @@ In addition to all argument reference list, you can access the following attribu
         - `message` -  (String) The fault message of the server.
 
   - `health_status` - (String) The health of the instance.
-  - `license_repository_capacity` - (Integer) The VTL license repository capacity TB value. Only available with VTL instances.
+  - `license_repository_capacity` - (Integer) The VTL license repository capacity TiB value. Only available with VTL instances.
   - `memory` - (Float) The amount of memory that is allocated to the instance.
   - `minproc`- (Float) The minimum number of processors that must be allocated to the instance.
   - `maxproc`- (Float) The maximum number of processors that can be allocated to the instance without shutting down or rebooting the `LPAR`.

--- a/website/docs/d/pi_sap_profile.html.markdown
+++ b/website/docs/d/pi_sap_profile.html.markdown
@@ -50,7 +50,7 @@ In addition to all argument reference list, you can access the following attribu
 - `cores` - (Integer) Amount of cores.
 - `default_system` - (String) System to use if not provided.
 - `full_system_profile` - (Boolean) Requires full system for deployment.
-- `memory` - (Integer) Amount of memory (in GB).
+- `memory` - (Integer) Amount of memory (in GiB).
 - `saps` - (Integer) SAP application performance standard.
 - `supported_systems` - (List) List of supported systems.
 - `type` - (String) Type of profile.

--- a/website/docs/d/pi_sap_profiles.html.markdown
+++ b/website/docs/d/pi_sap_profiles.html.markdown
@@ -53,7 +53,7 @@ In addition to all argument reference list, you can access the following attribu
   - `cores` - (Integer) Amount of cores.
   - `default_system` - (String) System to use if not provided.
   - `full_system_profile` - (Boolean) Requires full system for deployment.
-  - `memory` - (Integer) Amount of memory (in GB).
+  - `memory` - (Integer) Amount of memory (in GiB).
   - `profile_id` - (String) SAP Profile ID.
   - `saps` - (Integer) SAP application performance standard.
   - `supported_systems` - (List) List of supported systems.

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -71,7 +71,7 @@ In addition to all argument reference list, you can access the following attribu
 - `replication_status` - (String) The replication status of the volume.
 - `replication_type` - (String) The replication type of the volume, `metro` or `global`.
 - `shareable` - (String) Indicates if the volume is shareable between VMs.
-- `size` - (Integer) The size of the volume in GB.
+- `size` - (Integer) The size of the volume in GiB.
 - `state` - (String) The state of the volume.
 - `user_tags` - (List) List of user tags attached to the resource.
 - `volume_pool` - (String) The name of storage pool where the volume is located.

--- a/website/docs/d/pi_volumes.html.markdown
+++ b/website/docs/d/pi_volumes.html.markdown
@@ -71,7 +71,7 @@ In addition to all argument reference list, you can access the following attribu
   - `replication_status` - (String) The replication status of the volume.
   - `replication_type` - (String) The replication type of the volume, `metro` or `global`.
   - `shareable` - (String) Indicates if the volume is shareable between VMs.
-  - `size` - (Integer) The size of the volume in GB.
+  - `size` - (Integer) The size of the volume in GiB.
   - `state` - (String) The state of the volume.
   - `user_tags` - (List) List of user tags attached to the resource.
   - `volume_pool` - (String) The name of storage pool where the volume is located.

--- a/website/docs/r/pi_host.html.markdown
+++ b/website/docs/r/pi_host.html.markdown
@@ -69,13 +69,13 @@ In addition to all argument reference list, you can access the following attribu
 
     Nested schema for `capacity`:
       - `available_core` - (Float) Number of cores currently available.
-      - `available_memory` - (Float) Amount of memory currently available (in GB).
+      - `available_memory` - (Float) Amount of memory currently available (in GiB).
       - `reserved_core` - (Float) Number of cores reserved for system use.
-      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GB).
+      - `reserved_memory` - (Float) Amount of memory reserved for system use (in GiB).
       - `total_core` - (Float) Total number of cores of the host.
-      - `total_memory` - (Float) Total amount of memory of the host (in GB).
+      - `total_memory` - (Float) Total amount of memory of the host (in GiB).
       - `used_core` - (Float) Number of cores in use on the host.
-      - `used_memory` - (Float) Amount of memory used on the host (in GB).
+      - `used_memory` - (Float) Amount of memory used on the host (in GiB).
 
 - `crn` - (String) The CRN of this resource.
 - `host_group` - (Map)  Information about the owning host group.

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -89,8 +89,8 @@ Review the argument references that you can specify for your resource.
         - If using `pi_deployment_type = VMNoStorage` then use the following images for the respective OS you intend to create the instance: `AIX-EMPTY`, `IBMI-EMPTY`, `SLES-EMPTY`, `RHEL-EMPTY`.
 - `pi_instance_name` - (Required, String) The name of the Power Systems Virtual Server instance.
 - `pi_key_pair_name` - (Optional, String) The name of the SSH key that you want to use to access your Power Systems Virtual Server instance. The SSH key must be uploaded to IBM Cloud.
-- `pi_license_repository_capacity` - (Optional, Integer) The VTL license repository capacity TB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
-- `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in GB.
+- `pi_license_repository_capacity` - (Optional, Integer) The VTL license repository capacity TiB value. Only use with VTL instances. `pi_memory >= 16 + (2 * pi_license_repository_capacity)`.
+- `pi_memory` - (Optional, Float) The amount of memory that you want to assign to your instance in GiB.
   - Required when not creating SAP instances. Conflicts with `pi_sap_profile_id`.
 - `pi_network` - (Required, List of Map) List of one or more networks to attach to the instance.
 

--- a/website/docs/r/pi_volume.html.markdown
+++ b/website/docs/r/pi_volume.html.markdown
@@ -12,7 +12,7 @@ Create, update, or delete a volume to attach it to a Power Systems Virtual Serve
 
 ## Example Usage
 
-The following example creates a 20 GB volume.
+The following example creates a 20 GiB volume.
 
 ```terraform
 resource "ibm_pi_volume" "testacc_volume"{
@@ -67,7 +67,7 @@ Review the argument references that you can specify for your resource.
 - `pi_volume_name` - (Required, String) The name of the volume.
 - `pi_volume_pool` - (Optional, String) Volume pool where the volume will be created; if provided then `pi_affinity_policy` values will be ignored.
 - `pi_volume_shareable` - (Required, Boolean) If set to **true**, the volume can be shared across Power Systems Virtual Server instances. If set to **false**, you can attach it only to one instance.
-- `pi_volume_size`  - (Required, Integer) The size of the volume in GB.
+- `pi_volume_size`  - (Required, Integer) The size of the volume in GiB.
 - `pi_volume_type` - (Optional, String) Type of volume, if this field is not provided, it will default to `tier3`. To get a list of available volume types, please use the [ibm_pi_storage_types_capacity](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/pi_storage_types_capacity) data source.
 
 ## Attribute Reference


### PR DESCRIPTION
Fix GB into GiB.
Fix TB into TiB.
Fix megabytes into mebibytes.
