### PR TITLE
Add expires_at to service_api_key

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_api_key.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_api_key.go
@@ -92,7 +92,7 @@ func ResourceIBMIAMApiKey() *schema.Resource {
 			"expires_at": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'.",
+				Description: "Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'. WARNING An API key will be permanently and irrevocably deleted when both the expires_at and modified_at timestamps are more than ninety (90) days in the past, regardless of the key's locked status or any other state.",
 			},
 			"created_at": {
 				Type:        schema.TypeString,

--- a/ibm/service/iamidentity/resource_ibm_iam_service_api_key_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_api_key_test.go
@@ -23,6 +23,8 @@ func TestAccIBMIAMServiceAPIKey_Basic(t *testing.T) {
 	name := fmt.Sprintf("terraform_iam_%d", acctest.RandIntRange(10, 100))
 	updateName := fmt.Sprintf("terraform_iam_%d", acctest.RandIntRange(10, 100))
 	storeValue := true
+	expiresAt := "2040-01-28T15:00+0000"
+	expiresAtUpdate := "2035-01-28T15:00+0000"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -30,25 +32,28 @@ func TestAccIBMIAMServiceAPIKey_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckIBMIAMServiceAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name, storeValue),
+				Config: testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name, storeValue, expiresAt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIAMServiceAPIKeyExistsWithValidation("ibm_iam_service_api_key.testacc_apiKey", apiKey, storeValue),
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "expires_at", expiresAt),
 					resource.TestCheckResourceAttrSet("ibm_iam_service_api_key.testacc_apiKey", "apikey"),
 				),
 			},
 			{
-				Config: testAccCheckIBMIAMServiceAPIKeyUpdateWithSameName(serviceName, name),
+				Config: testAccCheckIBMIAMServiceAPIKeyUpdateWithSameName(serviceName, name, expiresAtUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIAMServiceAPIKeyExistsWithValidation("ibm_iam_service_api_key.testacc_apiKey", apiKey, storeValue),
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "name", name),
+					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "expires_at", expiresAtUpdate),
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "description", "Service API Key for test scenario1"),
 				),
 			},
 			{
-				Config: testAccCheckIBMIAMServiceAPIKeyUpdate(serviceName, updateName),
+				Config: testAccCheckIBMIAMServiceAPIKeyUpdate(serviceName, updateName, expiresAt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "name", updateName),
+					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "expires_at", expiresAt),
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "description", "Service API Key for test scenario2"),
 				),
 			},
@@ -61,6 +66,7 @@ func TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_iam_ser_%d", acctest.RandIntRange(10, 100))
 	name := fmt.Sprintf("terraform_iam_%d", acctest.RandIntRange(10, 100))
 	storeValue := false
+	expiresAt := "2040-01-28T15:00+0000"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -68,7 +74,7 @@ func TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue(t *testing.T) {
 		CheckDestroy: testAccCheckIBMIAMServiceAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name, storeValue),
+				Config: testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name, storeValue, expiresAt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIAMServiceAPIKeyExistsWithValidation("ibm_iam_service_api_key.testacc_apiKey", apiKey, storeValue),
 					resource.TestCheckResourceAttr("ibm_iam_service_api_key.testacc_apiKey", "name", name),
@@ -170,7 +176,7 @@ func testAccCheckIBMIAMServiceAPIKeyExistsWithValidation(n string, apiKey string
 	}
 }
 
-func testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name string, storeValue bool) string {
+func testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name string, storeValue bool, expiresAt string) string {
 	return fmt.Sprintf(`
 		
 		resource "ibm_iam_service_id" "serviceID" {
@@ -181,11 +187,12 @@ func testAccCheckIBMIAMServiceAPIKeyBasic(serviceName, name string, storeValue b
 			name = "%s"
 			iam_service_id = ibm_iam_service_id.serviceID.iam_id
 			store_value = "%t"
+			expires_at = "%s"
 	  	}
-	`, serviceName, name, storeValue)
+	`, serviceName, name, storeValue, expiresAt)
 }
 
-func testAccCheckIBMIAMServiceAPIKeyUpdateWithSameName(serviceName, name string) string {
+func testAccCheckIBMIAMServiceAPIKeyUpdateWithSameName(serviceName, name string, expiresAt string) string {
 	return fmt.Sprintf(`
 		
 		resource "ibm_iam_service_id" "serviceID" {
@@ -196,11 +203,12 @@ func testAccCheckIBMIAMServiceAPIKeyUpdateWithSameName(serviceName, name string)
 			name = "%s"
 			description = "Service API Key for test scenario1"
 			iam_service_id = ibm_iam_service_id.serviceID.iam_id
+			expires_at = "%s"
 	  	}
-	`, serviceName, name)
+	`, serviceName, name, expiresAt)
 }
 
-func testAccCheckIBMIAMServiceAPIKeyUpdate(serviceName, updateName string) string {
+func testAccCheckIBMIAMServiceAPIKeyUpdate(serviceName, updateName string, expiresAt string) string {
 	return fmt.Sprintf(`
 
 		resource "ibm_iam_service_id" "serviceID" {
@@ -212,8 +220,9 @@ func testAccCheckIBMIAMServiceAPIKeyUpdate(serviceName, updateName string) strin
 			name = "%s"
 			description = "Service API Key for test scenario2"
 			iam_service_id = ibm_iam_service_id.serviceID.iam_id
+			expires_at = "%s"
 	  	}
-	`, serviceName, updateName)
+	`, serviceName, updateName, expiresAt)
 }
 
 func testAccCheckIBMIAMServiceAPIKeyImport(serviceName, name string) string {

--- a/website/docs/r/iam_service_api_key.html.markdown
+++ b/website/docs/r/iam_service_api_key.html.markdown
@@ -34,6 +34,7 @@ Review the argument references that you can specify for your resource.
 - `locked`- (Optional, Bool) The API key cannot be changed if set to **true**.
 - `name` - (Required, String) The name of the service API key.
 - `store_value`- (Optional, Bool) The boolean value whether API key value is retrievable in the future.
+- `expires_at` - (Optional, String) Date and time when the API key becomes invalid, ISO 8601 datetime in the format 'yyyy-MM-ddTHH:mm+0000'. WARNING An API key will be permanently and irrevocably deleted when both the expires_at and modified_at timestamps are more than ninety (90) days in the past, regardless of the key's locked status or any other state.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_service_api_key_test.go   ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity/resource_ibm_iam_service_api_key_test.go -v  -timeout 700m 
=== RUN   TestAccIBMIAMServiceAPIKey_Basic
--- PASS: TestAccIBMIAMServiceAPIKey_Basic (73.87s)
=== RUN   TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue
--- PASS: TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue (27.36s)
=== RUN   TestAccIBMIAMServiceAPIKey_import
--- PASS: TestAccIBMIAMServiceAPIKey_import (32.23s)
PASS
ok      command-line-arguments  135.890s
➜  terraform-provider-ibm (service-id-apikey-exp)                                                                                                                                                                                                                                                                                       ✈
```
