### PR TITLE
Terraform should not plan update-in-place when no resources exist for template assignment 

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
@@ -184,46 +184,6 @@ func ResourceIBMAccountSettingsTemplate() *schema.Resource {
 				Optional:    true,
 				Description: "Committed flag determines if the template is ready for assignment.",
 			},
-			"history": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "History of the Template.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"timestamp": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Timestamp when the action was triggered.",
-						},
-						"iam_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "IAM ID of the identity which triggered the action.",
-						},
-						"iam_id_account": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Account of the identity which triggered the action.",
-						},
-						"action": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Action of the history entry.",
-						},
-						"params": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Description: "Params of the history entry.",
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-						"message": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Message which summarizes the executed action.",
-						},
-					},
-				},
-			},
 			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -427,20 +387,6 @@ func resourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.R
 	if err = d.Set("committed", accountSettingsTemplateResponse.Committed); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting committed: %s", err))
 	}
-	var history []map[string]interface{}
-	if !core.IsNil(accountSettingsTemplateResponse.History) {
-		for _, historyItem := range accountSettingsTemplateResponse.History {
-			historyItemMap, err := EnityHistoryRecordToMap(&historyItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			history = append(history, historyItemMap)
-		}
-	}
-	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting history: %s", err))
-	}
-
 	if err = d.Set("entity_tag", accountSettingsTemplateResponse.EntityTag); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
 	}

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -57,70 +57,6 @@ func ResourceIBMAccountSettingsTemplateAssignment() *schema.Resource {
 				Required:    true,
 				Description: "Assignment target.",
 			},
-			"context": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Context with key properties for problem determination.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"transaction_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The transaction ID of the inbound REST request.",
-						},
-						"operation": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The operation of the inbound REST request.",
-						},
-						"user_agent": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The user agent of the inbound REST request.",
-						},
-						"url": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The URL of that cluster.",
-						},
-						"instance_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The instance ID of the server instance processing the request.",
-						},
-						"thread_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The thread ID of the server instance processing the request.",
-						},
-						"host": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The host of the server instance processing the request.",
-						},
-						"start_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The start time of the request.",
-						},
-						"end_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The finish time of the request.",
-						},
-						"elapsed_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The elapsed time in msec.",
-						},
-						"cluster_name": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The cluster name.",
-						},
-					},
-				},
-			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -139,7 +75,7 @@ func ResourceIBMAccountSettingsTemplateAssignment() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"target": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: "Target account where the IAM resource is created.",
 						},
 						"account_settings": {
@@ -197,46 +133,6 @@ func ResourceIBMAccountSettingsTemplateAssignment() *schema.Resource {
 									},
 								},
 							},
-						},
-					},
-				},
-			},
-			"history": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Assignment history.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"timestamp": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Timestamp when the action was triggered.",
-						},
-						"iam_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "IAM ID of the identity which triggered the action.",
-						},
-						"iam_id_account": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Account of the identity which triggered the action.",
-						},
-						"action": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Action of the history entry.",
-						},
-						"params": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Description: "Params of the history entry.",
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-						"message": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Message which summarizes the executed action.",
 						},
 					},
 				},
@@ -358,23 +254,14 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
 	}
-	if !core.IsNil(templateAssignmentResponse.Context) {
-		contextMap, err := resourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if err = d.Set("context", []map[string]interface{}{contextMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting context: %s", err))
-		}
-	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
 	}
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 	}
+	var resources []map[string]interface{}
 	if !core.IsNil(templateAssignmentResponse.Resources) {
-		var resources []map[string]interface{}
 		for _, resourcesItem := range templateAssignmentResponse.Resources {
 			resourcesItemMap, err := resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(&resourcesItem)
 			if err != nil {
@@ -382,22 +269,9 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 			}
 			resources = append(resources, resourcesItemMap)
 		}
-		if err = d.Set("resources", resources); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
-		}
 	}
-	if !core.IsNil(templateAssignmentResponse.History) {
-		var history []map[string]interface{}
-		for _, historyItem := range templateAssignmentResponse.History {
-			historyItemMap, err := EnityHistoryRecordToMap(&historyItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			history = append(history, historyItemMap)
-		}
-		if err = d.Set("history", history); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting history: %s", err))
-		}
+	if err = d.Set("resources", resources); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
@@ -480,44 +354,6 @@ func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context,
 	d.SetId("")
 
 	return nil
-}
-
-func resourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(model *iamidentityv1.ResponseContext) (map[string]interface{}, error) {
-	modelMap := make(map[string]interface{})
-	if model.TransactionID != nil {
-		modelMap["transaction_id"] = model.TransactionID
-	}
-	if model.Operation != nil {
-		modelMap["operation"] = model.Operation
-	}
-	if model.UserAgent != nil {
-		modelMap["user_agent"] = model.UserAgent
-	}
-	if model.URL != nil {
-		modelMap["url"] = model.URL
-	}
-	if model.InstanceID != nil {
-		modelMap["instance_id"] = model.InstanceID
-	}
-	if model.ThreadID != nil {
-		modelMap["thread_id"] = model.ThreadID
-	}
-	if model.Host != nil {
-		modelMap["host"] = model.Host
-	}
-	if model.StartTime != nil {
-		modelMap["start_time"] = model.StartTime
-	}
-	if model.EndTime != nil {
-		modelMap["end_time"] = model.EndTime
-	}
-	if model.ElapsedTime != nil {
-		modelMap["elapsed_time"] = model.ElapsedTime
-	}
-	if model.ClusterName != nil {
-		modelMap["cluster_name"] = model.ClusterName
-	}
-	return modelMap, nil
 }
 
 func resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(model *iamidentityv1.TemplateAssignmentResponseResource) (map[string]interface{}, error) {
@@ -637,12 +473,12 @@ func isAccountSettingsTemplateAssigned(id string, meta interface{}) retry.StateR
 			}
 
 			if *assignment.Status == "failed" {
-				return assignment, READY, fmt.Errorf("[ERROR] The assignment %s did complete but with a 'failed' status. Please check assignment resource for detailed errors: %s\n", id, response)
+				return assignment, READY, fmt.Errorf("[ERROR] The assignment %s did complete but with a 'failed' status. Please check assignment resource for detailed errors: %s", id, response)
 			}
 
 			return assignment, READY, nil
 		}
 
-		return assignment, READY, fmt.Errorf("[ERROR] Unexpected status reached for assignment %s.: %s\n", id, response)
+		return assignment, READY, fmt.Errorf("[ERROR] Unexpected status reached for assignment %s.: %s", id, response)
 	}
 }

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go
@@ -31,8 +31,7 @@ func TestAccIBMAccountSettingsTemplateAssignmentBasic(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccCheckIBMAccountSettingsTemplateAssignmentConfigBasic(enterpriseAccountId, targetId, name),
-				ExpectNonEmptyPlan: true,
+				Config: testAccCheckIBMAccountSettingsTemplateAssignmentConfigBasic(enterpriseAccountId, targetId, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMAccountSettingsTemplateAssignmentExists("ibm_iam_account_settings_template_assignment.account_settings_template_assignment_instance", conf),
 					resource.TestCheckResourceAttrSet("ibm_iam_account_settings_template_assignment.account_settings_template_assignment_instance", "id"),

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
@@ -192,46 +192,6 @@ func ResourceIBMTrustedProfileTemplate() *schema.Resource {
 				Optional:    true,
 				Description: "Committed flag determines if the template is ready for assignment.",
 			},
-			"history": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "History of the trusted profile template.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"timestamp": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Timestamp when the action was triggered.",
-						},
-						"iam_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "IAM ID of the identity which triggered the action.",
-						},
-						"iam_id_account": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Account of the identity which triggered the action.",
-						},
-						"action": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Action of the history entry.",
-						},
-						"params": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Description: "Params of the history entry.",
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-						"message": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Message which summarizes the executed action.",
-						},
-					},
-				},
-			},
 			"entity_tag": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -474,20 +434,6 @@ func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.Re
 			return diag.FromErr(fmt.Errorf("error setting committed: %s", err))
 		}
 	}
-	var history []map[string]interface{}
-	if !core.IsNil(trustedProfileTemplateResponse.History) {
-		for _, historyItem := range trustedProfileTemplateResponse.History {
-			historyItemMap, err := EnityHistoryRecordToMap(&historyItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			history = append(history, historyItemMap)
-		}
-	}
-	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting history: %s", err))
-	}
-
 	if !core.IsNil(trustedProfileTemplateResponse.EntityTag) {
 		if err = d.Set("entity_tag", trustedProfileTemplateResponse.EntityTag); err != nil {
 			return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -63,70 +63,6 @@ func ResourceIBMTrustedProfileTemplateAssignment() *schema.Resource {
 				Required:    true,
 				Description: "Assignment target.",
 			},
-			"context": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Context with key properties for problem determination.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"transaction_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The transaction ID of the inbound REST request.",
-						},
-						"operation": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The operation of the inbound REST request.",
-						},
-						"user_agent": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The user agent of the inbound REST request.",
-						},
-						"url": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The URL of that cluster.",
-						},
-						"instance_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The instance ID of the server instance processing the request.",
-						},
-						"thread_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The thread ID of the server instance processing the request.",
-						},
-						"host": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The host of the server instance processing the request.",
-						},
-						"start_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The start time of the request.",
-						},
-						"end_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The finish time of the request.",
-						},
-						"elapsed_time": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The elapsed time in msec.",
-						},
-						"cluster_name": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The cluster name.",
-						},
-					},
-				},
-			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -145,7 +81,7 @@ func ResourceIBMTrustedProfileTemplateAssignment() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"target": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: "Target account where the IAM resource is created.",
 						},
 						"profile": {
@@ -284,46 +220,6 @@ func ResourceIBMTrustedProfileTemplateAssignment() *schema.Resource {
 					},
 				},
 			},
-			"history": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "Assignment history.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"timestamp": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Timestamp when the action was triggered.",
-						},
-						"iam_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "IAM ID of the identity which triggered the action.",
-						},
-						"iam_id_account": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Account of the identity which triggered the action.",
-						},
-						"action": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Action of the history entry.",
-						},
-						"params": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Description: "Params of the history entry.",
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-						"message": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Message which summarizes the executed action.",
-						},
-					},
-				},
-			},
 			"href": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -435,25 +331,14 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
 	}
-	ctx := []map[string]interface{}{}
-	if !core.IsNil(templateAssignmentResponse.Context) {
-		contextMap, err := resourceIBMTrustedProfileTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		ctx = append(ctx, contextMap)
-	}
-	if err = d.Set("context", ctx); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting context: %s", err))
-	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
 	}
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
 	}
+	resources := []map[string]interface{}{}
 	if !core.IsNil(templateAssignmentResponse.Resources) {
-		resources := []map[string]interface{}{}
 		for _, resourcesItem := range templateAssignmentResponse.Resources {
 			resourcesItemMap, err := resourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceToMap(&resourcesItem)
 			if err != nil {
@@ -461,22 +346,9 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 			}
 			resources = append(resources, resourcesItemMap)
 		}
-		if err = d.Set("resources", resources); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
-		}
 	}
-	history := []map[string]interface{}{}
-	if !core.IsNil(templateAssignmentResponse.History) {
-		for _, historyItem := range templateAssignmentResponse.History {
-			historyItemMap, err := EnityHistoryRecordToMap(&historyItem)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			history = append(history, historyItemMap)
-		}
-	}
-	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("[ERROR] Error setting history: %s", err))
+	if err = d.Set("resources", resources); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
@@ -622,44 +494,6 @@ func isTrustedProfileTemplateAssigned(id string, meta interface{}) retry.StateRe
 
 		return assignment, READY, fmt.Errorf("[ERROR] Unexpected status reached for assignment %s.: %s\n", id, response)
 	}
-}
-
-func resourceIBMTrustedProfileTemplateAssignmentResponseContextToMap(model *iamidentityv1.ResponseContext) (map[string]interface{}, error) {
-	modelMap := make(map[string]interface{})
-	if model.TransactionID != nil {
-		modelMap["transaction_id"] = model.TransactionID
-	}
-	if model.Operation != nil {
-		modelMap["operation"] = model.Operation
-	}
-	if model.UserAgent != nil {
-		modelMap["user_agent"] = model.UserAgent
-	}
-	if model.URL != nil {
-		modelMap["url"] = model.URL
-	}
-	if model.InstanceID != nil {
-		modelMap["instance_id"] = model.InstanceID
-	}
-	if model.ThreadID != nil {
-		modelMap["thread_id"] = model.ThreadID
-	}
-	if model.Host != nil {
-		modelMap["host"] = model.Host
-	}
-	if model.StartTime != nil {
-		modelMap["start_time"] = model.StartTime
-	}
-	if model.EndTime != nil {
-		modelMap["end_time"] = model.EndTime
-	}
-	if model.ElapsedTime != nil {
-		modelMap["elapsed_time"] = model.ElapsedTime
-	}
-	if model.ClusterName != nil {
-		modelMap["cluster_name"] = model.ClusterName
-	}
-	return modelMap, nil
 }
 
 func resourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceToMap(model *iamidentityv1.TemplateAssignmentResponseResource) (map[string]interface{}, error) {

--- a/website/docs/r/account_settings_template.html.markdown
+++ b/website/docs/r/account_settings_template.html.markdown
@@ -167,14 +167,6 @@ After your resource is created, you can read values from the listed arguments an
   * `session_invalidation_in_seconds` - (String) Defines the period of time in seconds in which a session is invalid due to inactivity.
   * `system_access_token_expiration_in_seconds` - (String) Defines the access token expiration in seconds.
   * `system_refresh_token_expiration_in_seconds` - (String) Defines the refresh token expiration in seconds.
-* `history` - (List) History of the Template.
-Nested schema for **history**:
-	* `action` - (String) Action of the history entry.
-	* `iam_id` - (String) IAM ID of the identity which triggered the action.
-	* `iam_id_account` - (String) Account of the identity which triggered the action.
-	* `message` - (String) Message which summarizes the executed action.
-	* `params` - (List) Params of the history entry.
-	* `timestamp` - (String) Timestamp when the action was triggered.
 * `last_modified_at` - (String) Template last modified at.
 * `last_modified_by_id` - (String) IAMid of the identity that made the latest modification.
 

--- a/website/docs/r/account_settings_template_assignment.html.markdown
+++ b/website/docs/r/account_settings_template_assignment.html.markdown
@@ -56,33 +56,12 @@ After your resource is created, you can read values from the listed arguments an
 			* `id` - (String) id of the created resource.
 		* `status` - (String) Status for the target account's assignment.
 	* `target` - (String) Target account where the IAM resource is created.
-* `history` - (List) Assignment history.
-  Nested schema for **history**:
-	* `action` - (String) Action of the history entry.
-	* `iam_id` - (String) IAM ID of the identity which triggered the action.
-	* `iam_id_account` - (String) Account of the identity which triggered the action.
-	* `message` - (String) Message which summarizes the executed action.
-	* `params` - (List) Params of the history entry.
-	* `timestamp` - (String) Timestamp when the action was triggered.
 * `href` - (String) Href.
 * `created_at` - (String) Assignment created at.
 * `created_by_id` - (String) IAMid of the identity that created the assignment.
 * `last_modified_at` - (String) Assignment modified at.
 * `last_modified_by_id` - (String) IAMid of the identity that last modified the assignment.
 * `entity_tag` - (String) Entity tag for this assignment record.
-* `context` - (List) Context with key properties for problem determination.
-  Nested schema for **context**:
-	* `cluster_name` - (String) The cluster name.
-	* `elapsed_time` - (String) The elapsed time in msec.
-	* `end_time` - (String) The finish time of the request.
-	* `host` - (String) The host of the server instance processing the request.
-	* `instance_id` - (String) The instance ID of the server instance processing the request.
-	* `operation` - (String) The operation of the inbound REST request.
-	* `start_time` - (String) The start time of the request.
-	* `thread_id` - (String) The thread ID of the server instance processing the request.
-	* `transaction_id` - (String) The transaction ID of the inbound REST request.
-	* `url` - (String) The URL of that cluster.
-	* `user_agent` - (String) The user agent of the inbound REST request.
 
 ## Import
 

--- a/website/docs/r/trusted_profile_template.html.markdown
+++ b/website/docs/r/trusted_profile_template.html.markdown
@@ -208,14 +208,6 @@ After your resource is created, you can read values from the listed arguments an
 * `created_by_id` - (String) IAMid of the creator.
 * `crn` - (String) Cloud resource name.
 * `entity_tag` - (String) Entity tag for this templateId-version combination.
-* `history` - (List) History of the trusted profile template.
-Nested schema for **history**:
-	* `action` - (String) Action of the history entry.
-	* `iam_id` - (String) IAM ID of the identity which triggered the action.
-	* `iam_id_account` - (String) Account of the identity which triggered the action.
-	* `message` - (String) Message which summarizes the executed action.
-	* `params` - (List) Params of the history entry.
-	* `timestamp` - (String) Timestamp when the action was triggered.
 * `last_modified_at` - (String) Timestamp of when the template was last modified.
 * `last_modified_by_id` - (String) IAMid of the identity that made the latest modification.
 

--- a/website/docs/r/trusted_profile_template_assignment.html.markdown
+++ b/website/docs/r/trusted_profile_template_assignment.html.markdown
@@ -36,30 +36,9 @@ After your resource is created, you can read values from the listed arguments an
 
 * `id` - The unique identifier of the trusted_profile_template_assignment.
 * `account_id` - (String) Enterprise account Id.
-* `context` - (List) Context with key properties for problem determination.
-Nested schema for **context**:
-	* `cluster_name` - (String) The cluster name.
-	* `elapsed_time` - (String) The elapsed time in msec.
-	* `end_time` - (String) The finish time of the request.
-	* `host` - (String) The host of the server instance processing the request.
-	* `instance_id` - (String) The instance ID of the server instance processing the request.
-	* `operation` - (String) The operation of the inbound REST request.
-	* `start_time` - (String) The start time of the request.
-	* `thread_id` - (String) The thread ID of the server instance processing the request.
-	* `transaction_id` - (String) The transaction ID of the inbound REST request.
-	* `url` - (String) The URL of that cluster.
-	* `user_agent` - (String) The user agent of the inbound REST request.
 * `created_at` - (String) Assignment created at.
 * `created_by_id` - (String) IAMid of the identity that created the assignment.
 * `entity_tag` - (String) Entity tag for this assignment record.
-* `history` - (List) Assignment history.
-Nested schema for **history**:
-	* `action` - (String) Action of the history entry.
-	* `iam_id` - (String) IAM ID of the identity which triggered the action.
-	* `iam_id_account` - (String) Account of the identity which triggered the action.
-	* `message` - (String) Message which summarizes the executed action.
-	* `params` - (List) Params of the history entry.
-	* `timestamp` - (String) Timestamp when the action was triggered.
 * `href` - (String) Href.
 * `last_modified_at` - (String) Assignment modified at.
 * `last_modified_by_id` - (String) IAMid of the identity that last modified the assignment.


### PR DESCRIPTION
Also removed `history` and `context` attributes as these are not necessary. 

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6216

Template related acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_test.go
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMTrustedProfileTemplateBasic
--- PASS: TestAccIBMTrustedProfileTemplateBasic (37.91s)
=== RUN   TestAccIBMTrustedProfileTemplateVersionBasic
--- PASS: TestAccIBMTrustedProfileTemplateVersionBasic (20.54s)
=== RUN   TestAccIBMTrustedProfileTemplateAllArgs
--- PASS: TestAccIBMTrustedProfileTemplateAllArgs (48.05s)
PASS
ok  	command-line-arguments	108.708s

make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMTrustedProfileTemplateAssignmentBasic
--- PASS: TestAccIBMTrustedProfileTemplateAssignmentBasic (328.86s)
PASS
ok  	command-line-arguments	331.088s

make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_test.go
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMAccountSettingsTemplateBasic
--- PASS: TestAccIBMAccountSettingsTemplateBasic (35.77s)
=== RUN   TestAccIBMAccountSettingsTemplateVersionBasic
--- PASS: TestAccIBMAccountSettingsTemplateVersionBasic (21.05s)
=== RUN   TestAccIBMAccountSettingsTemplateAllArgs
--- PASS: TestAccIBMAccountSettingsTemplateAllArgs (49.39s)
PASS
ok  	command-line-arguments	108.537s

make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go                              ✈
==> Checking that code complies with gofmt requirements...
=== RUN   TestAccIBMAccountSettingsTemplateAssignmentBasic
--- PASS: TestAccIBMAccountSettingsTemplateAssignmentBasic (218.20s)
PASS
ok  	command-line-arguments	220.717s

...
```
