### PR TITLE
Fix: prevent duplicate user invite API calls causing 409 error

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -67,6 +67,7 @@ var (
 	FloatingIpID                    string
 	HpcsInstanceID                  string
 	HpcsInstanceName                string
+	IAMAccessGroupId                string
 	IAMAccountId                    string
 	IAMServiceId                    string
 	IAMTrustedProfileID             string
@@ -536,6 +537,11 @@ func init() {
 	IAMUser = os.Getenv("IBM_IAMUSER")
 	if IAMUser == "" {
 		fmt.Println("[WARN] Set the environment variable IBM_IAMUSER for testing ibm_iam_user_policy resource Some tests for that resource will fail if this is not set correctly")
+	}
+
+	IAMAccessGroupId = os.Getenv("IBM_IAM_ACCESS_GROUP_ID")
+	if IAMAccessGroupId == "" {
+		fmt.Println("[WARN] Set the environment variable IBM_IAM_ACCESS_GROUP_ID for testing ibm_iam_user_invite resource Some tests for that resource will fail if this is not set correctly")
 	}
 
 	IAMAccountId = os.Getenv("IBM_IAMACCOUNTID")

--- a/ibm/service/iampolicy/resource_ibm_iam_user_invite.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_user_invite.go
@@ -682,7 +682,7 @@ func resourceIBMIAMUpdateUserProfile(d *schema.ResourceData, meta interface{}) e
 	}
 	Client := userManagement.UserInvite()
 
-	if d.HasChange("users") {
+	if d.HasChange("users") && !d.IsNewResource() {
 		//var removedUsers, addedUsers []string
 		accountID, err := getAccountID(d, meta)
 		if err != nil {

--- a/ibm/service/iampolicy/resource_ibm_iam_user_invite_test.go
+++ b/ibm/service/iampolicy/resource_ibm_iam_user_invite_test.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package iampolicy_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIBMIAMUserInvite_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIAMUserInviteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIAMUserInviteBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIAMUserInviteExists("ibm_iam_user_invite.invite_user"),
+					resource.TestCheckResourceAttr("ibm_iam_user_invite.invite_user", "users.#", "1"),
+					resource.TestCheckResourceAttr("ibm_iam_user_invite.invite_user", "access_groups.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIAMUserInviteDestroy(s *terraform.State) error {
+	// User invites are transient - once processed, they don't persist as resources
+	// The invited users become part of the account, but the invite itself is gone
+	// So there's nothing to check for destroy
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ibm_iam_user_invite" {
+			continue
+		}
+		// Just verify the resource was in state
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set for user invite resource")
+		}
+	}
+	return nil
+}
+
+func testAccCheckIBMIAMUserInviteExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user invite ID is set")
+		}
+		return nil
+	}
+}
+
+func testAccCheckIBMIAMUserInviteBasic() string {
+	return fmt.Sprintf(`
+		resource "ibm_iam_user_invite" "invite_user" {
+			users = ["%s"]
+			access_groups = ["%s"]
+		}
+	`, acc.IAMUser, acc.IAMAccessGroupId)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6662

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMIAMUserInvite_Basic (28.08s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iampolicy       29.984s

```
