### PR TITLE
Refactor host group update logic

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -270,6 +270,8 @@ var (
 	Pi_route_id                       string
 	Pi_sap_image                      string
 	Pi_sap_profile_id                 string
+	Pi_secondary_workspace_id_1       string
+	Pi_secondary_workspace_id_2       string
 	Pi_shared_processor_pool_id       string
 	Pi_snapshot_id                    string
 	Pi_spp_placement_group_id         string
@@ -1518,6 +1520,16 @@ func init() {
 	if Pi_host_group_id == "" {
 		Pi_host_group_id = ""
 		fmt.Println("[WARN] Set the environment variable PI_HOST_GROUP_ID for testing ibm_pi_host resource else it is set to default value ''")
+	}
+	Pi_secondary_workspace_id_1 = os.Getenv("PI_SECONDARY_WORKSPACE_ID_1")
+	if Pi_secondary_workspace_id_1 == "" {
+		Pi_secondary_workspace_id_1 = ""
+		fmt.Println("[WARN] Set the environment variable PI_SECONDARY_WORKSPACE_ID_1 for testing ibm_pi_host_group update else it is set to default value ''")
+	}
+	Pi_secondary_workspace_id_2 = os.Getenv("PI_SECONDARY_WORKSPACE_ID_2")
+	if Pi_secondary_workspace_id_2 == "" {
+		Pi_secondary_workspace_id_2 = ""
+		fmt.Println("[WARN] Set the environment variable PI_SECONDARY_WORKSPACE_ID_2 for testing ibm_pi_host_group update else it is set to default value ''")
 	}
 	Pi_host_id = os.Getenv("PI_HOST_ID")
 	if Pi_host_id == "" {

--- a/ibm/service/power/resource_ibm_pi_host_group.go
+++ b/ibm/service/power/resource_ibm_pi_host_group.go
@@ -51,12 +51,14 @@ func ResourceIBMPIHostGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						Attr_DisplayName: {
 							Description:  "Name of the host chosen by the user.",
+							ForceNew:     true,
 							Required:     true,
 							Type:         schema.TypeString,
 							ValidateFunc: validation.NoZeroValues,
 						},
 						Attr_SysType: {
 							Description:  "System type.",
+							ForceNew:     true,
 							Required:     true,
 							Type:         schema.TypeString,
 							ValidateFunc: validation.NoZeroValues,
@@ -64,6 +66,7 @@ func ResourceIBMPIHostGroup() *schema.Resource {
 						Attr_UserTags: {
 							Description: "List of user tags attached to the resource.",
 							Elem:        &schema.Schema{Type: schema.TypeString},
+							ForceNew:    true,
 							Optional:    true,
 							Set:         schema.HashString,
 							Type:        schema.TypeSet,

--- a/ibm/service/power/resource_ibm_pi_host_group_test.go
+++ b/ibm/service/power/resource_ibm_pi_host_group_test.go
@@ -44,13 +44,95 @@ func testAccCheckIBMPIHostGroupConfigBasic(name, displayName string) string {
 			pi_cloud_instance_id = "%[1]s"
 			pi_hosts {
 				display_name = "%[2]s"
-				sys_type = "s1022"
+				sys_type = "s922"
 			}
 			pi_name = "%[3]s"
 		}
 	`, acc.Pi_cloud_instance_id, displayName, name)
 }
+func TestAccIBMPIHostGroupUpdateSecondaries(t *testing.T) {
+	name := fmt.Sprintf("tf_name_%d", acctest.RandIntRange(10, 100))
+	displayName := fmt.Sprintf("tf_display_name_%d", acctest.RandIntRange(10, 100))
+	hostGroupRes := "ibm_pi_host_group.hostGroup"
 
+	resource.Test(t, resource.TestCase{
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIHostGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create host group with one secondary.
+				Config: testAccCheckIBMPIHostGroupConfigOneSecondary(name, displayName, acc.Pi_secondary_workspace_id_1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMPIHostGroupExists(hostGroupRes),
+					resource.TestCheckResourceAttr(hostGroupRes, "pi_name", name),
+					resource.TestCheckResourceAttr(hostGroupRes, "pi_secondaries.#", "1"),
+				),
+			},
+			{
+				// Add a second secondary workspace.
+				Config: testAccCheckIBMPIHostGroupConfigTwoSecondaries(name, displayName, acc.Pi_secondary_workspace_id_1, acc.Pi_secondary_workspace_id_2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMPIHostGroupExists(hostGroupRes),
+					resource.TestCheckResourceAttr(hostGroupRes, "secondaries.#", "2"),
+				),
+			},
+			{
+				// Remove the first secondary, keeping only the second.
+				Config: testAccCheckIBMPIHostGroupConfigOneSecondary(name, displayName, acc.Pi_secondary_workspace_id_2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMPIHostGroupExists(hostGroupRes),
+					resource.TestCheckResourceAttr(hostGroupRes, "secondaries.#", "1"),
+				),
+			},
+			{
+				// Remove all secondaries.
+				Config: testAccCheckIBMPIHostGroupConfigBasic(name, displayName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMPIHostGroupExists(hostGroupRes),
+					resource.TestCheckResourceAttr(hostGroupRes, "secondaries.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIHostGroupConfigOneSecondary(name, displayName, secondaryWorkspaceID string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_host_group" "hostGroup" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_hosts {
+				display_name = "%[2]s"
+				sys_type = "s922"
+			}
+			pi_name = "%[3]s"
+			pi_secondaries {
+				name      = "%[3]s-secondary"
+				workspace = "%[4]s"
+			}
+		}
+	`, acc.Pi_cloud_instance_id, displayName, name, secondaryWorkspaceID)
+}
+
+func testAccCheckIBMPIHostGroupConfigTwoSecondaries(name, displayName, secondaryWorkspaceID1, secondaryWorkspaceID2 string) string {
+	return fmt.Sprintf(`
+		resource "ibm_pi_host_group" "hostGroup" {
+			pi_cloud_instance_id = "%[1]s"
+			pi_hosts {
+				display_name = "%[2]s"
+				sys_type = "s922"
+			}
+			pi_name = "%[3]s"
+			pi_secondaries {
+				name      = "%[3]s-secondary-1"
+				workspace = "%[4]s"
+			}
+			pi_secondaries {
+				name      = "%[3]s-secondary-2"
+				workspace = "%[5]s"
+			}
+		}
+	`, acc.Pi_cloud_instance_id, displayName, name, secondaryWorkspaceID1, secondaryWorkspaceID2)
+}
 func testAccCheckIBMPIHostGroupExists(n string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
```
Handle changes to pi_secondaries by computing the set diff between old and new values.
The HostGroupShareOp API treats Add and Remove as mutually exclusive, so additions and
removals are sent as separate API calls. Additionally, Remove only accepts a single
workspace ID, so each removal requires its own call.
```
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6672 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPIHostGroupUpdateSecondaries
--- PASS: TestAccIBMPIHostGroupUpdateSecondaries (239.03s)
PASS
...

```
