### PR TITLE
removed redundant checks to fix build on 1.26

### DIFF
--- a/ibm/service/atracker/resource_ibm_atracker_settings_test.go
+++ b/ibm/service/atracker/resource_ibm_atracker_settings_test.go
@@ -155,7 +155,7 @@ func testAccCheckIBMAtrackerSettingsDestroy(s *terraform.State) error {
 
 		if err == nil {
 			// Settings can never really truely be deleted (at least for MetaRegionPrimary) but the other fields will be cleared
-			if *settings.MetadataRegionPrimary == rs.Primary.ID && len(*&settings.DefaultTargets) == 0 && len(*&settings.DefaultTargets) == 0 {
+			if *settings.MetadataRegionPrimary == rs.Primary.ID && len(*&settings.DefaultTargets) == 0 {
 				return nil
 			}
 			return fmt.Errorf("[ERROR] Activity Tracker Settings still exists but other fields not deleted: %s, Targets: %v, PermittedRegions: %v", rs.Primary.ID, *&settings.DefaultTargets, *&settings.PermittedTargetRegions)

--- a/ibm/service/backuprecovery/resource_ibm_backup_recovery_perform_action_on_protection_group_run_request_test.go
+++ b/ibm/service/backuprecovery/resource_ibm_backup_recovery_perform_action_on_protection_group_run_request_test.go
@@ -90,7 +90,6 @@ func testPerformRunExists(n string) resource.TestCheckFunc {
 			if performActionOnProtectionGroupRunResponse != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ProtectionGroupID) == rs.Primary.ID &&
-				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults[0].ArchivalTaskID) != "" {
@@ -165,7 +164,6 @@ func testAccCheckProtectionRunPerformActionCancelled(n string) resource.TestChec
 			if performActionOnProtectionGroupRunResponse != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ProtectionGroupID) == groupId &&
-				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults[0].Status) == "Canceled" {

--- a/ibm/service/backuprecovery/resource_ibm_backup_recovery_protection_group_run_request_test.go
+++ b/ibm/service/backuprecovery/resource_ibm_backup_recovery_protection_group_run_request_test.go
@@ -91,7 +91,6 @@ func testRunExists(n string) resource.TestCheckFunc {
 			if performActionOnProtectionGroupRunResponse != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ProtectionGroupID) == rs.Primary.ID &&
-				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults[0].ArchivalTaskID) != "" {
@@ -193,7 +192,6 @@ func testAccCheckProtectionRunCancelled(n string) resource.TestCheckFunc {
 			if performActionOnProtectionGroupRunResponse != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ProtectionGroupID) == groupId &&
-				len(performActionOnProtectionGroupRunResponse.Runs) > 0 &&
 				performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo != nil &&
 				len(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults) > 0 &&
 				*(performActionOnProtectionGroupRunResponse.Runs[0].ArchivalInfo.ArchivalTargetResults[0].Status) == "Canceled" {

--- a/ibm/service/backuprecovery/resource_ibm_backup_recovery_update_protection_group_run_request_test.go
+++ b/ibm/service/backuprecovery/resource_ibm_backup_recovery_update_protection_group_run_request_test.go
@@ -73,7 +73,6 @@ func testUpdateRunExists(n string) resource.TestCheckFunc {
 			if GetProtectionGroupRunsResponse != nil &&
 				len(GetProtectionGroupRunsResponse.Runs) > 0 &&
 				*(GetProtectionGroupRunsResponse.Runs[0].ProtectionGroupID) == rs.Primary.ID &&
-				len(GetProtectionGroupRunsResponse.Runs) > 0 &&
 				GetProtectionGroupRunsResponse.Runs[0].ArchivalInfo != nil &&
 				len(GetProtectionGroupRunsResponse.Runs[0].ArchivalInfo.ArchivalTargetResults) > 0 &&
 				*(GetProtectionGroupRunsResponse.Runs[0].ArchivalInfo.ArchivalTargetResults[0].ArchivalTaskID) != "" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
