### PR TITLE
revert: Revert PR #6688 (Fix rules on sg and network acl)

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_network_acl_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl_rule.go
@@ -68,6 +68,7 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{isNetworkACLRuleTCP, isNetworkACLRuleUDP, isNetworkACLRuleICMP},
 				Description:   "The name of the network protocol",
 				ValidateFunc:  validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleProtocol),
@@ -75,7 +76,6 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 			isNetworkACLRuleICMPCode: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isNetworkACLRuleProtocol},
 				ConflictsWith: []string{isNetworkACLRuleICMP, isNetworkACLRuleUDP, isNetworkACLRuleTCP, isNetworkACLRulePortMin, isNetworkACLRulePortMax, isNetworkACLRuleSourcePortMax, isNetworkACLRuleSourcePortMin},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleICMPCode),
@@ -84,7 +84,6 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 			isNetworkACLRuleICMPType: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isNetworkACLRuleProtocol},
 				ConflictsWith: []string{isNetworkACLRuleICMP, isNetworkACLRuleUDP, isNetworkACLRuleTCP, isNetworkACLRulePortMin, isNetworkACLRulePortMax, isNetworkACLRuleSourcePortMax, isNetworkACLRuleSourcePortMin},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRuleICMPType),
@@ -176,22 +175,20 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 				MinItems:      0,
 				MaxItems:      1,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{isNetworkACLRuleTCP, isNetworkACLRuleUDP, isNetworkACLRuleProtocol},
+				ForceNew:      true,
 				Deprecated:    "icmp is deprecated, use 'protocol', 'code', and 'type' instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isNetworkACLRuleICMPCode: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleICMPCode),
 							Description:  "The ICMP traffic code to allow. Valid values from 0 to 255.",
 						},
 						isNetworkACLRuleICMPType: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleICMPType),
 							Description:  "The ICMP traffic type to allow. Valid values from 0 to 254.",
 						},
@@ -204,36 +201,36 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 				MinItems:      0,
 				MaxItems:      1,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{isNetworkACLRuleICMP, isNetworkACLRuleUDP, isNetworkACLRuleProtocol},
+				ForceNew:      true,
 				Deprecated:    "tcp is deprecated, use 'protocol', 'port_min', 'port_max', 'source_port_min', and 'source_port_max' instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isNetworkACLRulePortMax: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRulePortMax),
 							Description:  "The highest port in the range of ports to be matched",
 						},
 						isNetworkACLRulePortMin: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRulePortMin),
 							Description:  "The lowest port in the range of ports to be matched",
 						},
 						isNetworkACLRuleSourcePortMax: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleSourcePortMax),
 							Description:  "The highest port in the range of ports to be matched",
 						},
 						isNetworkACLRuleSourcePortMin: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleSourcePortMin),
 							Description:  "The lowest port in the range of ports to be matched",
 						},
@@ -246,36 +243,36 @@ func ResourceIBMISNetworkACLRule() *schema.Resource {
 				MinItems:      0,
 				MaxItems:      1,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{isNetworkACLRuleICMP, isNetworkACLRuleTCP, isNetworkACLRuleProtocol},
+				ForceNew:      true,
 				Deprecated:    "udp is deprecated, use 'protocol', 'port_min', 'port_max', 'source_port_min', and 'source_port_max' instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isNetworkACLRulePortMax: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRulePortMax),
 							Description:  "The highest port in the range of ports to be matched",
 						},
 						isNetworkACLRulePortMin: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRulePortMin),
 							Description:  "The lowest port in the range of ports to be matched",
 						},
 						isNetworkACLRuleSourcePortMax: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleSourcePortMax),
 							Description:  "The highest port in the range of ports to be matched",
 						},
 						isNetworkACLRuleSourcePortMin: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleSourcePortMin),
 							Description:  "The lowest port in the range of ports to be matched",
 						},
@@ -503,13 +500,12 @@ func nwaclRuleCreate(context context.Context, d *schema.ResourceData, meta inter
 		protocol = "icmp"
 		ruleTemplate.Protocol = &protocol
 		if !isNil(icmp[0]) {
-			icmpTypePath := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPType)
-			icmpCodePath := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPCode)
-			if val, ok := d.GetOk(icmpTypePath); ok {
+			icmpval := icmp[0].(map[string]interface{})
+			if val, ok := icmpval[isNetworkACLRuleICMPType]; ok {
 				icmptype = int64(val.(int))
 				ruleTemplate.Type = &icmptype
 			}
-			if val, ok := d.GetOk(icmpCodePath); ok {
+			if val, ok := icmpval[isNetworkACLRuleICMPCode]; ok {
 				icmpcode = int64(val.(int))
 				ruleTemplate.Code = &icmpcode
 			}
@@ -529,37 +525,23 @@ func nwaclRuleCreate(context context.Context, d *schema.ResourceData, meta inter
 	if len(tcp) > 0 {
 		protocol = "tcp"
 		ruleTemplate.Protocol = &protocol
-		if !isNil(tcp[0]) {
-			tcpval := tcp[0].(map[string]interface{})
-			if val, ok := tcpval[isNetworkACLRulePortMin]; ok {
-				minport = int64(val.(int))
-			}
-			if val, ok := tcpval[isNetworkACLRulePortMax]; ok {
-				maxport = int64(val.(int))
-			}
-			if val, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
-				sourceminport = int64(val.(int))
-			}
-			if val, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
-				sourcemaxport = int64(val.(int))
-			}
+		tcpval := tcp[0].(map[string]interface{})
+		if val, ok := tcpval[isNetworkACLRulePortMin]; ok {
+			minport = int64(val.(int))
+			ruleTemplate.DestinationPortMin = &minport
 		}
-		if minport <= 0 {
-			minport = 1
+		if val, ok := tcpval[isNetworkACLRulePortMax]; ok {
+			maxport = int64(val.(int))
+			ruleTemplate.DestinationPortMax = &maxport
 		}
-		if maxport <= 0 {
-			maxport = 65535
+		if val, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
+			sourceminport = int64(val.(int))
+			ruleTemplate.SourcePortMin = &sourceminport
 		}
-		if sourceminport <= 0 {
-			sourceminport = 1
+		if val, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
+			sourcemaxport = int64(val.(int))
+			ruleTemplate.SourcePortMax = &sourcemaxport
 		}
-		if sourcemaxport <= 0 {
-			sourcemaxport = 65535
-		}
-		ruleTemplate.DestinationPortMin = &minport
-		ruleTemplate.DestinationPortMax = &maxport
-		ruleTemplate.SourcePortMin = &sourceminport
-		ruleTemplate.SourcePortMax = &sourcemaxport
 	} else if protocol == "tcp" {
 		ruleTemplate.Protocol = &protocol
 		if val, ok := d.GetOk(isNetworkACLRulePortMin); ok {
@@ -596,37 +578,23 @@ func nwaclRuleCreate(context context.Context, d *schema.ResourceData, meta inter
 	if len(udp) > 0 {
 		protocol = "udp"
 		ruleTemplate.Protocol = &protocol
-		if !isNil(udp[0]) {
-			udpval := udp[0].(map[string]interface{})
-			if val, ok := udpval[isNetworkACLRulePortMin]; ok {
-				minport = int64(val.(int))
-			}
-			if val, ok := udpval[isNetworkACLRulePortMax]; ok {
-				maxport = int64(val.(int))
-			}
-			if val, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
-				sourceminport = int64(val.(int))
-			}
-			if val, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
-				sourcemaxport = int64(val.(int))
-			}
+		udpval := udp[0].(map[string]interface{})
+		if val, ok := udpval[isNetworkACLRulePortMin]; ok {
+			minport = int64(val.(int))
+			ruleTemplate.DestinationPortMin = &minport
 		}
-		if minport <= 0 {
-			minport = 1
+		if val, ok := udpval[isNetworkACLRulePortMax]; ok {
+			maxport = int64(val.(int))
+			ruleTemplate.DestinationPortMax = &maxport
 		}
-		if maxport <= 0 {
-			maxport = 65535
+		if val, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
+			sourceminport = int64(val.(int))
+			ruleTemplate.SourcePortMin = &sourceminport
 		}
-		if sourceminport <= 0 {
-			sourceminport = 1
+		if val, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
+			sourcemaxport = int64(val.(int))
+			ruleTemplate.SourcePortMax = &sourcemaxport
 		}
-		if sourcemaxport <= 0 {
-			sourcemaxport = 65535
-		}
-		ruleTemplate.DestinationPortMin = &minport
-		ruleTemplate.DestinationPortMax = &maxport
-		ruleTemplate.SourcePortMin = &sourceminport
-		ruleTemplate.SourcePortMax = &sourcemaxport
 	} else if protocol == "udp" {
 		ruleTemplate.Protocol = &protocol
 		if val, ok := d.GetOk(isNetworkACLRulePortMin); ok {
@@ -765,18 +733,7 @@ func nwaclRuleGet(context context.Context, d *schema.ResourceData, meta interfac
 			}
 			d.Set(isNetworkACLRuleTCP, make([]map[string]int, 0, 0))
 			d.Set(isNetworkACLRuleUDP, make([]map[string]int, 0, 0))
-			if networkACLRule.Type != nil {
-				if err = d.Set(isNetworkACLRuleICMPType, int(*networkACLRule.Type)); err != nil {
-					err = fmt.Errorf("Error setting type: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-type").GetDiag()
-				}
-			}
-			if networkACLRule.Code != nil {
-				if err = d.Set(isNetworkACLRuleICMPCode, int(*networkACLRule.Code)); err != nil {
-					err = fmt.Errorf("Error setting code: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-code").GetDiag()
-				}
-			}
+			// To determine to set values only for old config and skip for new config as it sets '0' for nil values
 			icmpList := d.Get("icmp").([]interface{})
 			if len(icmpList) > 0 {
 				icmp := make([]map[string]int, 1, 1)
@@ -837,22 +794,7 @@ func nwaclRuleGet(context context.Context, d *schema.ResourceData, meta interfac
 				err = fmt.Errorf("Error setting direction: %s", err)
 				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-direction").GetDiag()
 			}
-			if err = d.Set(isNetworkACLRuleSourcePortMax, checkNetworkACLNil(networkACLRule.SourcePortMax)); err != nil {
-				err = fmt.Errorf("Error setting source port max: %s", err)
-				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-source-port-max").GetDiag()
-			}
-			if err = d.Set(isNetworkACLRuleSourcePortMin, checkNetworkACLNil(networkACLRule.SourcePortMin)); err != nil {
-				err = fmt.Errorf("Error setting source port min: %s", err)
-				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-source-port-min").GetDiag()
-			}
-			if err = d.Set(isNetworkACLRulePortMax, checkNetworkACLNil(networkACLRule.DestinationPortMax)); err != nil {
-				err = fmt.Errorf("Error setting port max: %s", err)
-				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-port-max").GetDiag()
-			}
-			if err = d.Set(isNetworkACLRulePortMin, checkNetworkACLNil(networkACLRule.DestinationPortMin)); err != nil {
-				err = fmt.Errorf("Error setting port min: %s", err)
-				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-port-min").GetDiag()
-			}
+			// To determine to set values for old or new config. New config is set as it has default values
 			tcpList := d.Get("tcp").([]interface{})
 			udpList := d.Get("udp").([]interface{})
 			if len(tcpList) > 0 || len(udpList) > 0 {
@@ -885,6 +827,11 @@ func nwaclRuleGet(context context.Context, d *schema.ResourceData, meta interfac
 						return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_network_acl_rule", "read", "set-udp").GetDiag()
 					}
 				}
+			} else {
+				d.Set(isNetworkACLRuleSourcePortMax, checkNetworkACLNil(networkACLRule.SourcePortMax))
+				d.Set(isNetworkACLRuleSourcePortMin, checkNetworkACLNil(networkACLRule.SourcePortMin))
+				d.Set(isNetworkACLRulePortMax, checkNetworkACLNil(networkACLRule.DestinationPortMax))
+				d.Set(isNetworkACLRulePortMin, checkNetworkACLNil(networkACLRule.DestinationPortMin))
 			}
 		}
 	case "*vpcv1.NetworkACLRuleNetworkACLRuleProtocolAny":
@@ -1091,237 +1038,6 @@ func resourceIBMISNetworkACLRuleUpdate(context context.Context, d *schema.Resour
 	return resourceIBMISNetworkACLRuleRead(context, d, meta)
 }
 
-// buildNetworkACLRuleUpdatePatch builds the update patch for network ACL rule
-// This function properly handles Computed attributes by using d.HasChange() to detect changes
-// and d.GetOk() to retrieve new values from the configuration
-func buildNetworkACLRuleUpdatePatch(d *schema.ResourceData) (*vpcv1.NetworkACLRulePatch, bool, bool, error) {
-	patchModel := &vpcv1.NetworkACLRulePatch{}
-	hasChanged := false
-	aclRuleBeforeNull := false
-
-	// Action
-	if d.HasChange(isNetworkACLRuleAction) {
-		if actionVar, ok := d.GetOk(isNetworkACLRuleAction); ok {
-			action := actionVar.(string)
-			patchModel.Action = &action
-			hasChanged = true
-		}
-	}
-
-	// Before
-	if d.HasChange(isNwACLRuleBefore) {
-		beforeVar := d.Get(isNwACLRuleBefore).(string)
-		if beforeVar == "null" {
-			aclRuleBeforeNull = true
-		} else if beforeVar != "" {
-			patchModel.Before = &vpcv1.NetworkACLRuleBeforePatchNetworkACLRuleIdentityByID{
-				ID: &beforeVar,
-			}
-		}
-		hasChanged = true
-	}
-
-	// Name
-	if d.HasChange(isNetworkACLRuleName) {
-		if nameVar, ok := d.GetOk(isNetworkACLRuleName); ok {
-			nameStr := nameVar.(string)
-			patchModel.Name = &nameStr
-			hasChanged = true
-		}
-	}
-
-	// Direction
-	if d.HasChange(isNetworkACLRuleDirection) {
-		if directionVar, ok := d.GetOk(isNetworkACLRuleDirection); ok {
-			directionStr := directionVar.(string)
-			patchModel.Direction = &directionStr
-			hasChanged = true
-		}
-	}
-
-	// Destination
-	if d.HasChange(isNetworkACLRuleDestination) {
-		if destinationVar, ok := d.GetOk(isNetworkACLRuleDestination); ok {
-			destination := destinationVar.(string)
-			patchModel.Destination = &destination
-			hasChanged = true
-		}
-	}
-
-	// ICMP block (deprecated)
-	if d.HasChange(isNetworkACLRuleICMP) {
-		icmpCode := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPCode)
-		icmpType := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPType)
-		if d.HasChange(icmpCode) {
-			if codeVar, ok := d.GetOk(icmpCode); ok {
-				code := int64(codeVar.(int))
-				patchModel.Code = &code
-				hasChanged = true
-			}
-		}
-		if d.HasChange(icmpType) {
-			if typeVar, ok := d.GetOk(icmpType); ok {
-				typeInt := int64(typeVar.(int))
-				patchModel.Type = &typeInt
-				hasChanged = true
-			}
-		}
-	}
-
-	// ICMP Code (new top-level attribute)
-	if d.HasChange(isNetworkACLRuleICMPCode) {
-		if codeVar, ok := d.GetOk(isNetworkACLRuleICMPCode); ok {
-			code := int64(codeVar.(int))
-			patchModel.Code = &code
-			hasChanged = true
-		}
-	}
-
-	// ICMP Type (new top-level attribute)
-	if d.HasChange(isNetworkACLRuleICMPType) {
-		if typeVar, ok := d.GetOk(isNetworkACLRuleICMPType); ok {
-			typeInt := int64(typeVar.(int))
-			patchModel.Type = &typeInt
-			hasChanged = true
-		}
-	}
-
-	// TCP block (deprecated)
-	if d.HasChange(isNetworkACLRuleTCP) {
-		// Use GetOk to get NEW values from configuration, not old state values
-		if tcpInterface, ok := d.GetOk(isNetworkACLRuleTCP); ok {
-			tcp := tcpInterface.([]interface{})
-			if len(tcp) > 0 {
-				tcpval := tcp[0].(map[string]interface{})
-				max := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRulePortMax)
-				min := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRulePortMin)
-				maxSource := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRuleSourcePortMax)
-				minSource := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRuleSourcePortMin)
-
-				if d.HasChange(max) {
-					if destinationVar, ok := tcpval[isNetworkACLRulePortMax]; ok {
-						destination := int64(destinationVar.(int))
-						patchModel.DestinationPortMax = &destination
-						hasChanged = true
-					}
-				}
-				if d.HasChange(min) {
-					if destinationVar, ok := tcpval[isNetworkACLRulePortMin]; ok {
-						destination := int64(destinationVar.(int))
-						patchModel.DestinationPortMin = &destination
-						hasChanged = true
-					}
-				}
-				if d.HasChange(maxSource) {
-					if sourceVar, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
-						source := int64(sourceVar.(int))
-						patchModel.SourcePortMax = &source
-						hasChanged = true
-					}
-				}
-				if d.HasChange(minSource) {
-					if sourceVar, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
-						source := int64(sourceVar.(int))
-						patchModel.SourcePortMin = &source
-						hasChanged = true
-					}
-				}
-			}
-		}
-	}
-
-	// Port Max (new top-level attribute) - Computed attribute, use HasChange + GetOk
-	if d.HasChange(isNetworkACLRulePortMax) {
-		if destinationVar, ok := d.GetOk(isNetworkACLRulePortMax); ok {
-			destination := int64(destinationVar.(int))
-			patchModel.DestinationPortMax = &destination
-			hasChanged = true
-		}
-	}
-
-	// Port Min (new top-level attribute) - Computed attribute, use HasChange + GetOk
-	if d.HasChange(isNetworkACLRulePortMin) {
-		if destinationVar, ok := d.GetOk(isNetworkACLRulePortMin); ok {
-			destination := int64(destinationVar.(int))
-			patchModel.DestinationPortMin = &destination
-			hasChanged = true
-		}
-	}
-
-	// Source Port Max (new top-level attribute) - Computed attribute, use HasChange + GetOk
-	if d.HasChange(isNetworkACLRuleSourcePortMax) {
-		if sourceVar, ok := d.GetOk(isNetworkACLRuleSourcePortMax); ok {
-			source := int64(sourceVar.(int))
-			patchModel.SourcePortMax = &source
-			hasChanged = true
-		}
-	}
-
-	// Source Port Min (new top-level attribute) - Computed attribute, use HasChange + GetOk
-	if d.HasChange(isNetworkACLRuleSourcePortMin) {
-		if sourceVar, ok := d.GetOk(isNetworkACLRuleSourcePortMin); ok {
-			source := int64(sourceVar.(int))
-			patchModel.SourcePortMin = &source
-			hasChanged = true
-		}
-	}
-
-	// UDP block (deprecated)
-	if d.HasChange(isNetworkACLRuleUDP) {
-		// Use GetOk to get NEW values from configuration, not old state values
-		if udpInterface, ok := d.GetOk(isNetworkACLRuleUDP); ok {
-			udp := udpInterface.([]interface{})
-			if len(udp) > 0 {
-				udpval := udp[0].(map[string]interface{})
-				max := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRulePortMax)
-				min := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRulePortMin)
-				maxSource := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRuleSourcePortMax)
-				minSource := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRuleSourcePortMin)
-
-				if d.HasChange(max) {
-					if destinationVar, ok := udpval[isNetworkACLRulePortMax]; ok {
-						destination := int64(destinationVar.(int))
-						patchModel.DestinationPortMax = &destination
-						hasChanged = true
-					}
-				}
-				if d.HasChange(min) {
-					if destinationVar, ok := udpval[isNetworkACLRulePortMin]; ok {
-						destination := int64(destinationVar.(int))
-						patchModel.DestinationPortMin = &destination
-						hasChanged = true
-					}
-				}
-				if d.HasChange(maxSource) {
-					if sourceVar, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
-						source := int64(sourceVar.(int))
-						patchModel.SourcePortMax = &source
-						hasChanged = true
-					}
-				}
-				if d.HasChange(minSource) {
-					if sourceVar, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
-						source := int64(sourceVar.(int))
-						patchModel.SourcePortMin = &source
-						hasChanged = true
-					}
-				}
-			}
-		}
-	}
-
-	// Source
-	if d.HasChange(isNetworkACLRuleSource) {
-		if sourceVar, ok := d.GetOk(isNetworkACLRuleSource); ok {
-			source := sourceVar.(string)
-			patchModel.Source = &source
-			hasChanged = true
-		}
-	}
-
-	return patchModel, hasChanged, aclRuleBeforeNull, nil
-}
-
 func nwaclRuleUpdate(context context.Context, d *schema.ResourceData, meta interface{}, id, nwACLId string) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
@@ -1329,33 +1045,210 @@ func nwaclRuleUpdate(context context.Context, d *schema.ResourceData, meta inter
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
+	updateNetworkACLRuleOptions := &vpcv1.UpdateNetworkACLRuleOptions{
+		NetworkACLID: &nwACLId,
+		ID:           &id,
+	}
+	updateNetworkACLOptionsPatchModel := &vpcv1.NetworkACLRulePatch{}
 
-	// Build the update patch using the dedicated function
-	patchModel, hasChanged, aclRuleBeforeNull, err := buildNetworkACLRuleUpdatePatch(d)
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("buildNetworkACLRuleUpdatePatch failed: %s", err.Error()), "ibm_is_network_acl_rule", "update")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+	hasChanged := false
+
+	if d.HasChange(isNetworkACLRuleAction) {
+		hasChanged = true
+		if actionVar, ok := d.GetOk(isNetworkACLRuleAction); ok {
+			action := actionVar.(string)
+			updateNetworkACLOptionsPatchModel.Action = &action
+		}
+	}
+	aclRuleBeforeNull := false
+	if d.HasChange(isNwACLRuleBefore) {
+		hasChanged = true
+		beforeVar := d.Get(isNwACLRuleBefore).(string)
+		if beforeVar == "null" {
+			aclRuleBeforeNull = true
+		} else if beforeVar != "" {
+			updateNetworkACLOptionsPatchModel.Before = &vpcv1.NetworkACLRuleBeforePatchNetworkACLRuleIdentityByID{
+				ID: &beforeVar,
+			}
+		}
+	}
+
+	if d.HasChange(isNetworkACLRuleName) {
+		hasChanged = true
+		if nameVar, ok := d.GetOk(isNetworkACLRuleName); ok {
+			nameStr := nameVar.(string)
+			updateNetworkACLOptionsPatchModel.Name = &nameStr
+		}
+	}
+	if d.HasChange(isNetworkACLRuleDirection) {
+		hasChanged = true
+		if directionVar, ok := d.GetOk(isNetworkACLRuleDirection); ok {
+			directionStr := directionVar.(string)
+			updateNetworkACLOptionsPatchModel.Direction = &directionStr
+		}
+	}
+	if d.HasChange(isNetworkACLRuleDestination) {
+		hasChanged = true
+		if destinationVar, ok := d.GetOk(isNetworkACLRuleDestination); ok {
+			destination := destinationVar.(string)
+			updateNetworkACLOptionsPatchModel.Destination = &destination
+		}
+	}
+	if d.HasChange(isNetworkACLRuleICMP) {
+		icmpCode := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPCode)
+		icmpType := fmt.Sprint(isNetworkACLRuleICMP, ".0.", isNetworkACLRuleICMPType)
+		if d.HasChange(icmpCode) {
+			hasChanged = true
+			if codeVar, ok := d.GetOk(icmpCode); ok {
+				code := int64(codeVar.(int))
+				updateNetworkACLOptionsPatchModel.Code = &code
+			}
+		}
+		if d.HasChange(icmpType) {
+			hasChanged = true
+			if typeVar, ok := d.GetOk(icmpType); ok {
+				typeInt := int64(typeVar.(int))
+				updateNetworkACLOptionsPatchModel.Type = &typeInt
+			}
+		}
+	}
+
+	if d.HasChange(isNetworkACLRuleICMPCode) {
+		hasChanged = true
+		if codeVar, ok := d.GetOk(isNetworkACLRuleICMPCode); ok {
+			code := int64(codeVar.(int))
+			updateNetworkACLOptionsPatchModel.Code = &code
+		}
+	}
+	if d.HasChange(isNetworkACLRuleICMPType) {
+		hasChanged = true
+		if typeVar, ok := d.GetOk(isNetworkACLRuleICMPType); ok {
+			typeInt := int64(typeVar.(int))
+			updateNetworkACLOptionsPatchModel.Type = &typeInt
+		}
+	}
+
+	if d.HasChange(isNetworkACLRuleTCP) {
+		tcp := d.Get(isNetworkACLRuleTCP).([]interface{})
+		tcpval := tcp[0].(map[string]interface{})
+		max := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRulePortMax)
+		min := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRulePortMin)
+		maxSource := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRuleSourcePortMax)
+		minSource := fmt.Sprint(isNetworkACLRuleTCP, ".0.", isNetworkACLRuleSourcePortMin)
+		if d.HasChange(max) {
+			hasChanged = true
+			if destinationVar, ok := tcpval[isNetworkACLRulePortMax]; ok {
+				destination := int64(destinationVar.(int))
+				updateNetworkACLOptionsPatchModel.DestinationPortMax = &destination
+			}
+		}
+		if d.HasChange(min) {
+			hasChanged = true
+			if destinationVar, ok := tcpval[isNetworkACLRulePortMin]; ok {
+				destination := int64(destinationVar.(int))
+				updateNetworkACLOptionsPatchModel.DestinationPortMin = &destination
+			}
+		}
+		if d.HasChange(maxSource) {
+			hasChanged = true
+			if sourceVar, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
+				source := int64(sourceVar.(int))
+				updateNetworkACLOptionsPatchModel.SourcePortMax = &source
+			}
+		}
+		if d.HasChange(minSource) {
+			hasChanged = true
+			if sourceVar, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
+				source := int64(sourceVar.(int))
+				updateNetworkACLOptionsPatchModel.SourcePortMin = &source
+			}
+		}
+	}
+	if d.HasChange(isNetworkACLRulePortMax) {
+		hasChanged = true
+		if destinationVar, ok := d.GetOk(isNetworkACLRulePortMax); ok {
+			destination := int64(destinationVar.(int))
+			updateNetworkACLOptionsPatchModel.DestinationPortMax = &destination
+		}
+	}
+	if d.HasChange(isNetworkACLRulePortMin) {
+		hasChanged = true
+		if destinationVar, ok := d.GetOk(isNetworkACLRulePortMin); ok {
+			destination := int64(destinationVar.(int))
+			updateNetworkACLOptionsPatchModel.DestinationPortMin = &destination
+		}
+	}
+	if d.HasChange(isNetworkACLRuleSourcePortMax) {
+		hasChanged = true
+		if sourceVar, ok := d.GetOk(isNetworkACLRuleSourcePortMax); ok {
+			source := int64(sourceVar.(int))
+			updateNetworkACLOptionsPatchModel.SourcePortMax = &source
+		}
+	}
+	if d.HasChange(isNetworkACLRuleSourcePortMin) {
+		hasChanged = true
+		if sourceVar, ok := d.GetOk(isNetworkACLRuleSourcePortMin); ok {
+			source := int64(sourceVar.(int))
+			updateNetworkACLOptionsPatchModel.SourcePortMin = &source
+		}
+	}
+	if d.HasChange(isNetworkACLRuleUDP) {
+		udp := d.Get(isNetworkACLRuleUDP).([]interface{})
+		udpval := udp[0].(map[string]interface{})
+		max := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRulePortMax)
+		min := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRulePortMin)
+		maxSource := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRuleSourcePortMax)
+		minSource := fmt.Sprint(isNetworkACLRuleUDP, ".0.", isNetworkACLRuleSourcePortMin)
+
+		if d.HasChange(max) {
+			hasChanged = true
+			if destinationVar, ok := udpval[isNetworkACLRulePortMax]; ok {
+				destination := int64(destinationVar.(int))
+				updateNetworkACLOptionsPatchModel.DestinationPortMax = &destination
+			}
+		}
+		if d.HasChange(min) {
+			hasChanged = true
+			if destinationVar, ok := udpval[isNetworkACLRulePortMin]; ok {
+				destination := int64(destinationVar.(int))
+				updateNetworkACLOptionsPatchModel.DestinationPortMin = &destination
+			}
+		}
+		if d.HasChange(maxSource) {
+			hasChanged = true
+			if sourceVar, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
+				source := int64(sourceVar.(int))
+				updateNetworkACLOptionsPatchModel.SourcePortMax = &source
+			}
+		}
+		if d.HasChange(minSource) {
+			hasChanged = true
+			if sourceVar, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
+				source := int64(sourceVar.(int))
+				updateNetworkACLOptionsPatchModel.SourcePortMin = &source
+			}
+		}
+	}
+
+	if d.HasChange(isNetworkACLRuleSource) {
+		hasChanged = true
+		if sourceVar, ok := d.GetOk(isNetworkACLRuleSource); ok {
+			source := sourceVar.(string)
+			updateNetworkACLOptionsPatchModel.Source = &source
+		}
 	}
 
 	if hasChanged {
-		updateNetworkACLOptionsPatch, err := patchModel.AsPatch()
+		updateNetworkACLOptionsPatch, err := updateNetworkACLOptionsPatchModel.AsPatch()
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("patchModel.AsPatch() failed: %s", err.Error()), "ibm_is_network_acl_rule", "update")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("updateNetworkACLOptionsPatchModel.AsPatch() failed: %s", err.Error()), "ibm_is_network_acl_rule", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
-
 		if aclRuleBeforeNull {
 			updateNetworkACLOptionsPatch["before"] = nil
 		}
-
-		updateNetworkACLRuleOptions := &vpcv1.UpdateNetworkACLRuleOptions{
-			NetworkACLID:        &nwACLId,
-			ID:                  &id,
-			NetworkACLRulePatch: updateNetworkACLOptionsPatch,
-		}
-
+		updateNetworkACLRuleOptions.NetworkACLRulePatch = updateNetworkACLOptionsPatch
 		_, _, err = sess.UpdateNetworkACLRuleWithContext(context, updateNetworkACLRuleOptions)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateNetworkACLRuleWithContext failed: %s", err.Error()), "ibm_is_network_acl_rule", "update")

--- a/ibm/service/vpc/resource_ibm_is_networkacls.go
+++ b/ibm/service/vpc/resource_ibm_is_networkacls.go
@@ -201,21 +201,18 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 						isNetworkACLRuleICMPCode: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl_rule", isNetworkACLRuleICMPCode),
 							Description:  "The ICMP traffic code to allow. Valid values from 0 to 255.",
 						},
 						isNetworkACLRuleICMPType: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRuleICMPType),
 							Description:  "The ICMP traffic type to allow. Valid values from 0 to 254.",
 						},
 						isNetworkACLRulePortMax: {
 							Type:             schema.TypeInt,
 							Optional:         true,
-							Computed:         true,
 							DiffSuppressFunc: suppressNullValues,
 							ValidateFunc:     validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRulePortMax),
 							Description:      "The highest port in the range of ports to be matched",
@@ -223,7 +220,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 						isNetworkACLRulePortMin: {
 							Type:             schema.TypeInt,
 							Optional:         true,
-							Computed:         true,
 							DiffSuppressFunc: suppressNullValues,
 							ValidateFunc:     validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRulePortMin),
 							Description:      "The lowest port in the range of ports to be matched",
@@ -231,7 +227,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 						isNetworkACLRuleSourcePortMax: {
 							Type:             schema.TypeInt,
 							Optional:         true,
-							Computed:         true,
 							DiffSuppressFunc: suppressNullValues,
 							ValidateFunc:     validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRuleSourcePortMax),
 							Description:      "The highest port in the range of ports to be matched",
@@ -239,7 +234,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 						isNetworkACLRuleSourcePortMin: {
 							Type:             schema.TypeInt,
 							Optional:         true,
-							Computed:         true,
 							DiffSuppressFunc: suppressNullValues,
 							ValidateFunc:     validate.InvokeValidator("ibm_is_network_acl", isNetworkACLRuleSourcePortMin),
 							Description:      "The lowest port in the range of ports to be matched",
@@ -249,7 +243,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 							MinItems:   0,
 							MaxItems:   1,
 							Optional:   true,
-							Computed:   true,
 							Deprecated: "icmp is deprecated, use 'protocol', 'code', and 'type' instead.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -272,7 +265,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 							MinItems:   0,
 							MaxItems:   1,
 							Optional:   true,
-							Computed:   true,
 							Deprecated: "tcp is deprecated, use 'protocol', 'port_min', 'port_max', 'source_port_min', and 'source_port_max' instead.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -309,7 +301,6 @@ func ResourceIBMISNetworkACL() *schema.Resource {
 							MinItems:   0,
 							MaxItems:   1,
 							Optional:   true,
-							Computed:   true,
 							Deprecated: "udp is deprecated, use 'protocol', 'port_min', 'port_max', 'source_port_min', and 'source_port_max' instead.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -691,39 +682,27 @@ func nwaclGet(context context.Context, d *schema.ResourceData, meta interface{},
 					rule[isNetworkACLRuleSource] = *rulex.Source
 					rule[isNetworkACLRuleDestination] = *rulex.Destination
 					rule[isNetworkACLRuleDirection] = *rulex.Direction
-
-					// Always populate new design fields
-					if rulex.Code != nil {
-						rule[isNetworkACLRuleICMPCode] = int(*rulex.Code)
-					}
-					if rulex.Type != nil {
-						rule[isNetworkACLRuleICMPType] = int(*rulex.Type)
-					}
-
-					// Only populate deprecated icmp block if user was using old-style
-					icmpPath := fmt.Sprintf("rules.%d.icmp", index)
-					usingDeprecatedIcmp := false
-					if _, ok := d.GetOk(icmpPath); ok {
-						usingDeprecatedIcmp = true
-					}
-					if usingDeprecatedIcmp {
-						icmpProtocol := map[string]int{}
+					val := fmt.Sprintf("rules.%d.icmp", index)
+					icmpList := d.Get(val).([]interface{})
+					if len(icmpList) > 0 {
+						rule[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
+						rule[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
+						icmp := make([]map[string]int, 1, 1)
+						if rulex.Code != nil && rulex.Type != nil {
+							icmp[0] = map[string]int{
+								isNetworkACLRuleICMPCode: int(*rulex.Code),
+								isNetworkACLRuleICMPType: int(*rulex.Type),
+							}
+						}
+						rule[isNetworkACLRuleICMP] = icmp
+					} else {
 						if rulex.Code != nil {
-							icmpProtocol[isNetworkACLRuleICMPCode] = int(*rulex.Code)
+							rule[isNetworkACLRuleICMPCode] = int(*rulex.Code)
 						}
 						if rulex.Type != nil {
-							icmpProtocol[isNetworkACLRuleICMPType] = int(*rulex.Type)
+							rule[isNetworkACLRuleICMPType] = int(*rulex.Type)
 						}
-						protocolList := make([]map[string]int, 1, 1)
-						if len(icmpProtocol) > 0 {
-							protocolList[0] = icmpProtocol
-						}
-						rule[isNetworkACLRuleICMP] = protocolList
-					} else {
-						rule[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
 					}
-					rule[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
-					rule[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
 				}
 			case "*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolTcpudp":
 				{
@@ -736,59 +715,50 @@ func nwaclGet(context context.Context, d *schema.ResourceData, meta interface{},
 					rule[isNetworkACLRuleSource] = *rulex.Source
 					rule[isNetworkACLRuleDestination] = *rulex.Destination
 					rule[isNetworkACLRuleDirection] = *rulex.Direction
+					var tcpList, udpList []interface{}
 
-					// Always populate new design fields
-					rule[isNetworkACLRuleSourcePortMax] = checkNetworkACLNil(rulex.SourcePortMax)
-					rule[isNetworkACLRuleSourcePortMin] = checkNetworkACLNil(rulex.SourcePortMin)
-					rule[isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
-					rule[isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
-
-					// Only populate deprecated tcp/udp blocks if user was using old-style
-					tcpPath := fmt.Sprintf("rules.%d.tcp", index)
-					udpPath := fmt.Sprintf("rules.%d.udp", index)
-					usingDeprecatedBlock := false
-					if v, ok := d.GetOk(tcpPath); ok {
-						if tcpList, ok := v.([]interface{}); ok && len(tcpList) > 0 {
-							usingDeprecatedBlock = true
-						}
-					}
-					if v, ok := d.GetOk(udpPath); ok {
-						if udpList, ok := v.([]interface{}); ok && len(udpList) > 0 {
-							usingDeprecatedBlock = true
-						}
+					tcp := fmt.Sprintf("rules.%d.tcp", index)
+					udp := fmt.Sprintf("rules.%d.udp", index)
+					if v, ok := d.GetOk(tcp); ok {
+						tcpList = v.([]interface{})
+					} else {
+						tcpList = []interface{}{}
 					}
 
-					if usingDeprecatedBlock {
-						tcpudpProtocol := map[string]int{}
-						if rulex.SourcePortMax != nil {
-							tcpudpProtocol[isNetworkACLRuleSourcePortMax] = checkNetworkACLNil(rulex.SourcePortMax)
-						}
-						if rulex.SourcePortMin != nil {
-							tcpudpProtocol[isNetworkACLRuleSourcePortMin] = checkNetworkACLNil(rulex.SourcePortMin)
-						}
-						if rulex.DestinationPortMax != nil {
-							tcpudpProtocol[isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
-						}
-						if rulex.DestinationPortMin != nil {
-							tcpudpProtocol[isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
-						}
-						protocolList := make([]map[string]int, 0)
-						if len(tcpudpProtocol) > 0 {
-							protocolList = append(protocolList, tcpudpProtocol)
-						}
+					if v, ok := d.GetOk(udp); ok {
+						udpList = v.([]interface{})
+					} else {
+						udpList = []interface{}{}
+					}
+					if len(tcpList) > 0 || len(udpList) > 0 {
 						if *rulex.Protocol == "tcp" {
 							rule[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
 							rule[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
-							rule[isNetworkACLRuleTCP] = protocolList
+							tcp := make([]map[string]int, 1, 1)
+							tcp[0] = map[string]int{
+								isNetworkACLRuleSourcePortMax: checkNetworkACLNil(rulex.SourcePortMax),
+								isNetworkACLRuleSourcePortMin: checkNetworkACLNil(rulex.SourcePortMin),
+							}
+							tcp[0][isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
+							tcp[0][isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
+							rule[isNetworkACLRuleTCP] = tcp
 						} else if *rulex.Protocol == "udp" {
 							rule[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
 							rule[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
-							rule[isNetworkACLRuleUDP] = protocolList
+							udp := make([]map[string]int, 1, 1)
+							udp[0] = map[string]int{
+								isNetworkACLRuleSourcePortMax: checkNetworkACLNil(rulex.SourcePortMax),
+								isNetworkACLRuleSourcePortMin: checkNetworkACLNil(rulex.SourcePortMin),
+							}
+							udp[0][isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
+							udp[0][isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
+							rule[isNetworkACLRuleUDP] = udp
 						}
 					} else {
-						rule[isNetworkACLRuleICMP] = make([]map[string]int, 0, 0)
-						rule[isNetworkACLRuleTCP] = make([]map[string]int, 0, 0)
-						rule[isNetworkACLRuleUDP] = make([]map[string]int, 0, 0)
+						rule[isNetworkACLRuleSourcePortMax] = checkNetworkACLNil(rulex.SourcePortMax)
+						rule[isNetworkACLRuleSourcePortMin] = checkNetworkACLNil(rulex.SourcePortMin)
+						rule[isNetworkACLRulePortMax] = checkNetworkACLNil(rulex.DestinationPortMax)
+						rule[isNetworkACLRulePortMin] = checkNetworkACLNil(rulex.DestinationPortMin)
 					}
 				}
 			case "*vpcv1.NetworkACLRuleItemNetworkACLRuleProtocolAny":
@@ -1198,39 +1168,16 @@ func createInlineRules(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid stri
 			}
 		}
 
-		// Detect if user is using new-style top-level fields vs deprecated blocks
-		// by checking which set of fields has actually changed
-		useTopLevelPorts := false
-		if protocol == "tcp" || protocol == "udp" {
-			portMinPath := fmt.Sprintf("rules.%d.port_min", i)
-			portMaxPath := fmt.Sprintf("rules.%d.port_max", i)
-			srcPortMinPath := fmt.Sprintf("rules.%d.source_port_min", i)
-			srcPortMaxPath := fmt.Sprintf("rules.%d.source_port_max", i)
-			if d.HasChange(portMinPath) || d.HasChange(portMaxPath) ||
-				d.HasChange(srcPortMinPath) || d.HasChange(srcPortMaxPath) {
-				useTopLevelPorts = true
-			}
-		}
-		useTopLevelIcmp := false
-		if protocol == "icmp" {
-			icmpTypePath := fmt.Sprintf("rules.%d.type", i)
-			icmpCodePath := fmt.Sprintf("rules.%d.code", i)
-			if d.HasChange(icmpTypePath) || d.HasChange(icmpCodePath) {
-				useTopLevelIcmp = true
-			}
-		}
-
-		if len(icmp) > 0 && !useTopLevelIcmp {
+		if len(icmp) > 0 {
 			protocol = "icmp"
 			ruleTemplate.Protocol = &protocol
 			if !isNil(icmp[0]) {
-				icmpTypePath := fmt.Sprintf("rules.%d.icmp.0.%s", i, isNetworkACLRuleICMPType)
-				icmpCodePath := fmt.Sprintf("rules.%d.icmp.0.%s", i, isNetworkACLRuleICMPCode)
-				if val, ok := d.GetOk(icmpTypePath); ok {
+				icmpval := icmp[0].(map[string]interface{})
+				if val, ok := icmpval[isNetworkACLRuleICMPType]; ok {
 					icmptype = int64(val.(int))
 					ruleTemplate.Type = &icmptype
 				}
-				if val, ok := d.GetOk(icmpCodePath); ok {
+				if val, ok := icmpval[isNetworkACLRuleICMPCode]; ok {
 					icmpcode = int64(val.(int))
 					ruleTemplate.Code = &icmpcode
 				}
@@ -1249,27 +1196,25 @@ func createInlineRules(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid stri
 			}
 		}
 
-		if len(tcp) > 0 && !useTopLevelPorts {
+		if len(tcp) > 0 {
 			protocol = "tcp"
 			ruleTemplate.Protocol = &protocol
-			if !isNil(tcp[0]) {
-				tcpval := tcp[0].(map[string]interface{})
-				if val, ok := tcpval[isNetworkACLRulePortMin]; ok {
-					minport = int64(val.(int))
-					ruleTemplate.DestinationPortMin = &minport
-				}
-				if val, ok := tcpval[isNetworkACLRulePortMax]; ok {
-					maxport = int64(val.(int))
-					ruleTemplate.DestinationPortMax = &maxport
-				}
-				if val, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
-					sourceminport = int64(val.(int))
-					ruleTemplate.SourcePortMin = &sourceminport
-				}
-				if val, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
-					sourcemaxport = int64(val.(int))
-					ruleTemplate.SourcePortMax = &sourcemaxport
-				}
+			tcpval := tcp[0].(map[string]interface{})
+			if val, ok := tcpval[isNetworkACLRulePortMin]; ok {
+				minport = int64(val.(int))
+				ruleTemplate.DestinationPortMin = &minport
+			}
+			if val, ok := tcpval[isNetworkACLRulePortMax]; ok {
+				maxport = int64(val.(int))
+				ruleTemplate.DestinationPortMax = &maxport
+			}
+			if val, ok := tcpval[isNetworkACLRuleSourcePortMin]; ok {
+				sourceminport = int64(val.(int))
+				ruleTemplate.SourcePortMin = &sourceminport
+			}
+			if val, ok := tcpval[isNetworkACLRuleSourcePortMax]; ok {
+				sourcemaxport = int64(val.(int))
+				ruleTemplate.SourcePortMax = &sourcemaxport
 			}
 		} else if protocol == "tcp" {
 			ruleTemplate.Protocol = &protocol
@@ -1303,27 +1248,25 @@ func createInlineRules(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid stri
 			}
 		}
 
-		if len(udp) > 0 && !useTopLevelPorts {
+		if len(udp) > 0 {
 			protocol = "udp"
 			ruleTemplate.Protocol = &protocol
-			if !isNil(udp[0]) {
-				udpval := udp[0].(map[string]interface{})
-				if val, ok := udpval[isNetworkACLRulePortMin]; ok {
-					minport = int64(val.(int))
-					ruleTemplate.DestinationPortMin = &minport
-				}
-				if val, ok := udpval[isNetworkACLRulePortMax]; ok {
-					maxport = int64(val.(int))
-					ruleTemplate.DestinationPortMax = &maxport
-				}
-				if val, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
-					sourceminport = int64(val.(int))
-					ruleTemplate.SourcePortMin = &sourceminport
-				}
-				if val, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
-					sourcemaxport = int64(val.(int))
-					ruleTemplate.SourcePortMax = &sourcemaxport
-				}
+			udpval := udp[0].(map[string]interface{})
+			if val, ok := udpval[isNetworkACLRulePortMin]; ok {
+				minport = int64(val.(int))
+				ruleTemplate.DestinationPortMin = &minport
+			}
+			if val, ok := udpval[isNetworkACLRulePortMax]; ok {
+				maxport = int64(val.(int))
+				ruleTemplate.DestinationPortMax = &maxport
+			}
+			if val, ok := udpval[isNetworkACLRuleSourcePortMin]; ok {
+				sourceminport = int64(val.(int))
+				ruleTemplate.SourcePortMin = &sourceminport
+			}
+			if val, ok := udpval[isNetworkACLRuleSourcePortMax]; ok {
+				sourcemaxport = int64(val.(int))
+				ruleTemplate.SourcePortMax = &sourcemaxport
 			}
 		} else if protocol == "udp" {
 			ruleTemplate.Protocol = &protocol

--- a/ibm/service/vpc/resource_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule.go
@@ -103,7 +103,7 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 				Type:          schema.TypeList,
 				MaxItems:      1,
 				Optional:      true,
-				Computed:      true,
+				ForceNew:      true,
 				MinItems:      1,
 				ConflictsWith: []string{isSecurityGroupRuleProtocolTCP, isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleProtocol},
 				Deprecated:    "icmp is deprecated, use 'protocol', 'code', and 'type' instead.",
@@ -113,13 +113,13 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 						isSecurityGroupRuleType: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							ForceNew:     false,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleType),
 						},
 						isSecurityGroupRuleCode: {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							ForceNew:     false,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleCode),
 						},
 					},
@@ -131,24 +131,24 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 				MaxItems:      1,
 				Optional:      true,
 				MinItems:      1,
-				Computed:      true,
+				ForceNew:      true,
 				Description:   "protocol=tcp",
 				Deprecated:    "tcp is deprecated, use 'protocol', 'code', and 'type' instead.",
 				ConflictsWith: []string{isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocol, isSecurityGroupRuleType, isSecurityGroupRuleCode},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isSecurityGroupRulePortMin: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							// Default:      1,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     false,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMin),
 						},
 						isSecurityGroupRulePortMax: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							// Default:      65535,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     false,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMax),
 						},
 					},
@@ -159,7 +159,7 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 				Type:          schema.TypeList,
 				MaxItems:      1,
 				Optional:      true,
-				Computed:      true,
+				ForceNew:      true,
 				MinItems:      1,
 				Description:   "protocol=udp",
 				Deprecated:    "udp is deprecated, use 'protocol', 'port_min', and 'port_max' instead.",
@@ -167,17 +167,17 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						isSecurityGroupRulePortMin: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							// Default:      1,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     false,
+							Default:      1,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMin),
 						},
 						isSecurityGroupRulePortMax: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							// Default:      65535,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     false,
+							Default:      65535,
 							ValidateFunc: validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMax),
 						},
 					},
@@ -190,10 +190,10 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 				Description: "The crn of the Security Group",
 			},
 			isSecurityGroupRuleProtocol: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				// ForceNew:      true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
 				Description:   "The name of the network protocol",
 				ConflictsWith: []string{isSecurityGroupRuleProtocolTCP, isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocolUDP},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleProtocol),
@@ -201,7 +201,6 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 			isSecurityGroupRuleType: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isSecurityGroupRuleProtocol},
 				ConflictsWith: []string{isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleProtocolTCP, isSecurityGroupRulePortMin, isSecurityGroupRulePortMax},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleType),
@@ -209,7 +208,6 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 			isSecurityGroupRuleCode: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isSecurityGroupRuleProtocol},
 				ConflictsWith: []string{isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleProtocolTCP, isSecurityGroupRulePortMin, isSecurityGroupRulePortMax},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRuleCode),
@@ -217,7 +215,6 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 			isSecurityGroupRulePortMin: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isSecurityGroupRuleProtocol, isSecurityGroupRulePortMax},
 				ConflictsWith: []string{isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocolTCP, isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleType, isSecurityGroupRuleCode},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMin),
@@ -225,7 +222,6 @@ func ResourceIBMISSecurityGroupRule() *schema.Resource {
 			isSecurityGroupRulePortMax: {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Computed:      true,
 				RequiredWith:  []string{isSecurityGroupRuleProtocol, isSecurityGroupRulePortMin},
 				ConflictsWith: []string{isSecurityGroupRuleProtocolICMP, isSecurityGroupRuleProtocolTCP, isSecurityGroupRuleProtocolUDP, isSecurityGroupRuleType, isSecurityGroupRuleCode},
 				ValidateFunc:  validate.InvokeValidator("ibm_is_security_group_rule", isSecurityGroupRulePortMax),
@@ -449,18 +445,6 @@ func resourceIBMISSecurityGroupRuleRead(context context.Context, d *schema.Resou
 				if err = d.Set(isSecurityGroupRuleProtocolICMP, protocolList); err != nil {
 					err = fmt.Errorf("Error setting icmp: %s", err)
 					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "read", "set-icmp").GetDiag()
-				}
-			}
-			if securityGroupRule.Type != nil {
-				if err = d.Set(isSecurityGroupRuleType, int(*securityGroupRule.Type)); err != nil {
-					err = fmt.Errorf("Error setting type: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "read", "set-type").GetDiag()
-				}
-			}
-			if securityGroupRule.Code != nil {
-				if err = d.Set(isSecurityGroupRuleCode, int(*securityGroupRule.Code)); err != nil {
-					err = fmt.Errorf("Error setting code: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "read", "set-code").GetDiag()
 				}
 			}
 			remote, ok := securityGroupRule.Remote.(*vpcv1.SecurityGroupRuleRemote)
@@ -786,16 +770,8 @@ func resourceIBMISSecurityGroupRuleRead(context context.Context, d *schema.Resou
 				if securityGroupRule.PortMin != nil {
 					tcpProtocol["port_min"] = *securityGroupRule.PortMin
 				}
-				if err = d.Set("port_min", securityGroupRule.PortMin); err != nil {
-					err = fmt.Errorf("Error setting port_min: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "read", "set-port_min").GetDiag()
-				}
 				if securityGroupRule.PortMax != nil {
 					tcpProtocol["port_max"] = *securityGroupRule.PortMax
-				}
-				if err = d.Set("port_max", securityGroupRule.PortMax); err != nil {
-					err = fmt.Errorf("Error setting port_max: %s", err)
-					return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "read", "set-port_max").GetDiag()
 				}
 				protocolList := make([]map[string]interface{}, 0)
 				protocolList = append(protocolList, tcpProtocol)
@@ -853,204 +829,6 @@ func resourceIBMISSecurityGroupRuleRead(context context.Context, d *schema.Resou
 	return nil
 }
 
-func buildSecurityGroupRuleUpdatePatch(d *schema.ResourceData, sess *vpcv1.VpcV1) (*vpcv1.UpdateSecurityGroupRuleOptions, error) {
-	secgrpID, ruleID, err := parseISTerraformID(d.Id())
-	if err != nil {
-		return nil, err
-	}
-
-	securityGroupRulePatchModel := &vpcv1.SecurityGroupRulePatch{}
-
-	// Direction
-	if d.HasChange(isSecurityGroupRuleDirection) {
-		direction := d.Get(isSecurityGroupRuleDirection).(string)
-		securityGroupRulePatchModel.Direction = &direction
-	}
-
-	// Name
-	if d.HasChange(isSecurityGroupRuleName) {
-		if v, ok := d.GetOk(isSecurityGroupRuleName); ok && v.(string) != "" {
-			name := v.(string)
-			securityGroupRulePatchModel.Name = &name
-		}
-	}
-
-	// IP Version
-	if d.HasChange(isSecurityGroupRuleIPVersion) {
-		if v, ok := d.GetOk(isSecurityGroupRuleIPVersion); ok {
-			ipversion := v.(string)
-			securityGroupRulePatchModel.IPVersion = &ipversion
-		}
-	}
-
-	// Remote
-	if d.HasChange(isSecurityGroupRuleRemote) {
-		if pr, ok := d.GetOk(isSecurityGroupRuleRemote); ok {
-			remote := pr.(string)
-			remoteAddress, remoteCIDR, remoteSecGrpID, err := inferRemoteSecurityGroup(remote)
-			if err != nil {
-				return nil, err
-			}
-			remoteTemplateUpdate := &vpcv1.SecurityGroupRuleRemotePatch{}
-			if remoteAddress != "" {
-				remoteTemplateUpdate.Address = &remoteAddress
-			} else if remoteCIDR != "" {
-				remoteTemplateUpdate.CIDRBlock = &remoteCIDR
-			} else if remoteSecGrpID != "" {
-				remoteTemplateUpdate.ID = &remoteSecGrpID
-				// Verify it's a valid security group
-				getSecurityGroupOptions := &vpcv1.GetSecurityGroupOptions{
-					ID: &remoteSecGrpID,
-				}
-				sg, res, err := sess.GetSecurityGroup(getSecurityGroupOptions)
-				if err != nil || sg == nil {
-					if res != nil && res.StatusCode == 404 {
-						return nil, fmt.Errorf("[ERROR] Invalid remote provided (%s): %s\n%s", remoteSecGrpID, err, res)
-					}
-					return nil, fmt.Errorf("[ERROR] Invalid remote provided (%s): %s", remoteSecGrpID, err)
-				}
-			}
-			securityGroupRulePatchModel.Remote = remoteTemplateUpdate
-		}
-	}
-
-	// Local
-	if d.HasChange(isSecurityGroupRuleLocal) {
-		if pl, ok := d.GetOk(isSecurityGroupRuleLocal); ok {
-			local := pl.(string)
-			localAddress, localCIDR, err := inferLocalSecurityGroup(local)
-			if err != nil {
-				return nil, err
-			}
-			localTemplateUpdate := &vpcv1.SecurityGroupRuleLocalPatch{}
-			if localAddress != "" {
-				localTemplateUpdate.Address = &localAddress
-			} else if localCIDR != "" {
-				localTemplateUpdate.CIDRBlock = &localCIDR
-			}
-			securityGroupRulePatchModel.Local = localTemplateUpdate
-		}
-	}
-
-	// Check if using new protocol attribute or deprecated blocks
-	// These are mutually exclusive due to ConflictsWith in schema
-	// Check if deprecated blocks exist in the configuration (not state)
-	hasTCP := d.HasChange(isSecurityGroupRuleProtocolTCP)
-	hasUDP := d.HasChange(isSecurityGroupRuleProtocolUDP)
-	hasICMP := d.HasChange(isSecurityGroupRuleProtocolICMP)
-	usingDeprecatedBlocks := hasTCP || hasUDP || hasICMP
-
-	protocol := d.Get(isSecurityGroupRuleProtocol).(string)
-
-	if usingDeprecatedBlocks {
-		// Handle deprecated TCP block
-		if d.HasChange(isSecurityGroupRuleProtocolTCP) {
-			// Use GetOk to get NEW values from configuration, not old state values
-			if tcpInterface, ok := d.GetOk(isSecurityGroupRuleProtocolTCP); ok {
-				tcp := tcpInterface.([]interface{})
-				if len(tcp) > 0 {
-					tcpval := tcp[0].(map[string]interface{})
-					if portMin, ok := tcpval[isSecurityGroupRulePortMin]; ok {
-						portMinInt := int64(portMin.(int))
-						securityGroupRulePatchModel.PortMin = &portMinInt
-					}
-					if portMax, ok := tcpval[isSecurityGroupRulePortMax]; ok {
-						portMaxInt := int64(portMax.(int))
-						securityGroupRulePatchModel.PortMax = &portMaxInt
-					}
-				}
-			}
-		}
-
-		// Handle deprecated UDP block
-		if d.HasChange(isSecurityGroupRuleProtocolUDP) {
-			// Use GetOk to get NEW values from configuration, not old state values
-			if udpInterface, ok := d.GetOk(isSecurityGroupRuleProtocolUDP); ok {
-				udp := udpInterface.([]interface{})
-				if len(udp) > 0 {
-					udpval := udp[0].(map[string]interface{})
-					if portMin, ok := udpval[isSecurityGroupRulePortMin]; ok {
-						portMinInt := int64(portMin.(int))
-						securityGroupRulePatchModel.PortMin = &portMinInt
-					}
-					if portMax, ok := udpval[isSecurityGroupRulePortMax]; ok {
-						portMaxInt := int64(portMax.(int))
-						securityGroupRulePatchModel.PortMax = &portMaxInt
-					}
-				}
-			}
-		}
-
-		// Handle deprecated ICMP block
-		if d.HasChange(isSecurityGroupRuleProtocolICMP) {
-			// Use GetOk to get NEW values from configuration, not old state values
-			if icmpInterface, ok := d.GetOk(isSecurityGroupRuleProtocolICMP); ok {
-				icmp := icmpInterface.([]interface{})
-				if len(icmp) > 0 {
-					icmpval := icmp[0].(map[string]interface{})
-					if icmpType, ok := icmpval[isSecurityGroupRuleType]; ok {
-						icmpTypeInt := int64(icmpType.(int))
-						securityGroupRulePatchModel.Type = &icmpTypeInt
-					}
-					if icmpCode, ok := icmpval[isSecurityGroupRuleCode]; ok {
-						icmpCodeInt := int64(icmpCode.(int))
-						securityGroupRulePatchModel.Code = &icmpCodeInt
-					}
-				}
-			}
-		}
-	} else {
-		// Handle new top-level attributes (when protocol is set)
-		// Handle port_min and port_max for TCP/UDP protocols
-		if protocol == "tcp" || protocol == "udp" {
-			// For Computed attributes, we need to check HasChange to get the new value
-			if d.HasChange(isSecurityGroupRulePortMin) {
-				if v, ok := d.GetOk(isSecurityGroupRulePortMin); ok {
-					portMin := int64(v.(int))
-					securityGroupRulePatchModel.PortMin = &portMin
-				}
-			}
-			if d.HasChange(isSecurityGroupRulePortMax) {
-				if v, ok := d.GetOk(isSecurityGroupRulePortMax); ok {
-					portMax := int64(v.(int))
-					securityGroupRulePatchModel.PortMax = &portMax
-				}
-			}
-		}
-
-		// Handle type and code for ICMP protocol
-		if protocol == "icmp" {
-			if d.HasChange(isSecurityGroupRuleType) {
-				if v, ok := d.GetOk(isSecurityGroupRuleType); ok {
-					icmpType := int64(v.(int))
-					securityGroupRulePatchModel.Type = &icmpType
-				}
-			}
-			if d.HasChange(isSecurityGroupRuleCode) {
-				if v, ok := d.GetOk(isSecurityGroupRuleCode); ok {
-					icmpCode := int64(v.(int))
-					securityGroupRulePatchModel.Code = &icmpCode
-				}
-			}
-		}
-	}
-
-	// Convert patch model to map
-	securityGroupRulePatch, err := securityGroupRulePatchModel.AsPatch()
-	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error calling asPatch for SecurityGroupRulePatch: %s", err)
-	}
-
-	// Build update options
-	updateOptions := &vpcv1.UpdateSecurityGroupRuleOptions{
-		SecurityGroupID:        &secgrpID,
-		ID:                     &ruleID,
-		SecurityGroupRulePatch: securityGroupRulePatch,
-	}
-
-	return updateOptions, nil
-}
-
 func resourceIBMISSecurityGroupRuleUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := vpcClient(meta)
 	if err != nil {
@@ -1059,21 +837,15 @@ func resourceIBMISSecurityGroupRuleUpdate(context context.Context, d *schema.Res
 		return tfErr.GetDiag()
 	}
 
-	// Build the update patch using the dedicated function
-	updateSecurityGroupRuleOptions, err := buildSecurityGroupRuleUpdatePatch(d, sess)
+	parsed, _, sgTemplate, err := parseIBMISSecurityGroupRuleDictionary(d, "update", sess)
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "update", "build-patch").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "update", "sep-id-parts").GetDiag()
 	}
-
-	secgrpID, _, err := parseISTerraformID(d.Id())
-	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_security_group_rule", "update", "parse-id").GetDiag()
-	}
-
-	isSecurityGroupRuleKey := "security_group_rule_key_" + secgrpID
+	isSecurityGroupRuleKey := "security_group_rule_key_" + parsed.secgrpID
 	conns.IbmMutexKV.Lock(isSecurityGroupRuleKey)
 	defer conns.IbmMutexKV.Unlock(isSecurityGroupRuleKey)
 
+	updateSecurityGroupRuleOptions := sgTemplate
 	_, _, err = sess.UpdateSecurityGroupRuleWithContext(context, updateSecurityGroupRuleOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateSecurityGroupRuleWithContext failed: %s", err.Error()), "ibm_is_security_group_rule", "update")
@@ -1416,46 +1188,18 @@ func parseIBMISSecurityGroupRuleDictionary(d *schema.ResourceData, tag string, s
 				parsed.portMax = 65535
 				parsed.portMin = 1
 			}
-			if parsed.portMax <= 0 {
-				parsed.portMax = 65535
-			}
-			if parsed.portMin <= 0 {
-				parsed.portMin = 1
-			}
 			sgTemplate.PortMax = &parsed.portMax
 			sgTemplate.PortMin = &parsed.portMin
 			securityGroupRulePatchModel.PortMax = &parsed.portMax
 			securityGroupRulePatchModel.PortMin = &parsed.portMin
 		} else {
 			if parsed.protocol == prot {
-				// First try to get from new attributes
 				if value, ok := d.GetOk("port_min"); ok {
 					parsed.portMin = int64(value.(int))
 				}
 				if value, ok := d.GetOk("port_max"); ok {
 					parsed.portMax = int64(value.(int))
 				}
-
-				// If not found in new attributes, try to get from deprecated block in state
-				// This handles the migration case where values are still in the old block
-				if parsed.portMin == -1 || parsed.portMax == -1 {
-					if tcpInterface, ok := d.GetOk(prot); ok {
-						if tcpInterface.([]interface{})[0] != nil {
-							ports := tcpInterface.([]interface{})[0].(map[string]interface{})
-							if parsed.portMin == -1 {
-								if value, ok := ports["port_min"]; ok {
-									parsed.portMin = int64(value.(int))
-								}
-							}
-							if parsed.portMax == -1 {
-								if value, ok := ports["port_max"]; ok {
-									parsed.portMax = int64(value.(int))
-								}
-							}
-						}
-					}
-				}
-
 				parsed.protocol = prot
 				sgTemplate.Protocol = &parsed.protocol
 				if parsed.portMin == -1 && parsed.portMax == -1 {


### PR DESCRIPTION
Reverts merge commit e3791cc7f771f8b736fd50e02af6e05e200b5db2

This reverts changes to:
- ibm/service/vpc/resource_ibm_is_network_acl_rule.go
- ibm/service/vpc/resource_ibm_is_networkacls.go
- ibm/service/vpc/resource_ibm_is_security_group_rule.go

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
