### PR TITLE
(DUX) Bug: Fixed the Terraform create DB with non-existing region

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -72,6 +72,18 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 )
 
+var regionLocationMap = map[string]struct{}{
+	"au-syd":   {},
+	"ca-tor":   {},
+	"eu-de":    {},
+	"eu-gb":    {},
+	"jp-tok":   {},
+	"jp-osa":   {},
+	"us-east":  {},
+	"us-south": {},
+	"br-sao":   {},
+}
+
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
 	provider := schema.Provider{
@@ -2498,6 +2510,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if isValidRegion(region) == false {
+		return nil, fmt.Errorf("[ERROR] Provider region %q is not supported. Valid provider region(s) are: %q", region, getValidRegions())
+	}
+
 	// Set environment variable to be used in DiffSupressFunction
 	if wskEnvVal.(string) == "" {
 		os.Setenv("FUNCTION_NAMESPACE", wskNameSpace)
@@ -2528,4 +2545,17 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	return config.ClientSession()
+}
+
+func isValidRegion(region string) bool {
+	_, exists := regionLocationMap[region]
+	return exists
+}
+
+func getValidRegions() []string {
+	regions := make([]string, 0, len(regionLocationMap))
+	for region := range regionLocationMap {
+		regions = append(regions, region)
+	}
+	return regions
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
Issue: https://github.ibm.com/compose/App/issues/2087

**Before the Fix**
<img width="1635" height="976" alt="Screenshot 2026-03-11 at 3 19 49 PM" src="https://github.com/user-attachments/assets/153176b8-5aa1-423f-a94e-0f7e19805703" />

**Proposed changes:**
**Terraform plan will check the valid regions and give the validation errors instead of panic errors before TF apply** 

**After the Fix**
<img width="1399" height="660" alt="Screenshot 2026-03-11 at 3 27 50 PM" src="https://github.com/user-attachments/assets/6c2d3bef-d333-4058-a148-c2a508aab992" />



Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstancePostgresBasic'
=== RUN   TestAccIBMDatabaseInstancePostgresBasic
=== PAUSE TestAccIBMDatabaseInstancePostgresBasic
=== CONT  TestAccIBMDatabaseInstancePostgresBasic
--- PASS: TestAccIBMDatabaseInstancePostgresBasic (1157.09s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1158.496s


...
```
