### PR TITLE
fix(cis): handle null timestamps in CIS custom page resource

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_custom_page.go
+++ b/ibm/service/cis/resource_ibm_cis_custom_page.go
@@ -185,15 +185,13 @@ func resourceCISCustomPageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set(cisCustomPageRequiredTokens, flex.FlattenStringList(result.Result.RequiredTokens))
 	d.Set(cisCustomPageDesc, result.Result.Description)
 	d.Set(cisCustomPagePreviewTarget, result.Result.PreviewTarget)
+
+	// Handle nullable timestamp fields - API returns null for default custom pages
 	if result.Result.CreatedOn != nil {
 		d.Set(cisCustomPageCreatedOn, (*result.Result.CreatedOn).String())
-	} else {
-		d.Set(cisCustomPageCreatedOn, "")
 	}
 	if result.Result.ModifiedOn != nil {
 		d.Set(cisCustomPageModifiedOn, (*result.Result.ModifiedOn).String())
-	} else {
-		d.Set(cisCustomPageModifiedOn, "")
 	}
 	return nil
 }


### PR DESCRIPTION

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Issue Link: https://github.ibm.com/NetworkTribe/CIS/issues/7811

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccIBMCISCustomPage_Basic'

=== RUN   TestAccIBMCISCustomPage_Basic
--- PASS: TestAccIBMCISCustomPage_Basic (44.15s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis     46.217s

...
```
