### PR TITLE
Add externalIP attribute for network_interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.25.2
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.14.4
+	github.com/IBM-Cloud/power-go-client v1.15.0
 	github.com/IBM/appconfiguration-go-admin-sdk v0.5.1
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.8.1
@@ -105,7 +105,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
-	github.com/go-openapi/errors v0.22.4 // indirect
+	github.com/go-openapi/errors v0.22.6 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31 h1:3ITr1iuk27
 github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31/go.mod h1:lU1/3aolIs4y062yTTokFEiIEssAZqqjdj/5qvkBeq8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
-github.com/IBM-Cloud/power-go-client v1.14.4 h1:XXQp4atVwvCfDps1nF5zyi2FzNbsuHtszz5nBJ9yCYg=
-github.com/IBM-Cloud/power-go-client v1.14.4/go.mod h1:TT0jJbptQuDRwB9PPYDcGe0ZwFSl5GiSrNuQeJzJYco=
+github.com/IBM-Cloud/power-go-client v1.15.0 h1:bXkcx9DlhCmNr9w2xHI9lpzjkfM7uLVviaQGDAg0U50=
+github.com/IBM-Cloud/power-go-client v1.15.0/go.mod h1:UTyMxybFDj0xHNalAIC5qfRZs16gOSDzPFfUOWnRD64=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/appconfiguration-go-admin-sdk v0.5.1 h1:EAotl3yQ/u5u/uBryySJMm0COgsYhtNzQ1g2IChtlE0=
@@ -415,8 +415,8 @@ github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpX
 github.com/go-openapi/errors v0.20.0/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.20.2/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.21.0/go.mod h1:jxNTMUxRCKj65yb/okJGEtahVd7uvWnuWfj53bse4ho=
-github.com/go-openapi/errors v0.22.4 h1:oi2K9mHTOb5DPW2Zjdzs/NIvwi2N3fARKaTJLdNabaM=
-github.com/go-openapi/errors v0.22.4/go.mod h1:z9S8ASTUqx7+CP1Q8dD8ewGH/1JWFFLX/2PmAYNQLgk=
+github.com/go-openapi/errors v0.22.6 h1:eDxcf89O8odEnohIXwEjY1IB4ph5vmbUsBMsFNwXWPo=
+github.com/go-openapi/errors v0.22.6/go.mod h1:z9S8ASTUqx7+CP1Q8dD8ewGH/1JWFFLX/2PmAYNQLgk=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -66,6 +66,11 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 				},
 				Type: schema.TypeList,
 			},
+			Attr_ExternalIP: {
+				Computed:    true,
+				Description: "The external ip address for pub-vlan networks.",
+				Type:        schema.TypeString,
+			},
 			Attr_IPAddress: {
 				Computed:    true,
 				Description: "The ip address of this Network Interface.",
@@ -134,6 +139,7 @@ func dataSourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.Resource
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", networkID, *networkInterface.ID))
+	d.Set(Attr_ExternalIP, networkInterface.ExternalIP)
 	d.Set(Attr_IPAddress, networkInterface.IPAddress)
 	d.Set(Attr_MacAddress, networkInterface.MacAddress)
 	d.Set(Attr_Name, networkInterface.Name)

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -47,6 +47,11 @@ func DataSourceIBMPINetworkInterfaces() *schema.Resource {
 							Description: "The network interface's crn.",
 							Type:        schema.TypeString,
 						},
+						Attr_ExternalIP: {
+							Computed:    true,
+							Description: "The external ip address for pub-vlan networks.",
+							Type:        schema.TypeString,
+						},
 						Attr_ID: {
 							Computed:    true,
 							Description: "The unique network interface ID.",
@@ -153,6 +158,7 @@ func dataSourceIBMPINetworkInterfacesRead(ctx context.Context, d *schema.Resourc
 
 func networkInterfaceToMap(netInterface *models.NetworkInterface, meta any) map[string]any {
 	interfaceMap := make(map[string]any)
+	interfaceMap[Attr_ExternalIP] = netInterface.ExternalIP
 	interfaceMap[Attr_ID] = netInterface.ID
 	interfaceMap[Attr_IPAddress] = netInterface.IPAddress
 	interfaceMap[Attr_MacAddress] = netInterface.MacAddress

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -88,6 +88,11 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 				Description: "The network interface's crn.",
 				Type:        schema.TypeString,
 			},
+			Attr_ExternalIP: {
+				Computed:    true,
+				Description: "The external ip address for pub-vlan networks.",
+				Type:        schema.TypeString,
+			},
 			Attr_Instance: {
 				Computed:    true,
 				Optional:    true,
@@ -222,6 +227,7 @@ func resourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	d.Set(Attr_ExternalIP, networkInterface.ExternalIP)
 	d.Set(Attr_IPAddress, networkInterface.IPAddress)
 	d.Set(Attr_MacAddress, networkInterface.MacAddress)
 	d.Set(Attr_Name, networkInterface.Name)

--- a/website/docs/d/pi_network_interface.html.markdown
+++ b/website/docs/d/pi_network_interface.html.markdown
@@ -49,7 +49,8 @@ You can specify the following arguments for this data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `crn` - (String) The network interface's crn.
-- `id` - (String) The unique identifier of the network interface resource.The id is composed of `<network_id>/<network_interface_id>`  
+- `external_ip` - (String) The external ip address for pub-vlan networks.
+- `id` - (String) The unique identifier of the network interface resource.The id is composed of `<network_id>/<network_interface_id>`
 - `instance` - (List) The attached instance to this Network Interface.
 
    Nested scheme for `instance`:

--- a/website/docs/d/pi_network_interfaces.html.markdown
+++ b/website/docs/d/pi_network_interfaces.html.markdown
@@ -52,6 +52,7 @@ In addition to all argument reference listed, you can access the following attri
   
   Nested scheme for `interfaces`:
   - `crn` - (String) The network interface's crn.
+  - `external_ip` - (String) The external ip address for pub-vlan networks.
   - `id` - (String) The unique network interface id.
   - `instance` - (List) The attached instance to this network interface.
 

--- a/website/docs/r/pi_network_interface.html.markdown
+++ b/website/docs/r/pi_network_interface.html.markdown
@@ -60,6 +60,7 @@ Review the argument references that you can specify for your resource.
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
 - `crn` - (String) The network interface's crn.
+- `external_ip` - (String) The external ip address for pub-vlan networks.
 - `id` - (String) The unique identifier of the network interface resource. The ID is composed of `<cloud_instance_id>/<network_id>/<network_interface_id>`.
 - `instance` - (List) The attached instance to this network interface.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPINetworkInterfaceBasic
--- PASS: TestAccIBMPINetworkInterfaceBasic (54.43s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power   56.390s

=== RUN   TestAccIBMPINetworkInterfaceDataSourceBasic
--- PASS: TestAccIBMPINetworkInterfaceDataSourceBasic (43.78s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power   45.948s

=== RUN   TestAccIBMPINetworkInterfacesDataSourceBasic
--- PASS: TestAccIBMPINetworkInterfacesDataSourceBasic (39.89s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/power   41.805s
```
