### PR TITLE
feat(directlink): support Secrets Manager CRNs in authentication_key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/IBM/logs-go-sdk v0.5.0
 	github.com/IBM/logs-router-go-sdk v1.0.8
 	github.com/IBM/mqcloud-go-sdk v0.4.0
-	github.com/IBM/networking-go-sdk v0.51.14
+	github.com/IBM/networking-go-sdk v0.52.0
 	github.com/IBM/platform-services-go-sdk v0.94.3
 	github.com/IBM/project-go-sdk v0.4.0
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/IBM/logs-router-go-sdk v1.0.8 h1:MU1TdYNdVbvVTUXeqeYPItu6BoiSV/NMN49y
 github.com/IBM/logs-router-go-sdk v1.0.8/go.mod h1:tCN2vFgu5xG0ob9iJcxi5M4bJ6mWmu3nhmRPnvlwev0=
 github.com/IBM/mqcloud-go-sdk v0.4.0 h1:BuZNXA6iYEg5OEPr13CMGrhH0ew4rH/4L56b1nFtA10=
 github.com/IBM/mqcloud-go-sdk v0.4.0/go.mod h1:7zigCUz6k3eRrNE8KOcDkY72oPppEmoQifF+SB0NPRM=
-github.com/IBM/networking-go-sdk v0.51.14 h1:WYUdTmFZKeEDYctOk4YpNHNtjN3OOvV8/JDcrmglh4A=
-github.com/IBM/networking-go-sdk v0.51.14/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
+github.com/IBM/networking-go-sdk v0.52.0 h1:tCwjUIE1Uo91i2bAZTxa/rKPg4SuQg7iJtGoIk4bCNM=
+github.com/IBM/networking-go-sdk v0.52.0/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
 github.com/IBM/platform-services-go-sdk v0.94.3 h1:eV0FwDz2cTMNiIKA6JGB3EU4VzkizVmRDifCPhdy7v8=
 github.com/IBM/platform-services-go-sdk v0.94.3/go.mod h1:KAnBhxKaYsu9It2aVXV6oCPEj78imvTs2qSG0ScZKpM=
 github.com/IBM/project-go-sdk v0.4.0 h1:72pEtVHJn434+MYRawER7Hk/kblapdfotoLBBhjv/jo=

--- a/ibm/service/directlink/data_source_ibm_dl_gateway_macsec_cak.go
+++ b/ibm/service/directlink/data_source_ibm_dl_gateway_macsec_cak.go
@@ -145,18 +145,32 @@ func dataSourceIBMDLGatewayMacsecCakRead(context context.Context, d *schema.Reso
 		d.Set(dlUpdatedAt, result.UpdatedAt.String())
 	}
 
-	hpcsKey := map[string]interface{}{}
 	if result.Key != nil {
-		hpcsKey[dlGatewayMacsecHPCSCrn] = *result.Key.Crn
-		d.Set(dlGatewayMacsecHPCSKey, []map[string]interface{}{hpcsKey})
+		// Type assert to access Crn field from polymorphic interface
+		if hpcsKey, ok := result.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+			keyMap := map[string]interface{}{}
+			keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+			d.Set(dlGatewayMacsecHPCSKey, []map[string]interface{}{keyMap})
+		} else if smKey, ok := result.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+			keyMap := map[string]interface{}{}
+			keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+			d.Set(dlGatewayMacsecHPCSKey, []map[string]interface{}{keyMap})
+		}
 	}
 
 	activeDelta := map[string]interface{}{}
 	if result.ActiveDelta != nil {
-		hpcsKey := map[string]interface{}{}
 		if result.ActiveDelta.Key != nil {
-			hpcsKey[dlGatewayMacsecHPCSCrn] = *result.ActiveDelta.Key.Crn
-			activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{hpcsKey}
+			// Type assert to access Crn field from polymorphic interface
+			if hpcsKey, ok := result.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+				keyMap := map[string]interface{}{}
+				keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+				activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+			} else if smKey, ok := result.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+				keyMap := map[string]interface{}{}
+				keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+				activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+			}
 		}
 
 		activeDelta[dlGatewayMacsecCakName] = *result.ActiveDelta.Name

--- a/ibm/service/directlink/data_source_ibm_dl_gateway_macsec_caks.go
+++ b/ibm/service/directlink/data_source_ibm_dl_gateway_macsec_caks.go
@@ -145,18 +145,32 @@ func dataSourceIBMDLGatewayMacsecCaksRead(context context.Context, d *schema.Res
 			cakItem[dlUpdatedAt] = cak.UpdatedAt.String()
 			cakItem[dlGatewayMacsecCakID] = *cak.ID
 
-			hpcsKey := map[string]interface{}{}
 			if cak.Key != nil {
-				hpcsKey[dlGatewayMacsecHPCSCrn] = *cak.Key.Crn
-				cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{hpcsKey}
+				// Type assert to access Crn field from polymorphic interface
+				if hpcsKey, ok := cak.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+					keyMap := map[string]interface{}{}
+					keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+					cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+				} else if smKey, ok := cak.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+					keyMap := map[string]interface{}{}
+					keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+					cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+				}
 			}
 
 			activeDelta := map[string]interface{}{}
 			if cak.ActiveDelta != nil {
-				hpcsKey := map[string]interface{}{}
 				if cak.ActiveDelta.Key != nil {
-					hpcsKey[dlGatewayMacsecHPCSCrn] = cak.ActiveDelta.Key.Crn
-					activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{hpcsKey}
+					// Type assert to access Crn field from polymorphic interface
+					if hpcsKey, ok := cak.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+						keyMap := map[string]interface{}{}
+						keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+						activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+					} else if smKey, ok := cak.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+						keyMap := map[string]interface{}{}
+						keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+						activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+					}
 				}
 				activeDelta[dlGatewayMacsecCakName] = cak.ActiveDelta.Name
 				// activeDelta[dlGatewayMacsecCakStatus] = *result.ActiveDelta.Status

--- a/ibm/service/directlink/resource_ibm_dl_gateway_macsec_cak.go
+++ b/ibm/service/directlink/resource_ibm_dl_gateway_macsec_cak.go
@@ -203,7 +203,9 @@ func resourceIBMdlGatewayMacsecCakCreate(context context.Context, d *schema.Reso
 	session := d.Get(dlGatewayMacsecCakSession).(string)
 	keyMapIntf := d.Get(dlGatewayMacsecHPCSKey).(*schema.Set).List()[0].(map[string]interface{})
 	crn := keyMapIntf[dlCrn].(string)
-	key, _ := directLink.NewHpcsKeyIdentity(crn)
+
+	// Use polymorphic key reference constructor
+	key, _ := directLink.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(crn)
 
 	createGatewayMacsecCakOptions := directLink.NewCreateGatewayMacsecCakOptions(gatewayID, key, name, session)
 
@@ -260,18 +262,32 @@ func resourceIBMdlGatewayMacsecCakRead(context context.Context, d *schema.Resour
 
 	cakItem[dlGatewayMacsecCakID] = *instance.ID
 
-	hpcsKey := map[string]interface{}{}
 	if instance.Key != nil {
-		hpcsKey[dlGatewayMacsecHPCSCrn] = *instance.Key.Crn
-		cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{hpcsKey}
+		// Type assert to access Crn field from polymorphic interface
+		if hpcsKey, ok := instance.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+			keyMap := map[string]interface{}{}
+			keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+			cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+		} else if smKey, ok := instance.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+			keyMap := map[string]interface{}{}
+			keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+			cakItem[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+		}
 	}
 
 	activeDelta := map[string]interface{}{}
 	if instance.ActiveDelta != nil {
-		hpcsKey := map[string]interface{}{}
 		if instance.ActiveDelta.Key != nil {
-			hpcsKey[dlGatewayMacsecHPCSCrn] = *instance.ActiveDelta.Key.Crn
-			activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{hpcsKey}
+			// Type assert to access Crn field from polymorphic interface
+			if hpcsKey, ok := instance.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference); ok {
+				keyMap := map[string]interface{}{}
+				keyMap[dlGatewayMacsecHPCSCrn] = *hpcsKey.Crn
+				activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+			} else if smKey, ok := instance.ActiveDelta.Key.(*directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference); ok {
+				keyMap := map[string]interface{}{}
+				keyMap[dlGatewayMacsecHPCSCrn] = *smKey.Crn
+				activeDelta[dlGatewayMacsecHPCSKey] = []map[string]interface{}{keyMap}
+			}
 		}
 
 		activeDelta[dlGatewayMacsecCakName] = *instance.ActiveDelta.Name
@@ -302,7 +318,9 @@ func resourceIBMdlGatewayMacsecCakUpdate(context context.Context, d *schema.Reso
 
 	keyMapIntf := d.Get(dlGatewayMacsecHPCSKey).(*schema.Set).List()[0].(map[string]interface{})
 	crn := keyMapIntf[dlCrn].(string)
-	key, _ := directLink.NewHpcsKeyIdentity(crn)
+
+	// Use polymorphic key reference constructor
+	key, _ := directLink.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(crn)
 	gatewayMacsecCakPatch[dlGatewayMacsecHPCSKey] = &key
 
 	patchGatewayOptions := directLink.NewUpdateGatewayMacsecCakOptions(gatewayID, getMacsecCakID, gatewayMacsecCakPatch)

--- a/ibm/service/directlink/resource_ibm_dl_gateway_macsec_config.go
+++ b/ibm/service/directlink/resource_ibm_dl_gateway_macsec_config.go
@@ -180,10 +180,12 @@ func resourceIBMdlGatewayMacsecConfigCreate(context context.Context, d *schema.R
 
 		keyMap := cakMap[dlGatewayMacsecHPCSKey].(*schema.Set).List()[0].(map[string]interface{})
 		crn := keyMap[dlGatewayMacsecHPCSCrn].(string)
-		keyItem := directlinkv1.HpcsKeyIdentity{Crn: &crn}
+
+		// Use polymorphic key reference constructor
+		keyItem, _ := directLink.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(crn)
 
 		cakItem := &directlinkv1.GatewayMacsecCakPrototype{
-			Key:     &keyItem,
+			Key:     keyItem,
 			Name:    &name,
 			Session: &session,
 		}


### PR DESCRIPTION
### Summary

This PR extends support for IBM Secrets Manager CRNs in the existing `authentication_key` field for Direct Link Gateway via SDK upgrade.

---

### Changes

- Upgraded `github.com/IBM/networking-go-sdk` from `v0.51.14` to `v0.52.0`
- Added support for Secrets Manager CRNs in `authentication_key`
- Updated MACsec-related resources and data sources to align with SDK polymorphic changes

---

### Behavior

- No Terraform schema changes
- `authentication_key` remains a string field
- Now supports:
  - HPCS (existing)
  - Key Protect (existing)
  - Secrets Manager (new)
- CRN validation handled by backend API/SDK

---

### Backward Compatibility

- No breaking changes
- Existing configurations continue to work unchanged