### PR TITLE
Adding the support for objectlock governance mode

### DIFF
--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -457,6 +457,7 @@ func ResourceIBMCOSBucket() *schema.Resource {
 			"object_lock": {
 				Type:         schema.TypeBool,
 				Optional:     true,
+				Computed:     true,
 				RequiredWith: []string{"object_versioning"},
 				Description:  "Enable objectlock for the bucket. When enabled, buckets within the container vault can have Object Lock Configuration applied to the bucket.",
 			},
@@ -1373,11 +1374,15 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 		Bucket: aws.String(bucketName),
 	}
 	output, err := s3Client.GetObjectLockConfiguration(getObjectLockConfigurationInput)
-	if output.ObjectLockConfiguration != nil {
+	if err == nil && output != nil && output.ObjectLockConfiguration != nil {
 		objectLockEnabled := *output.ObjectLockConfiguration.ObjectLockEnabled
 		if objectLockEnabled == "Enabled" {
 			d.Set("object_lock", true)
+		} else {
+			d.Set("object_lock", false)
 		}
+	} else {
+		d.Set("object_lock", false)
 	}
 	return nil
 }
@@ -1621,7 +1626,7 @@ func resourceIBMCOSBucketDelete(d *schema.ResourceData, meta interface{}) error 
 
 				// Delete everything including locked objects.
 				// Don't ignore any object errors or we could recurse infinitely.
-				err = deleteAllCOSObjectVersions(s3Client, bucketName, "", false, false)
+				err = deleteAllCOSObjectVersions(s3Client, bucketName, "", false, false, false)
 
 				if err != nil {
 					return fmt.Errorf("[ERROR] Error COS Bucket force_delete: %s", err)

--- a/ibm/service/cos/resource_ibm_cos_bucket_object.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object.go
@@ -146,6 +146,12 @@ func ResourceIBMCOSBucketObject() *schema.Resource {
 				ValidateFunc: validation.IsRFC3339Time,
 				Description:  "An object cannot be deleted when the current time is earlier than the retainUntilDate. After this date, the object can be deleted.",
 			},
+			"bypass_governance_retention": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Allows deleting or modifying object versions locked with GOVERNANCE mode. Required to bypass governance-mode retention when updating or deleting objects.",
+			},
 			"website_redirect": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -336,7 +342,7 @@ func resourceIBMCOSBucketObjectRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("object_lock_mode", out.ObjectLockMode)
 	}
 	if out.ObjectLockRetainUntilDate != nil {
-		d.Set("object_lock_retain_until_date", out.ObjectLockRetainUntilDate.Format(time.RFC1123))
+		d.Set("object_lock_retain_until_date", out.ObjectLockRetainUntilDate.Format(time.RFC3339))
 	}
 	if out.ObjectLockLegalHoldStatus != nil {
 		d.Set("object_lock_legal_hold_status", out.ObjectLockLegalHoldStatus)
@@ -441,6 +447,9 @@ func resourceIBMCOSBucketObjectUpdate(ctx context.Context, d *schema.ResourceDat
 				RetainUntilDate: parseDate(d.Get("object_lock_retain_until_date").(string)),
 			},
 		}
+		if v, ok := d.GetOk("bypass_governance_retention"); ok && v.(bool) {
+			putObjectRetentionInput.BypassGovernanceRetention = aws.Bool(true)
+		}
 		_, err = s3Client.PutObjectRetention(putObjectRetentionInput)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("[ERROR] Error putting objectlock retention on (%s) in COS bucket (%s): %s", objectKey, bucketName, err))
@@ -476,10 +485,15 @@ func resourceIBMCOSBucketObjectDelete(ctx context.Context, d *schema.ResourceDat
 	}
 	objectKey := d.Get("key").(string)
 
+	bypassGovernance := false
+	if v, ok := d.GetOk("bypass_governance_retention"); ok {
+		bypassGovernance = v.(bool)
+	}
+
 	if _, ok := d.GetOk("version_id"); ok {
-		err = deleteAllCOSObjectVersions(s3Client, bucketName, objectKey, d.Get("force_delete").(bool), false)
+		err = deleteAllCOSObjectVersions(s3Client, bucketName, objectKey, d.Get("force_delete").(bool), false, bypassGovernance)
 	} else {
-		err = deleteCOSObjectVersion(s3Client, bucketName, objectKey, "", false)
+		err = deleteCOSObjectVersion(s3Client, bucketName, objectKey, "", false, bypassGovernance)
 	}
 
 	if err != nil {
@@ -615,7 +629,7 @@ func parseObjectId(id string, info string) string {
 
 // deleteAllCOSObjectVersions deletes all versions of a specified key from an COS bucket.
 // If key is empty then all versions of all objects are deleted.
-func deleteAllCOSObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreObjectErrors bool) error {
+func deleteAllCOSObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreObjectErrors, bypassGovernance bool) error {
 	input := &s3.ListObjectVersionsInput{
 		Bucket: aws.String(bucketName),
 	}
@@ -638,7 +652,7 @@ func deleteAllCOSObjectVersions(conn *s3.S3, bucketName, key string, force, igno
 				continue
 			}
 
-			err := deleteCOSObjectVersion(conn, bucketName, objectKey, objectVersionID, force)
+			err := deleteCOSObjectVersion(conn, bucketName, objectKey, objectVersionID, force, bypassGovernance)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "AccessDenied") && force {
@@ -691,7 +705,7 @@ func deleteAllCOSObjectVersions(conn *s3.S3, bucketName, key string, force, igno
 			}
 
 			// Delete markers have no object lock protections.
-			err := deleteCOSObjectVersion(conn, bucketName, deleteMarkerKey, deleteMarkerVersionID, false)
+			err := deleteCOSObjectVersion(conn, bucketName, deleteMarkerKey, deleteMarkerVersionID, false, false)
 
 			if err != nil {
 				lastErr = err
@@ -717,7 +731,7 @@ func deleteAllCOSObjectVersions(conn *s3.S3, bucketName, key string, force, igno
 }
 
 // deleteCOSObjectVersion deletes a specific bucket object version.
-func deleteCOSObjectVersion(conn *s3.S3, b, k, v string, force bool) error {
+func deleteCOSObjectVersion(conn *s3.S3, b, k, v string, force, bypassGovernance bool) error {
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String(b),
 		Key:    aws.String(k),
@@ -725,6 +739,10 @@ func deleteCOSObjectVersion(conn *s3.S3, b, k, v string, force bool) error {
 
 	if v != "" {
 		input.VersionId = aws.String(v)
+	}
+
+	if bypassGovernance {
+		input.BypassGovernanceRetention = aws.Bool(true)
 	}
 
 	log.Printf("[INFO] Deleting COS Bucket (%s) Object (%s) Version: %s", b, k, v)

--- a/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_object_test.go
@@ -272,7 +272,75 @@ func TestAccIBMCOSBucketObjectlock_Retention_Without_Retainuntildate(t *testing.
 		},
 	})
 }
+func TestAccIBMCOSBucketObject_Governance_Shorten_Retention_Without_Bypass_Negative(t *testing.T) {
+	name := fmt.Sprintf("tf-testacc-cos-%d", acctest.RandIntRange(10, 100))
+	instanceCRN := acc.CosCRN
+	objectBody := "Governance Mode Test"
 
+	// Set initial retention to 2 minutes from now
+	initialRetainUntilDate := time.Now().UTC().Add(time.Minute * 2)
+	initialRetainUntilDateString := initialRetainUntilDate.Format(time.RFC3339)
+	// Try to shorten to 1 minute from now
+	shortenedRetainUntilDate := time.Now().UTC().Add(time.Minute * 1)
+	shortenedRetainUntilDateString := shortenedRetainUntilDate.Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCOS(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketObject_Governance_Retention(name, instanceCRN, objectBody, "GOVERNANCE", initialRetainUntilDateString, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc", "object_lock_mode", "GOVERNANCE"),
+				),
+			},
+			{
+				Config:      testAccIBMCOSBucketObject_Governance_Retention(name, instanceCRN, objectBody, "GOVERNANCE", shortenedRetainUntilDateString, false),
+				ExpectError: regexp.MustCompile("AccessDenied|Access Denied"),
+			},
+			{
+				PreConfig: func() {
+					// Wait for retention to expire before cleanup
+					time.Sleep(time.Until(initialRetainUntilDate) + time.Second*5)
+				},
+				Config: testAccIBMCOSBucketObject_Governance_Retention(name, instanceCRN, objectBody, "GOVERNANCE", initialRetainUntilDateString, false),
+			},
+		},
+	})
+}
+
+func TestAccIBMCOSBucketObject_Governance_Shorten_Retention_With_Bypass_Positive(t *testing.T) {
+	name := fmt.Sprintf("tf-testacc-cos-%d", acctest.RandIntRange(10, 100))
+	instanceCRN := acc.CosCRN
+	objectBody := "Governance Mode Test"
+
+	// Set initial retention to 2 minutes from now
+	initialRetainUntilDate := time.Now().UTC().Add(time.Minute * 2)
+	initialRetainUntilDateString := initialRetainUntilDate.Format(time.RFC3339)
+	// Shorten to 1 minute from now with bypass
+	shortenedRetainUntilDate := time.Now().UTC().Add(time.Minute * 1)
+	shortenedRetainUntilDateString := shortenedRetainUntilDate.Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckCOS(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketObject_Governance_Retention(name, instanceCRN, objectBody, "GOVERNANCE", initialRetainUntilDateString, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc", "object_lock_mode", "GOVERNANCE"),
+				),
+			},
+			{
+				Config: testAccIBMCOSBucketObject_Governance_Retention(name, instanceCRN, objectBody, "GOVERNANCE", shortenedRetainUntilDateString, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc", "object_lock_mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object.testacc", "bypass_governance_retention", "true"),
+				),
+			},
+		},
+	})
+}
 func testAccIBMCOSBucketObjectConfig_plaintext(name string, instanceCRN string, objectBody string) string {
 	return fmt.Sprintf(`
 		resource "ibm_cos_bucket" "testacc" {
@@ -506,5 +574,34 @@ func testAccIBMCOSBucketObjectlock_legalhold_off(name string, instanceCRN string
 			content			    = "%[3]s"
 			object_lock_legal_hold_status = "OFF"
    			force_delete = true
-		}`, name, instanceCRN, objectBody)
+  }`, name, instanceCRN, objectBody)
+}
+
+func testAccIBMCOSBucketObject_Governance_Retention(name string, instanceCRN string, objectBody string, mode string, retainUntilDate string, bypassGovernance bool) string {
+	bypassParam := ""
+	if bypassGovernance {
+		bypassParam = "bypass_governance_retention = true"
+	}
+
+	return fmt.Sprintf(`
+		resource "ibm_cos_bucket" "testacc" {
+			bucket_name          = "%[1]s"
+			resource_instance_id = "%[2]s"
+			cross_region_location      = "us"
+			storage_class        = "standard"
+			object_versioning {
+				enable  = true
+			}
+			object_lock = true
+		}
+		resource "ibm_cos_bucket_object" "testacc" {
+			bucket_crn	    = ibm_cos_bucket.testacc.crn
+			bucket_location = ibm_cos_bucket.testacc.cross_region_location
+			key 					  = "%[1]s.txt"
+			content			    = "%[3]s"
+			object_lock_mode              = "%[4]s"
+			object_lock_retain_until_date = "%[5]s"
+			%[6]s
+			force_delete = true
+		}`, name, instanceCRN, objectBody, mode, retainUntilDate, bypassParam)
 }

--- a/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration.go
@@ -73,9 +73,10 @@ func ResourceIBMCOSBucketObjectlock() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"mode": {
-													Type:        schema.TypeString,
-													Required:    true,
-													Description: "Retention modes apply different levels of protection to the objects.",
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validate.ValidateAllowedStringValues([]string{"COMPLIANCE", "GOVERNANCE"}),
+													Description:  "Retention modes apply different levels of protection to the objects. Valid values: COMPLIANCE, GOVERNANCE.",
 												},
 												"years": {
 													Type:          schema.TypeInt,

--- a/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_objectlock_configuration_test.go
@@ -356,6 +356,101 @@ func TestAccIBMCosBucket_Objectlock_Configuration_Invalid_Days(t *testing.T) {
 	})
 }
 
+func TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Days(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	objectLockEnabled := true
+	mode := "GOVERNANCE"
+	days := int64(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Objectlock_Valid_Mode_and_Days(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, objectLockEnabled, mode, days),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "object_versioning.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "object_lock", "true"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.days", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Years(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+	objectLockEnabled := true
+	mode := "GOVERNANCE"
+	years := int64(2)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Objectlock_Valid_Mode_and_Years(serviceName, bucketName, bucketRegionType, bucketRegion, bucketClass, objectLockEnabled, mode, years),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "storage_class", bucketClass),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "cross_region_location", bucketRegion),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "object_versioning.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "object_lock", "true"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.years", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCosBucket_Objectlock_Configuration_Governance_Shorten_Retention_With_Bypass(t *testing.T) {
+	bucketRegion := "us-south"
+	bucketCRN := acc.BucketCRN
+	mode := "GOVERNANCE"
+	initialDays := int64(10)
+	shortenedDays := int64(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCosBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCosBucket_Objectlock_Existing_bucket_Days(bucketCRN, bucketRegion, mode, initialDays),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.days", "10"),
+				),
+			},
+			{
+				Config: testAccCheckIBMCosBucket_Objectlock_Existing_bucket_Days(bucketCRN, bucketRegion, mode, shortenedDays),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.mode", "GOVERNANCE"),
+					resource.TestCheckResourceAttr("ibm_cos_bucket_object_lock_configuration.objectlock", "object_lock_configuration.0.object_lock_rule.0.default_retention.0.days", "5"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIBMCosBucket_Objectlock_Bucket_Enabled(cosServiceName string, bucketName string, regiontype string, region string, storageClass string, objectLockEnabled bool) string {
 
 	return fmt.Sprintf(`

--- a/website/docs/r/cos_bucket_object.html.markdown
+++ b/website/docs/r/cos_bucket_object.html.markdown
@@ -95,6 +95,16 @@ resource "ibm_cos_bucket_object" "cos_object_objectlock" {
   object_lock_retain_until_date = "2023-02-15T18:00:00Z"
   object_lock_legal_hold_status = "ON"
 }
+
+# Example with GOVERNANCE mode and bypass parameter
+resource "ibm_cos_bucket_object" "cos_object_governance" {
+  bucket_crn      = data.ibm_cos_bucket.cos_bucket.crn
+  bucket_location = data.ibm_cos_bucket.cos_bucket.bucket_region
+  key             = "object_governance.json"
+  object_lock_mode              = "GOVERNANCE"
+  object_lock_retain_until_date = "2024-12-31T23:59:59Z"
+  bypass_governance_retention   = true  # Required to update or delete objects with GOVERNANCE mode
+}
 ```
 
 # Website redirect 
@@ -128,6 +138,10 @@ Review the argument references that you can specify for your resource.
 - `endpoint_type` - (Optional, String) The type of endpoint used to access COS. Supported values are `public`, `private`, or `direct`. Default value is `public`.
 - `etag` - (Optional, String) MD5 hexdigest used to trigger updates. The only meaningful value is `filemd5("path/to/file")`.
 - `key` - (Required, Forces new resource, String) The name of an object in the COS bucket.
+- `object_lock_legal_hold_status` - (Optional, String) An object lock configuration on the object. Valid values are `ON` or `OFF`. When `ON`, prevents deletion of the object version.
+- `object_lock_mode` - (Optional, String) Retention mode to apply to the object. Valid values are `COMPLIANCE` or `GOVERNANCE`. Must be used with `object_lock_retain_until_date`.
+- `object_lock_retain_until_date` - (Optional, String) The date and time when the object lock retention expires. Must be in RFC3339 format (e.g., `2024-12-31T23:59:59Z`). Must be used with `object_lock_mode`.
+- `bypass_governance_retention` - (Optional, Bool) Allows deleting or modifying object versions locked with `GOVERNANCE` mode. Set to `true` to bypass governance-mode retention when updating or deleting objects. Default is `false`. **Note:** This parameter is required to delete or update objects with GOVERNANCE mode retention.
 - `website_redirect` - (Optional, String) Target URL for website redirect.
 
 ## Attribute reference

--- a/website/docs/r/cos_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/cos_bucket_object_lock_configuration.html.markdown
@@ -59,6 +59,25 @@ resource ibm_cos_bucket_object_lock_configuration "objectlock" {
 }
 
 ```
+
+## Example usage with GOVERNANCE mode
+
+```terraform
+resource ibm_cos_bucket_object_lock_configuration "objectlock" {
+ bucket_crn      = ibm_cos_bucket.cos_bucket.crn
+ bucket_location = ibm_cos_bucket.cos_bucket.bucket_region
+ object_lock_configuration{
+   object_lock_enabled = "Enabled"
+   object_lock_rule{
+     default_retention{
+        mode = "GOVERNANCE"
+        years = 1
+      }
+    }
+  }
+}
+
+```
 # Enabling Object Lock configuration on an existing bucket
 To enable  Object Lock configuration on an existing bucket, create a COS bucket with object versioning enabled and pass the crn of the COS bucket and location of the bucket to `ibm_cos_bucket_object_lock_configuration.bucket_crn` and `ibm_cos_bucket_object_lock_configuration.bucket_location` as shown in the example.
 
@@ -101,6 +120,22 @@ resource ibm_cos_bucket_object_lock_configuration "objectlock" {
   }
 }
 
+// To enable object lock configuration with GOVERNANCE mode and set default retention on a bucket
+
+resource ibm_cos_bucket_object_lock_configuration "objectlock" {
+bucket_crn      = ibm_cos_bucket.cos_bucket.crn
+bucket_location = ibm_cos_bucket.cos_bucket.bucket_region
+object_lock_configuration{
+ object_lock_enabled = "Enabled"
+ object_lock_rule{
+   default_retention{
+      mode = "GOVERNANCE"
+      years = 2
+    }
+  }
+}
+}
+
 
 ```
 
@@ -118,9 +153,13 @@ Review the argument references that you can specify for your resource.
   Nested scheme for `object_lock_rule`:
   - `default_retention`- (Required) Configuration block for specifying the default Object Lock retention settings for new objects placed in the specified bucket
   Nested scheme for `default_retention`:
-  - `mode`- (String)  Default Object Lock retention mode you want to apply to new objects placed in the specified bucket. Supported values: COMPLIANCE.
+  - `mode`- (String)  Default Object Lock retention mode you want to apply to new objects placed in the specified bucket. Supported values: COMPLIANCE, GOVERNANCE.
   - `days`- (Int) Specifies number of days after which the object can be deleted from the COS bucket.
   - `years`- (Int) Specifies number of years after which the object can be deleted from the COS bucket.
+
+**Note:**
+- **COMPLIANCE mode**: Objects cannot be overwritten or deleted by any user, including the root user. When an object is locked in compliance mode, its retention mode can't be changed, and its retention period can't be shortened. Compliance mode helps ensure that an object version can't be overwritten or deleted for the duration of the retention period.
+- **GOVERNANCE mode**: Users with special permissions can alter the retention settings or delete the object if necessary. Governance mode allows you to protect objects against deletion by most users, but you can still grant some users permission to alter the retention settings or delete the object if necessary.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION

Output from acceptance testing:


```
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Days
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Days (79.46s)
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Years
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Governance_Mode_Years (71.57s)
PASS
ok  	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	152.548s
=== RUN   TestAccIBMCosBucket_Objectlock_Configuration_Governance_Shorten_Retention_With_Bypass
--- PASS: TestAccIBMCosBucket_Objectlock_Configuration_Governance_Shorten_Retention_With_Bypass (30.20s)
PASS
ok  	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	31.584s
=== RUN   TestAccIBMCOSBucketObject_Governance_Shorten_Retention_Without_Bypass_Negative
--- PASS: TestAccIBMCOSBucketObject_Governance_Shorten_Retention_Without_Bypass_Negative (147.96s)
=== RUN   TestAccIBMCOSBucketObject_Governance_Shorten_Retention_With_Bypass_Positive
--- PASS: TestAccIBMCOSBucketObject_Governance_Shorten_Retention_With_Bypass_Positive (45.77s)
PASS
ok  	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	195.068s
=== RUN   TestAccIBMCOSBucketObject_basic
--- PASS: TestAccIBMCOSBucketObject_basic (82.57s)
PASS
ok  	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	83.990s
=== RUN   TestAccIBMCosBucket_Basic
--- PASS: TestAccIBMCosBucket_Basic (81.61s)
=== RUN   TestAccIBMCosBucket_Basic_Single_Site_Location
--- PASS: TestAccIBMCosBucket_Basic_Single_Site_Location (61.94s)
PASS
ok  	[github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos](http://github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cos)	144.867s
```
