### PR TITLE
fix(logs_alert): add Computed to filter_type and incident_settings fields

### DIFF
--- a/ibm/service/logs/resource_ibm_logs_alert.go
+++ b/ibm/service/logs/resource_ibm_logs_alert.go
@@ -1398,6 +1398,7 @@ func ResourceIbmLogsAlert() *schema.Resource {
 						"filter_type": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The type of the filter.",
 						},
 					},
@@ -1528,17 +1529,20 @@ func ResourceIbmLogsAlert() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Description: "Incident settings, will create the incident based on this configuration.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"retriggering_period_seconds": &schema.Schema{
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Computed:    true,
 							Description: "The retriggering period of the alert in seconds.",
 						},
 						"notify_on": &schema.Schema{
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "Notify on setting.",
 						},
 						"use_as_notification_settings": &schema.Schema{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/logs TESTARGS='-run=TestAccIbmLogsAlert'
```

Test failures are pre-existing and unrelated to this change:
```
summary: 'CreateAlertWithContext failed: ''notification_groups'' field cannot be set for ''new_value'' alerts'
```

The schema change (adding `Computed: true` to `filter_type` and `incident_settings fields`)
was validated manually via OpenTofu plan/apply — perpetual diff no longer occurs.

## Summary

Add `Computed: true` to `filter_type` and `incident_settings` block (and some nested fields) in `ibm_logs_alert`.

These fields are populated by the API with defaults when not set by the user. Without **Computed**, Terraform treats API-returned values as drift and plans to remove them on every subsequent apply.


