### PR TITLE
fix(cis): Allow import of CIS instances with EOM plans

### DIFF
--- a/ibm/service/cis/data_source_ibm_cis.go
+++ b/ibm/service/cis/data_source_ibm_cis.go
@@ -4,9 +4,9 @@
 package cis
 
 import (
+	"log"
 	"net/url"
 	"reflect"
-	"strings"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -186,13 +186,13 @@ func dataSourceIBMCISInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 		ID: instance.ResourcePlanID,
 	}
-	plan, _, err := globalClient.GetCatalogEntry(&planOptions)
+	plan, planResp, err := globalClient.GetCatalogEntry(&planOptions)
 	if err != nil {
-		// Handle EOM (End-of-Market) plans that are no longer in the Global Catalog
-		// For existing instances with EOM plans, use the plan ID directly
-		// This allows data source to work with existing instances even if the plan is deprecated
-		if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "Not authorized") {
-			d.Set("plan", *instance.ResourcePlanID)
+		if planResp != nil && planResp.StatusCode == 403 {
+			log.Printf("[WARN] Unable to retrieve plan name from catalog (likely EOM plan): %s. Falling back to plan ID.", err)
+			if instance.ResourcePlanID != nil {
+				d.Set("plan", *instance.ResourcePlanID)
+			}
 		} else {
 			return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
 		}

--- a/ibm/service/cis/data_source_ibm_cis.go
+++ b/ibm/service/cis/data_source_ibm_cis.go
@@ -6,6 +6,7 @@ package cis
 import (
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -187,9 +188,17 @@ func dataSourceIBMCISInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	plan, _, err := globalClient.GetCatalogEntry(&planOptions)
 	if err != nil {
-		return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
+		// Handle EOM (End-of-Market) plans that are no longer in the Global Catalog
+		// For existing instances with EOM plans, use the plan ID directly
+		// This allows data source to work with existing instances even if the plan is deprecated
+		if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "Not authorized") {
+			d.Set("plan", *instance.ResourcePlanID)
+		} else {
+			return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
+		}
+	} else {
+		d.Set("plan", plan.Name)
 	}
-	d.Set("plan", plan.Name)
 
 	d.Set(flex.ResourceName, instance.Name)
 	d.Set(flex.ResourceCRN, instance.CRN)

--- a/ibm/service/cis/resource_ibm_cis.go
+++ b/ibm/service/cis/resource_ibm_cis.go
@@ -312,9 +312,18 @@ func ResourceIBMCISInstanceRead(d *schema.ResourceData, meta interface{}) error 
 
 	servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
 	if err != nil {
-		return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
+		// Handle EOM (End-of-Market) plans that are no longer in the Global Catalog
+		// For existing instances with EOM plans, use the plan ID directly
+		// This allows import and management of existing instances even if the plan is deprecated
+		if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 403 {
+			log.Printf("[WARN] Unable to retrieve plan name from catalog (likely EOM plan): %s. Using plan ID instead.", err)
+			d.Set("plan", *instance.ResourcePlanID)
+		} else {
+			return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
+		}
+	} else {
+		d.Set("plan", servicePlan)
 	}
-	d.Set("plan", servicePlan)
 
 	d.Set(flex.ResourceName, *instance.Name)
 	d.Set(flex.ResourceCRN, *instance.CRN)

--- a/ibm/service/cis/resource_ibm_cis.go
+++ b/ibm/service/cis/resource_ibm_cis.go
@@ -310,14 +310,20 @@ func ResourceIBMCISInstanceRead(d *schema.ResourceData, meta interface{}) error 
 
 	d.Set("service", "internet-svcs")
 
+	// Known EOM plan IDs that are no longer resolvable via the Global Catalog.
+	cisEOMPlans := map[string]string{
+		"d70686a9-bce1-4015-ae06-db8f027d09e0": "standard",
+	}
+
 	servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
 	if err != nil {
-		// Handle EOM (End-of-Market) plans that are no longer in the Global Catalog
-		// For existing instances with EOM plans, use the plan ID directly
-		// This allows import and management of existing instances even if the plan is deprecated
 		if apiErr, ok := err.(bmxerror.RequestFailure); ok && apiErr.StatusCode() == 403 {
-			log.Printf("[WARN] Unable to retrieve plan name from catalog (likely EOM plan): %s. Using plan ID instead.", err)
-			d.Set("plan", *instance.ResourcePlanID)
+			if planName, known := cisEOMPlans[*instance.ResourcePlanID]; known {
+				d.Set("plan", planName)
+			} else {
+				log.Printf("[WARN] Unable to retrieve plan name from catalog (likely EOM plan): %s. Using plan ID instead.", err)
+				d.Set("plan", *instance.ResourcePlanID)
+			}
 		} else {
 			return flex.FmtErrorf("[ERROR] Error retrieving plan: %s", err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

```
$ make testacc TEST=./ibm/service/cis TESTARGS='-run=TestAccIBMCisDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cis -v -run=TestAccIBMCisDataSource_basic -timeout 700m 

.
.
.

=== RUN   TestAccIBMCisDataSource_basic
--- PASS: TestAccIBMCisDataSource_basic (27.94s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis	29.726s
...
```
