### PR TITLE
Update: Pull in latest icr SDK version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|.*.map|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-02-15T18:15:37Z",
+  "generated_at": "2026-04-02T07:59:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -627,6 +627,16 @@
         "verified_result": null
       }
     ],
+    "examples/ibm-logs/terraform.tfvars.template": [
+      {
+        "hashed_secret": "12e532ff4ad20c8604dbc101ef3de2dbc644b4a5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "examples/ibm-partner-center-sell/README.md": [
       {
         "hashed_secret": "82544d75d1e4f24e6c8b7dc9adaf73130575e3db",
@@ -906,7 +916,7 @@
         "hashed_secret": "9184b0c38101bf24d78b2bb0d044deb1d33696fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 152,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -914,7 +924,7 @@
         "hashed_secret": "c427f185ddcb2440be9b77c8e45f1cd487a2e790",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1590,
+        "line_number": 1602,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -922,7 +932,7 @@
         "hashed_secret": "1f614c2eb6b3da22d89bd1b9fd47d7cb7c8fc670",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3918,
+        "line_number": 3953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -930,7 +940,7 @@
         "hashed_secret": "7abfce65b8504403afc25c9790f358d513dfbcc6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3931,
+        "line_number": 3966,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -938,7 +948,7 @@
         "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4005,
+        "line_number": 4040,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -946,7 +956,7 @@
         "hashed_secret": "0c2d85bf9a9b1579b16f220a4ea8c3d62b2e24b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4025,
+        "line_number": 4060,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -984,7 +994,7 @@
         "hashed_secret": "2aae003e7f01a852f797506f32c9e209cb19c15c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2592,
+        "line_number": 2599,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -992,7 +1002,7 @@
         "hashed_secret": "c8b6f5ef11b9223ac35a5663975a466ebe7ebba9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2774,
+        "line_number": 2781,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1000,7 +1010,7 @@
         "hashed_secret": "8abf4899c01104241510ba87685ad4de76b0c437",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2780,
+        "line_number": 2787,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1036,6 +1046,16 @@
         "is_verified": false,
         "line_number": 429,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/accountmanagement/data_source_ibm_account_test.go": [
+      {
+        "hashed_secret": "e77cef297aa4322b376276a8e22098f9979d81fe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -3890,7 +3910,7 @@
         "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1696,
+        "line_number": 1699,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3926,7 +3946,7 @@
         "hashed_secret": "a2277f800807615d59cc7925271ea2c54de5fb96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2604,
+        "line_number": 2612,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3934,7 +3954,7 @@
         "hashed_secret": "b5366a2d2ac98dae978423083f8b09e5cddc705d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3461,
+        "line_number": 3478,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/IBM/cloudant-go-sdk v0.8.0
 	github.com/IBM/code-engine-go-sdk v0.0.0-20260304141634-773f5cd0b0ed
 	github.com/IBM/configuration-aggregator-go-sdk v0.0.2
-	github.com/IBM/container-registry-go-sdk v1.2.0
+	github.com/IBM/container-registry-go-sdk v1.3.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6
 	github.com/IBM/dra-go-sdk v0.0.0-20251210070042-5072d22c26d0
 	github.com/IBM/event-notifications-go-admin-sdk v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,12 @@ github.com/IBM/configuration-aggregator-go-sdk v0.0.2 h1:IRDIrGyLNXq+wQRj/js/Bzr
 github.com/IBM/configuration-aggregator-go-sdk v0.0.2/go.mod h1:Ql2N5j4d4Pj1/GoLzFwZw0DomCG4b1O33kKs3TZ+O+I=
 github.com/IBM/container-registry-go-sdk v1.2.0 h1:DX08GSKFvgCcUne9rWwb9+UttevV4WiG2YfEvKjY5HA=
 github.com/IBM/container-registry-go-sdk v1.2.0/go.mod h1:fE1iNfehccXBx1wmX/RUWksDteWOOOXJFtHWYlT4zKk=
+github.com/IBM/container-registry-go-sdk v1.2.2 h1:jOiga5+kBD0/i1JldA9HL82Z8B3+80rjgu9vVofOfu0=
+github.com/IBM/container-registry-go-sdk v1.2.2/go.mod h1:Hl3fxl82IPZXPINwn1XCIhS2UUKf2rNXOxCGhGB+YOE=
+github.com/IBM/container-registry-go-sdk v1.2.3 h1:vByOhtfs8w+bnVeyvqgZawmYQwiqGYNUKr6fO4xeQ6Q=
+github.com/IBM/container-registry-go-sdk v1.2.3/go.mod h1:EaWX5/MXNpKyib47BMOddO3dK6om/xN6Lz5oQlzX9gU=
+github.com/IBM/container-registry-go-sdk v1.3.0 h1:hRyLabAFPBDb67hYJOCdz6g+7Cc7FnQDb6foey12xvU=
+github.com/IBM/container-registry-go-sdk v1.3.0/go.mod h1:EaWX5/MXNpKyib47BMOddO3dK6om/xN6Lz5oQlzX9gU=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6 h1:CdJWGVzcHngf6un5N2C4KDgIzqViA2Md6pSeZNZzsLQ=
 github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.6/go.mod h1:Iibf+4gRasEZHakDgnMm7TOX87xex0L+DfghUclcmcg=
 github.com/IBM/dra-go-sdk v0.0.0-20251210070042-5072d22c26d0 h1:XMWoX+WicTwmve5Rn2Gmt3W/7KRA7nxq9cT0Dr8mQRk=
@@ -639,6 +645,7 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Add support for in-che ICR region

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/registry TESTARGS='-run="TestAccIBMCr.*"'         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/registry -v -run="TestAccIBMCr.*" -timeout 700m 

=== RUN   TestAccIBMCrNamespacesDataSourceBasic
--- PASS: TestAccIBMCrNamespacesDataSourceBasic (24.20s)
=== RUN   TestAccIBMCrNamespaceBasic
--- PASS: TestAccIBMCrNamespaceBasic (27.54s)
=== RUN   TestAccIBMCrNamespaceAllArgs
--- PASS: TestAccIBMCrNamespaceAllArgs (36.48s)
=== RUN   TestAccIBMCrRetentionPolicyAllArgs
--- PASS: TestAccIBMCrRetentionPolicyAllArgs (26.97s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/registry        117.060s
...
```
