### PR TITLE
Fix: Have single source of truth for ICR urls

### DIFF
--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2354,10 +2354,8 @@ func (c *Config) ClientSession() (interface{}, error) {
 		containerRegistryClientURL = containerregistryv1.DefaultServiceURL
 	}
 	if c.Visibility == "private" || c.Visibility == "public-and-private" {
-		containerRegistryClientURL, err = GetPrivateServiceURLForRegion(c.Region)
-		if err != nil {
-			containerRegistryClientURL, _ = GetPrivateServiceURLForRegion("global")
-		}
+		containerRegistryClientURL = fmt.Sprintf("private.%s", containerRegistryClientURL)
+
 	}
 	if fileMap != nil && c.Visibility != "public-and-private" {
 		containerRegistryClientURL = fileFallBack(fileMap, c.Visibility, "IBMCLOUD_CR_API_ENDPOINT", c.Region, containerRegistryClientURL)

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -2354,7 +2354,7 @@ func (c *Config) ClientSession() (interface{}, error) {
 		containerRegistryClientURL = containerregistryv1.DefaultServiceURL
 	}
 	if c.Visibility == "private" || c.Visibility == "public-and-private" {
-		containerRegistryClientURL = fmt.Sprintf("private.%s", containerRegistryClientURL)
+		containerRegistryClientURL = strings.Replace(containerRegistryClientURL, "https://", "https://private.", 1)
 
 	}
 	if fileMap != nil && c.Visibility != "public-and-private" {

--- a/ibm/conns/utils.go
+++ b/ibm/conns/utils.go
@@ -4,8 +4,6 @@
 package conns
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -13,26 +11,4 @@ import (
 func IsResourceTimeoutError(err error) bool {
 	timeoutErr, ok := err.(*resource.TimeoutError)
 	return ok && timeoutErr.LastError == nil
-}
-func GetPrivateServiceURLForRegion(region string) (string, error) {
-	var endpoints = map[string]string{
-		"us-south":   "https://private.us.icr.io",  // us-south
-		"uk-south":   "https://private.uk.icr.io",  // uk-south
-		"eu-gb":      "https://private.uk.icr.io",  // eu-gb
-		"eu-central": "https://private.de.icr.io",  // eu-central
-		"eu-de":      "https://private.de.icr.io",  // eu-de
-		"ap-north":   "https://private.jp.icr.io",  // ap-north
-		"jp-tok":     "https://private.jp.icr.io",  // jp-tok
-		"ap-south":   "https://private.au.icr.io",  // ap-south
-		"au-syd":     "https://private.au.icr.io",  // au-syd
-		"global":     "https://private.icr.io",     // global
-		"jp-osa":     "https://private.jp2.icr.io", // jp-osa
-		"ca-tor":     "https://private.ca.icr.io",  // ca-tor
-		"br-sao":     "https://private.br.icr.io",  // br-sao
-	}
-
-	if url, ok := endpoints[region]; ok {
-		return url, nil
-	}
-	return "", fmt.Errorf("service URL for region '%s' not found", region)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6737


This PR changes the behaviour to constructing the private ICR endpoint based on the public one. This is deterministic and means that it is only maintained in one place.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/registry TESTARGS='-run="TestAccIBMCr.*"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/registry -v -run="TestAccIBMCr.*" -timeout 700m 
=== RUN   TestAccIBMCrNamespacesDataSourceBasic
--- PASS: TestAccIBMCrNamespacesDataSourceBasic (37.75s)
=== RUN   TestAccIBMCrNamespaceBasic
--- PASS: TestAccIBMCrNamespaceBasic (46.64s)
=== RUN   TestAccIBMCrNamespaceAllArgs
--- PASS: TestAccIBMCrNamespaceAllArgs (69.03s)
=== RUN   TestAccIBMCrRetentionPolicyAllArgs
--- PASS: TestAccIBMCrRetentionPolicyAllArgs (38.95s)
PASS

```
