### PR TITLE
in satellite cluster resource, return if getcluster or getworkerpool fails

### DIFF
--- a/ibm/service/satellite/resource_ibm_satellite_cluster.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster.go
@@ -498,11 +498,8 @@ func resourceIBMSatelliteClusterCreate(d *schema.ResourceData, meta interface{})
 		}
 
 		cluster, response, err := satClient.GetCluster(getSatClusterOptions)
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error in retreiving ibm satellite cluster : %s", response)
-		}
-		if cluster == nil {
-			return fmt.Errorf("[ERROR] Error in retreiving ibm satellite cluster, cluster is nil: %s", err)
+		if err != nil || cluster == nil {
+			return fmt.Errorf("[ERROR] Error in retreiving ibm satellite cluster : %w - %s", err, GetDetailedResultString(response))
 		}
 
 		oldList, newList := d.GetChange("tags")
@@ -583,11 +580,8 @@ func resourceIBMSatelliteClusterRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	workerPool, response, err := satClient.GetWorkerPool(getWorkerPoolOptions)
-	if err != nil {
-		return fmt.Errorf("[ERROR] An error occured while retrieving default workerpool: %s", err)
-	}
-	if workerPool == nil {
-		return fmt.Errorf("[ERROR] An error occured while retrieving default workerpool, workerPool is nil: %s", response)
+	if err != nil || workerPool == nil {
+		return fmt.Errorf("[ERROR] An error occured while retrieving default workerpool : %w - %s", err, GetDetailedResultString(response))
 	}
 
 	tags, err := flex.GetTagsUsingCRN(meta, *cluster.Crn)
@@ -1009,4 +1003,14 @@ func satelliteClusterVersionRefreshFunc(client v1.Clusters, instanceID string, d
 		}
 		return clusterFields, clusterNormal, nil
 	}
+}
+
+func GetDetailedResultString(response *core.DetailedResponse) string {
+	if response != nil {
+		if response.GetResult() != nil {
+			return fmt.Sprintf("%v", response.GetResult())
+		}
+		return string(response.GetRawResult())
+	}
+	return ""
 }

--- a/ibm/service/satellite/resource_ibm_satellite_cluster.go
+++ b/ibm/service/satellite/resource_ibm_satellite_cluster.go
@@ -498,9 +498,11 @@ func resourceIBMSatelliteClusterCreate(d *schema.ResourceData, meta interface{})
 		}
 
 		cluster, response, err := satClient.GetCluster(getSatClusterOptions)
-		if err != nil || cluster == nil {
-			log.Printf(
-				"Error in retreiving ibm satellite cluster : %s\n%s", err, response)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error in retreiving ibm satellite cluster : %s", response)
+		}
+		if cluster == nil {
+			return fmt.Errorf("[ERROR] Error in retreiving ibm satellite cluster, cluster is nil: %s", err)
 		}
 
 		oldList, newList := d.GetChange("tags")
@@ -581,9 +583,11 @@ func resourceIBMSatelliteClusterRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	workerPool, response, err := satClient.GetWorkerPool(getWorkerPoolOptions)
-	if err != nil || workerPool == nil {
-		log.Printf(
-			"An error occured while retrieving default workerpool : %s\n%s", err, response)
+	if err != nil {
+		return fmt.Errorf("[ERROR] An error occured while retrieving default workerpool: %s", err)
+	}
+	if workerPool == nil {
+		return fmt.Errorf("[ERROR] An error occured while retrieving default workerpool, workerPool is nil: %s", response)
 	}
 
 	tags, err := flex.GetTagsUsingCRN(meta, *cluster.Crn)


### PR DESCRIPTION
https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6740

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
