### PR TITLE
Read crash on power volumes datasource

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -261,7 +261,6 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[str
 	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
 		l := map[string]any{
-			Attr_Auxiliary:            *i.Auxiliary,
 			Attr_AuxiliaryVolumeName:  i.AuxVolumeName,
 			Attr_Bootable:             *i.Bootable,
 			Attr_ConsistencyGroupName: i.ConsistencyGroupName,
@@ -288,6 +287,9 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[str
 			Attr_VolumeType:           i.VolumeType,
 			Attr_WWN:                  *i.Wwn,
 		}
+		if i.Auxiliary != nil {
+			l[Attr_Auxiliary] = *i.Auxiliary
+		}
 		if i.Crn != "" {
 			l[Attr_CRN] = i.Crn
 			tags, err := flex.GetGlobalTagsUsingCRN(meta, string(i.Crn), "", UserTagType)
@@ -301,6 +303,9 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[str
 		}
 		if i.FreezeTime != nil {
 			l[Attr_FreezeTime] = i.FreezeTime.String()
+		}
+		if i.ReplicationEnabled != nil {
+			l[Attr_ReplicationEnabled] = *i.ReplicationEnabled
 		}
 		if len(i.ReplicationSites) > 0 {
 			l[Attr_ReplicationSites] = i.ReplicationSites

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -211,7 +211,9 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.SetId(*volumedata.VolumeID)
-	d.Set(Attr_Auxiliary, volumedata.Auxiliary)
+	if volumedata.Auxiliary != nil {
+		d.Set(Attr_Auxiliary, volumedata.Auxiliary)
+	}
 	d.Set(Attr_AuxiliaryVolumeName, volumedata.AuxVolumeName)
 	d.Set(Attr_Bootable, volumedata.Bootable)
 	d.Set(Attr_ConsistencyGroupName, volumedata.ConsistencyGroupName)
@@ -236,7 +238,9 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_Name, volumedata.Name)
 	d.Set(Attr_OutOfBandDeleted, volumedata.OutOfBandDeleted)
 	d.Set(Attr_PrimaryRole, volumedata.PrimaryRole)
-	d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
+	if volumedata.ReplicationEnabled != nil {
+		d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
+	}
 	if len(volumedata.ReplicationSites) > 0 {
 		d.Set(Attr_ReplicationSites, volumedata.ReplicationSites)
 	}

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -211,9 +211,7 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.SetId(*volumedata.VolumeID)
-	if volumedata.Auxiliary != nil {
-		d.Set(Attr_Auxiliary, volumedata.Auxiliary)
-	}
+	d.Set(Attr_Auxiliary, volumedata.Auxiliary)
 	d.Set(Attr_AuxiliaryVolumeName, volumedata.AuxVolumeName)
 	d.Set(Attr_Bootable, volumedata.Bootable)
 	d.Set(Attr_ConsistencyGroupName, volumedata.ConsistencyGroupName)
@@ -238,9 +236,7 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_Name, volumedata.Name)
 	d.Set(Attr_OutOfBandDeleted, volumedata.OutOfBandDeleted)
 	d.Set(Attr_PrimaryRole, volumedata.PrimaryRole)
-	if volumedata.ReplicationEnabled != nil {
-		d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
-	}
+	d.Set(Attr_ReplicationEnabled, volumedata.ReplicationEnabled)
 	if len(volumedata.ReplicationSites) > 0 {
 		d.Set(Attr_ReplicationSites, volumedata.ReplicationSites)
 	}

--- a/ibm/service/power/data_source_ibm_pi_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_volumes.go
@@ -214,7 +214,6 @@ func flattenVolumes(list []*models.VolumeReference, meta any) []map[string]any {
 	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
 		volume := map[string]any{
-			Attr_Auxiliary:            *i.Auxiliary,
 			Attr_AuxiliaryVolumeName:  i.AuxVolumeName,
 			Attr_Bootable:             *i.Bootable,
 			Attr_ConsistencyGroupName: i.ConsistencyGroupName,
@@ -229,7 +228,6 @@ func flattenVolumes(list []*models.VolumeReference, meta any) []map[string]any {
 			Attr_Name:                 *i.Name,
 			Attr_OutOfBandDeleted:     i.OutOfBandDeleted,
 			Attr_PrimaryRole:          i.PrimaryRole,
-			Attr_ReplicationEnabled:   *i.ReplicationEnabled,
 			Attr_ReplicationStatus:    i.ReplicationStatus,
 			Attr_ReplicationType:      i.ReplicationType,
 			Attr_Shareable:            *i.Shareable,
@@ -239,8 +237,14 @@ func flattenVolumes(list []*models.VolumeReference, meta any) []map[string]any {
 			Attr_VolumeType:           i.VolumeType,
 			Attr_WWN:                  *i.Wwn,
 		}
+		if i.Auxiliary != nil {
+			volume[Attr_Auxiliary] = *i.Auxiliary
+		}
 		if i.FreezeTime != nil {
 			volume[Attr_FreezeTime] = i.FreezeTime.String()
+		}
+		if i.ReplicationEnabled != nil {
+			volume[Attr_ReplicationEnabled] = *i.ReplicationEnabled
 		}
 		if len(i.ReplicationSites) > 0 {
 			volume[Attr_ReplicationSites] = i.ReplicationSites


### PR DESCRIPTION
Attr_Auxiliary and Attr_ReplicationEnabled are optional to return from the swagger so they may not come back in the response. We should have nil checks before reading from them.

```
--- PASS: TestAccIBMPIInstanceDataSource_basic (28.26s)
PASS

--- PASS: TestAccIBMPIVolumesDataSourceBasic (89.45s)
PASS
```