### PR TITLE
fix: address go vet issues and fmt formatting for Go 1.26.1

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,7 @@ github.com/IBM/mqcloud-go-sdk v0.4.0 h1:BuZNXA6iYEg5OEPr13CMGrhH0ew4rH/4L56b1nFt
 github.com/IBM/mqcloud-go-sdk v0.4.0/go.mod h1:7zigCUz6k3eRrNE8KOcDkY72oPppEmoQifF+SB0NPRM=
 github.com/IBM/networking-go-sdk v0.53.4 h1:XDGOhavZocjVfItgcaT7/SFqB8zT2kznYuJ9LXkz/ug=
 github.com/IBM/networking-go-sdk v0.53.4/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
-github.com/IBM/platform-services-go-sdk v0.97.2 h1:CdiLSFB0+oaAsucgVnpwn31YTAr47qFROPes4zXJalk=
-github.com/IBM/platform-services-go-sdk v0.97.2/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
+github.com/IBM/platform-services-go-sdk v0.97.4 h1:UiHTDanRY+Laydss68GFLHqoOy4l7VCj0dBNFgdGlYU=
 github.com/IBM/platform-services-go-sdk v0.97.4/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
 github.com/IBM/project-go-sdk v0.4.0 h1:72pEtVHJn434+MYRawER7Hk/kblapdfotoLBBhjv/jo=
 github.com/IBM/project-go-sdk v0.4.0/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=

--- a/ibm/conns/config.go
+++ b/ibm/conns/config.go
@@ -130,6 +130,7 @@ import (
 	"github.com/IBM/continuous-delivery-go-sdk/v2/cdtektonpipelinev2"
 	"github.com/IBM/continuous-delivery-go-sdk/v2/cdtoolchainv2"
 	"github.com/IBM/dra-go-sdk/drautomationservicev1"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/event-notifications-go-admin-sdk/eventnotificationsv1"
 	"github.com/IBM/eventstreams-go-sdk/pkg/adminrestv1"
 	"github.com/IBM/eventstreams-go-sdk/pkg/schemaregistryv1"
@@ -139,7 +140,6 @@ import (
 	"github.com/IBM/platform-services-go-sdk/partnercentersellv1"
 	scc "github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3"
 	"github.com/IBM/secrets-manager-go-sdk/v2/secretsmanagerv2"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 // RetryAPIDelay - retry api delay

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -1152,7 +1152,7 @@ func Provider() *schema.Provider {
 
 			// NEW Data Sources
 			"ibm_pdr_dr_summary_response": drautomationservice.DataSourceIBMPdrDrSummaryResponse(),
-			"ibm_pdr_powervs_workspaces":   drautomationservice.DataSourceIBMPdrPowervsWorkspace(),
+			"ibm_pdr_powervs_workspaces":  drautomationservice.DataSourceIBMPdrPowervsWorkspace(),
 			"ibm_pdr_event":               drautomationservice.DataSourceIBMPdrEvent(),
 			"ibm_pdr_events":              drautomationservice.DataSourceIBMPdrEvents(),
 			"ibm_pdr_dr_locations":        drautomationservice.DataSourceIBMPdrDrLocations(),
@@ -1171,11 +1171,11 @@ func Provider() *schema.Provider {
 			"ibm_pdr_get_grs_location_pairs":  drautomationservice.DataSourceIBMPdrGetGrsLocationPairs(),
 
 			// PHA service
-			"ibm_pha_last_operation":     powerhaautomationservice.DataSourceIBMPhaLastOperation(),
+			"ibm_pha_last_operation":      powerhaautomationservice.DataSourceIBMPhaLastOperation(),
 			"ibm_pha_supported_locations": powerhaautomationservice.DataSourceIBMPhaSupportedLocation(),
 			"ibm_pha_powervs_workspaces":  powerhaautomationservice.DataSourceIBMPhaPowervsWorkspace(),
-			"ibm_pha_cluster_nodes":      powerhaautomationservice.DataSourceIBMPhaClusterNodes(),
-			"ibm_pha_deployment":         powerhaautomationservice.DataSourceIBMPhaDeployment(),
+			"ibm_pha_cluster_nodes":       powerhaautomationservice.DataSourceIBMPhaClusterNodes(),
+			"ibm_pha_deployment":          powerhaautomationservice.DataSourceIBMPhaDeployment(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -2076,7 +2076,7 @@ func Validator() validate.ValidatorDict {
 				"ibm_iam_custom_role":                            iampolicy.ResourceIBMIAMCustomRoleValidator(),
 				"ibm_pha_api_key":                                powerhaautomationservice.ResourceIBMPhaAPIKeyValidator(),
 				"ibm_pha_deployment":                             powerhaautomationservice.ResourceIBMPhaClusterNodesValidator(),
-				"ibm_pha_cluster_nodes" :                         powerhaautomationservice.ResourceIBMPhaDeploymentValidator(),
+				"ibm_pha_cluster_nodes":                          powerhaautomationservice.ResourceIBMPhaDeploymentValidator(),
 				"ibm_cis_healthcheck":                            cis.ResourceIBMCISHealthCheckValidator(),
 				"ibm_cis_rate_limit":                             cis.ResourceIBMCISRateLimitValidator(),
 				"ibm_cis":                                        cis.ResourceIBMCISValidator(),

--- a/ibm/service/drautomationservice/data_source_ibm_pdr_dr_summary_response.go
+++ b/ibm/service/drautomationservice/data_source_ibm_pdr_dr_summary_response.go
@@ -24,7 +24,6 @@ import (
 func dataSourceIBMPdrDrSummaryResponseCommon() *schema.Resource {
 	return &schema.Resource{
 
-
 		Schema: map[string]*schema.Schema{
 			"instance_id": &schema.Schema{
 				Type:        schema.TypeString,

--- a/ibm/service/drautomationservice/data_source_ibm_pdr_events.go
+++ b/ibm/service/drautomationservice/data_source_ibm_pdr_events.go
@@ -255,7 +255,7 @@ func dataSourceIBMPdrGetEventsRead(ctx context.Context, d *schema.ResourceData, 
 	return dataSourceIBMPdrEventsReadCommon(ctx, d, meta, "ibm_pdr_get_events")
 }
 
-func dataSourceIBMPdrEventsReadCommon(context context.Context, d *schema.ResourceData, meta interface{},dsname string) diag.Diagnostics {
+func dataSourceIBMPdrEventsReadCommon(context context.Context, d *schema.ResourceData, meta interface{}, dsname string) diag.Diagnostics {
 	drAutomationServiceClient, err := meta.(conns.ClientSession).DrAutomationServiceV1()
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) "+dsname, "read", "initialize-client")

--- a/ibm/service/drautomationservice/data_source_ibm_pdr_grs_location_pairs.go
+++ b/ibm/service/drautomationservice/data_source_ibm_pdr_grs_location_pairs.go
@@ -48,8 +48,6 @@ func dataSourceIBMPdrGrsLocationPairsCommon() *schema.Resource {
 	}
 }
 
-
-
 func DataSourceIBMPdrGrsLocationPairs() *schema.Resource {
 	res := dataSourceIBMPdrGrsLocationPairsCommon()
 	res.ReadContext = dataSourceIBMPdrGrsLocationPairsRead

--- a/ibm/service/drautomationservice/data_source_ibm_pdr_last_operation_test.go
+++ b/ibm/service/drautomationservice/data_source_ibm_pdr_last_operation_test.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.108.0-56772134-20251111-102802
-*/
+ */
 
 package drautomationservice_test
 
@@ -59,4 +59,3 @@ func testAccCheckIBMPdrLastOperationDataSourceConfigBasic() string {
 		}
 	`)
 }
-

--- a/ibm/service/drautomationservice/data_source_ibm_pdr_machine_types_test.go
+++ b/ibm/service/drautomationservice/data_source_ibm_pdr_machine_types_test.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.108.0-56772134-20251111-102802
-*/
+ */
 
 package drautomationservice_test
 
@@ -43,4 +43,3 @@ func testAccCheckIBMPdrMachineTypesDataSourceConfigBasic() string {
 		}
 	`)
 }
-

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_cluster_nodes.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_cluster_nodes.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
-*/
+ */
 
 package powerhaautomationservice
 
@@ -178,7 +178,7 @@ func dataSourceIBMPhaClusterNodesRead(context context.Context, d *schema.Resourc
 		getClusterNodeOptions.SetIfNoneMatch(d.Get("if_none_match").(string))
 	}
 
-    clusterNodeResponse, response, err := powerhaAutomationServiceClient.GetClusterNodeWithContext(context, getClusterNodeOptions)
+	clusterNodeResponse, response, err := powerhaAutomationServiceClient.GetClusterNodeWithContext(context, getClusterNodeOptions)
 	if err != nil {
 		detailedMsg := fmt.Sprintf("GetClusterNodeWithContext failed: %s", err.Error())
 

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_cluster_nodes_test.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_cluster_nodes_test.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
-*/
+ */
 
 package powerhaautomationservice_test
 
@@ -14,11 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
-	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
 func TestAccIBMPhaClusterNodesDataSourceBasic(t *testing.T) {

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_deployment.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_deployment.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
-*/
+ */
 
 package powerhaautomationservice
 
@@ -17,8 +17,8 @@ import (
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
-	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func DataSourceIBMPhaDeployment() *schema.Resource {

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_deployment_test.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_deployment_test.go
@@ -15,9 +15,9 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 func TestAccIBMPhaDeploymentDataSourceBasic(t *testing.T) {

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_powervs_workspaces_test.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_powervs_workspaces_test.go
@@ -15,9 +15,9 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 func TestAccIBMPhaGetPowervsWorkspaceDataSourceBasic(t *testing.T) {

--- a/ibm/service/powerhaautomationservice/data_source_ibm_pha_supported_locations_test.go
+++ b/ibm/service/powerhaautomationservice/data_source_ibm_pha_supported_locations_test.go
@@ -15,9 +15,9 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 func TestAccIBMPhaSupportedLocationDataSourceBasic(t *testing.T) {

--- a/ibm/service/powerhaautomationservice/resource_ibm_pha_api_key.go
+++ b/ibm/service/powerhaautomationservice/resource_ibm_pha_api_key.go
@@ -18,8 +18,8 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
-	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func ResourceIBMPhaAPIKey() *schema.Resource {
@@ -51,13 +51,13 @@ func ResourceIBMPhaAPIKey() *schema.Resource {
 				Description:  "ETag for conditional requests (optional).",
 			},
 			"api_key": &schema.Schema{
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Sensitive:        true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				Sensitive: true,
 				// DiffSuppressFunc: flex.ApplyOnce,
-				ValidateFunc:     validate.InvokeValidator("ibm_pha_api_key", "api_key"),
-				Description:      "The API key associated with the request.",
+				ValidateFunc: validate.InvokeValidator("ibm_pha_api_key", "api_key"),
+				Description:  "The API key associated with the request.",
 			},
 			"id": &schema.Schema{
 				Type:        schema.TypeString,

--- a/ibm/service/powerhaautomationservice/resource_ibm_pha_cluster_nodes.go
+++ b/ibm/service/powerhaautomationservice/resource_ibm_pha_cluster_nodes.go
@@ -20,8 +20,8 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
-	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func ResourceIBMPhaClusterNodes() *schema.Resource {
@@ -505,8 +505,7 @@ func resourceIBMPhaClusterNodesUpdate(ctx context.Context, d *schema.ResourceDat
 	// -------------------------
 	removed := oldSet.Difference(newSet)
 	if len(removed.List()) > 1 {
-		msg := fmt.Sprintf("Only 1 VM can be deleted at a time")
-		return diag.FromErr(fmt.Errorf(msg))
+		return diag.FromErr(fmt.Errorf("Only 1 VM can be deleted at a time"))
 	}
 
 	for _, item := range removed.List() {
@@ -518,12 +517,17 @@ func resourceIBMPhaClusterNodesUpdate(ctx context.Context, d *schema.ResourceDat
 
 		_, response, err := client.DeleteClusterNodeWithContext(ctx, opts)
 		if err != nil {
-			msg := fmt.Sprintf("Failed to delete VM %s: %s", vmID, err.Error())
 			if response != nil {
-				msg = fmt.Sprintf("Failed to delete VM %s: %s (status: %d, response: %s)",
-					vmID, err.Error(), response.StatusCode, response.Result)
+				return diag.FromErr(fmt.Errorf(
+					"failed to delete VM %s: %w (status: %d, response: %v)",
+					vmID, err, response.StatusCode, response.Result,
+				))
 			}
-			return diag.FromErr(fmt.Errorf(msg))
+
+			return diag.FromErr(fmt.Errorf(
+				"failed to delete VM %s: %w",
+				vmID, err,
+			))
 		}
 	}
 
@@ -544,12 +548,17 @@ func resourceIBMPhaClusterNodesUpdate(ctx context.Context, d *schema.ResourceDat
 
 		_, response, err := client.CreateClusterNodeWithContext(ctx, opts)
 		if err != nil {
-			msg := fmt.Sprintf("Failed to add VMs: %s", err.Error())
 			if response != nil {
-				msg = fmt.Sprintf("Failed to add VMs: %s (status: %d, response: %s)",
-					err.Error(), response.StatusCode, response.Result)
+				return diag.FromErr(fmt.Errorf(
+					"failed to add VMs: %w (status: %d, response: %v)",
+					err, response.StatusCode, response.Result,
+				))
 			}
-			return diag.FromErr(fmt.Errorf(msg))
+
+			return diag.FromErr(fmt.Errorf(
+				"failed to add VMs: %w",
+				err,
+			))
 		}
 	}
 

--- a/ibm/service/powerhaautomationservice/resource_ibm_pha_cluster_nodes_test.go
+++ b/ibm/service/powerhaautomationservice/resource_ibm_pha_cluster_nodes_test.go
@@ -13,9 +13,9 @@ import (
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 func TestAccIBMPhaClusterNodesBasic(t *testing.T) {

--- a/ibm/service/powerhaautomationservice/resource_ibm_pha_deployment.go
+++ b/ibm/service/powerhaautomationservice/resource_ibm_pha_deployment.go
@@ -20,8 +20,8 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
-	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 func ResourceIBMPhaDeployment() *schema.Resource {

--- a/ibm/service/powerhaautomationservice/resource_ibm_pha_deployment_test.go
+++ b/ibm/service/powerhaautomationservice/resource_ibm_pha_deployment_test.go
@@ -14,9 +14,9 @@ import (
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/powerhaautomationservice"
+	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/IBM/dra-go-sdk/powerhaautomationservicev1"
 )
 
 func TestAccIBMPhaDeploymentBasic(t *testing.T) {
@@ -102,7 +102,7 @@ func testAccCheckIBMPhaDeploymentConfig(instanceID string, acceptLanguage string
 			secondary_location = "%s"
 			secondary_workspace = "%s"
 		}
-	`, instanceID, acceptLanguage, ifNoneMatch, apiKey, primaryLocation, primaryWorkspace, secondaryLocation, secondaryWorkspace)
+	`, instanceID, acceptLanguage, ifNoneMatch, primaryLocation, primaryWorkspace, secondaryLocation, secondaryWorkspace)
 }
 
 func testAccCheckIBMPhaDeploymentExists(n string, obj powerhaautomationservicev1.PhaDeploymentResponse) resource.TestCheckFunc {


### PR DESCRIPTION
* remove redundant fmt.Sprintf usage (S1039)
* replace err.Error() with %w for proper error wrapping
* eliminate unnecessary intermediate msg variables
* fix printf argument mismatch in testAccCheckIBMPhaDeploymentConfig
* align code with gofmt output for 1.26.1
* minor cleanup of error handling paths

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
