### PR TITLE
chore: add go mod tidy, go fmt, and go vet checks to CI workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,15 @@
 <!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
 Relates OR Closes #0000
 
+### Pre-submission Checklist
+
+Before submitting this PR, please ensure you have completed the following:
+
+- [ ] Run `go mod tidy` (if you modified `go.mod`)
+- [ ] Run `go fmt ./...` to format all code
+- [ ] Run `go vet ./...` to check for common errors
+- [ ] All acceptance tests pass locally
+
 Output from acceptance testing:
 
 <!--

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,24 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v5.0.1
 
+    - name: Verify go.mod and go.sum are tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum || (echo "go.mod or go.sum is not tidy. Please run 'go mod tidy' and commit the changes." && exit 1)
+
+    - name: Run go fmt
+      run: |
+        fmt_output=$(gofmt -l .)
+        if [ -n "$fmt_output" ]; then
+          echo "The following files are not formatted correctly:"
+          echo "$fmt_output"
+          echo "Please run 'go fmt ./...' and commit the changes."
+          exit 1
+        fi
+
+    - name: Run go vet
+      run: go vet ./...
+
     - name: Get dependencies
       run: |
         go get -v -t -d ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,15 @@ Working on an existing resources is a great way to start as a Terraform contribu
 
  - [ ] __Acceptance test coverage of new behavior__: Existing resources each have a set of [acceptance tests][acctests] covering their functionality. These tests  exercises all the behavior of the resource. Whether you are adding something or fixing a bug, the idea is to have an acceptance test that fails if your code are removed. Sometimes it is sufficient to **enhance** an existing test by adding an assertion or tweaking the configuration that are used, but often a new test is better to add. You can copy or paste an existing test and follow the conventions you see there, modifying the test to exercise the behavior of your code.
 
- - [ ] __Documentation updates__: If your code makes any changes that need to be documented, you should include those documentation updates in the same PR. 
+ - [ ] __Documentation updates__: If your code makes any changes that need to be documented, you should include those documentation updates in the same PR.
    
  - [ ] __Well-formed Code__: Do your best to follow an existing conventions you see in the codebase, and ensure your code is formatted with **go fmt**. (The Travis CI build fails if **go fmt** has not been run on incoming code.) The PR reviewers can help out on this front, and may provide comments with suggestions on how to improve the code.
+
+ - [ ] __Run go mod tidy__: If you update dependencies in `go.mod`, you **must** run `go mod tidy` to ensure `go.sum` is properly updated with correct checksums. The CI build will fail if `go.mod` or `go.sum` are not tidy.
+
+ - [ ] __Run go vet__: Before submitting your PR, run `go vet ./...` to catch common Go programming errors. The CI build will fail if `go vet` reports any issues.
+
+ - [ ] __Run go fmt__: Before submitting your PR, run `go fmt ./...` to ensure all code is properly formatted. The CI build will fail if any files are not formatted correctly.
 
 #### New resource
 
@@ -130,6 +136,9 @@ Implementing a new resource is a good way to learn more about how Terraform inte
  - [ ] __Acceptance tests__: New resources should include acceptance tests covering their behavior. See [Writing Acceptance Tests](#writing-acceptance-tests) below for a detailed guide on how to approach these.
  - [ ] __Documentation__: Each resource gets a page in the Terraform documentation. The [Terraform website](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs) source is in this repository and includes instructions for getting a local copy of the site up and running if you would like to preview your changes. For a resource, you will want to add a new file in the appropriate place and add a link to the sidebar for that page.
  - [ ] __Well-formed Code__: Do your best to follow an existing conventions you see in the codebase, and ensure your code is formatted with **go fmt**. (The Travis CI build fail if **go fmt** has not been run on incoming code.) The PR reviewers help out on this front, and may provide comments with suggestions on how to improve the code.
+ - [ ] __Run go mod tidy__: If you add new dependencies in `go.mod`, you **must** run `go mod tidy` to ensure `go.sum` is properly updated with correct checksums. The CI build will fail if `go.mod` or `go.sum` are not tidy.
+ - [ ] __Run go vet__: Before submitting your PR, run `go vet ./...` to catch common Go programming errors. The CI build will fail if `go vet` reports any issues.
+ - [ ] __Run go fmt__: Before submitting your PR, run `go fmt ./...` to ensure all code is properly formatted. The CI build will fail if any files are not formatted correctly.
 
 ### Writing acceptance tests
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
