### PR TITLE
Stop skipping first two ip addresses when creating a network in terra…

### DIFF
--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -681,8 +681,7 @@ func generateIPData(cdir string) (gway, firstip, lastip string, err error) {
 	ad := cidr.AddressCount(ipv4Net)
 
 	convertedad := strconv.FormatUint(ad, 10)
-	// Powervc in wdc04 has to reserve 3 ip address hence we start from the 4th. This will be the default behaviour
-	firstusable, err := cidr.Host(ipv4Net, 4)
+	firstusable, err := cidr.Host(ipv4Net, 2)
 	if err != nil {
 		log.Print(err)
 		return "", "", "", err


### PR DESCRIPTION
In the past Powervc in wdc04 had to reserve 3 ip address, which is why we started from the 4th. This is no longer true.


Test results:
```
--- PASS: TestAccIBMPINetworkbasic (67.81s)
PASS

--- PASS: TestAccIBMPINetworkGatewaybasic (67.40s)
PASS

--- PASS: TestAccIBMPINetworkUserTags (71.33s)
PASS

--- PASS: TestAccIBMPINetworkAdvertiseArpBroadcast (169.93s)
PASS
```


```
{"cidr":"192.168.17.0/24","crn":"crn:v1:staging:public:power-iaas:dal12:a/efe5e8b9d3f04b948790fe5499bd18bc:6021a723-bcab-4d3f-9985-d0cb2f864f35:network:639d228c-6a70-4905-9a8b-a554e3988043","dnsServers":["127.0.0.1"],"enableDHCP":false,"gateway":"192.168.17.1","ipAddressMetrics":{"available":253,"total":253,"used":0,"utilization":0},"ipAddressRanges":[{"endingIPAddress":"192.168.17.254","startingIPAddress":"192.168.17.2"}],"mtu":1450,"name":"tf-pi-network-34","networkID":"639d228c-6a70-4905-9a8b-a554e3988043","type":"vlan","vlanID":3438}
```