### PR TITLE
Feat: 2857 Implement Gen2 Support for ibm_database datasource

### DIFF
--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -92,7 +92,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Computed:    true,
 			},
 			"adminuser": {
-				Description: "The admin user id for the instance",
+				Description: "The admin user id for the instance. Note: In Gen2, there is no default admin user. Users should manage credentials using the ibm_resource_key resource (https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_key).",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -152,8 +152,9 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				},
 			},
 			"allowlist": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Allowlist for database access. Note: This attribute is not supported for Gen2 database instances.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address": {
@@ -326,7 +327,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 			},
 			"auto_scaling": {
 				Type:        schema.TypeList,
-				Description: "ICD Auto Scaling",
+				Description: "ICD Auto Scaling. Note: This attribute is currently not supported for Gen2 database instances.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -97,7 +97,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Computed:    true,
 			},
 			"adminpassword": {
-				Description: "The admin user id for the instance",
+				Description: "The admin user id for the instance. Note: This attribute is not supported for Gen2 database instances",
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
@@ -119,7 +119,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 							Computed:    true,
 						},
 						"backup_encryption_key_crn": {
-							Description: "Backup encryption key crn",
+							Description: "Backup encryption key crn. Note: This attribute is not supported for Gen2 database instances",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
@@ -133,8 +133,9 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"users": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Database users. Note: This attribute is not supported for Gen2 database instances.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -487,7 +488,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 			"configuration_schema": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The configuration schema in JSON format",
+				Description: "The configuration schema in JSON format, Note: This attribute is currently not supported for Gen2 database instances.",
 			},
 			flex.ResourceName: {
 				Type:        schema.TypeString,

--- a/ibm/service/database/data_source_ibm_database_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_gen2.go
@@ -3,6 +3,8 @@ package database
 import (
 	"fmt"
 
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -12,18 +14,92 @@ func newDataSourceIBMDatabaseGen2Backend() dataSourceIBMDatabaseBackend {
 	return &dataSourceIBMDatabaseGen2Backend{}
 }
 
+// Read retrieves and populates the state for a Gen2 database instance data source.
+// It handles the migration scenario where a data source may have previously resolved
+// to a Classic instance and now resolves to a Gen2 instance, ensuring stale Classic-only
+// attributes are properly cleared from state.
+//
+// IMPORTANT: Gen2 Migration Edge Case
+// =====================================
+// When a data source previously resolved to a Classic instance and later resolves
+// to a Gen2 instance (e.g., due to filter changes), Terraform does not automatically
+// clear attributes that are no longer set. This differs from resources which would
+// trigger ForceNew on such changes.
+//
+// Result: Gen2-unsupported attributes (adminuser, auto_scaling, allowlist) may
+// persist with stale Classic values in state.
+//
+// Mitigation: These attributes are explicitly set to nil below to ensure state
+// consistency. This is the recommended approach as fully resetting data source
+// state is considered an anti-pattern in Terraform.
 func (g *dataSourceIBMDatabaseGen2Backend) Read(d *schema.ResourceData, meta interface{}) error {
-	// NOTE - Edge case: potential stale values for unsupported Gen2 attributes.
-	// If this data source was previously resolved to a Classic instance, all
-	// attributes (including ones not supported by Gen2) would have been set.
-	// If the same filters later resolve to a Gen2 instance (e.g., name/location/service),
-	// Terraform will not automatically clear attributes that are no longer set,
-	// unlike a resource which would ForceNew on such changes.
-	// As a result, the Gen2 read path may only set supported attributes while
-	// previously populated Classic-only attributes remain stale in state.
-	// There is no clean mechanism to fully reset datasource state, and doing so
-	// is generally considered an anti-pattern.
-	// If this becomes an issue, unsupported attributes could be explicitly set
-	// to null via d.Set() to ensure stale values are cleared.
-	return fmt.Errorf("gen2 backend not implemented yet")
+	// Find the database instance
+	instance, err := findInstance(d, meta)
+	if err != nil {
+		return fmt.Errorf("failed to find database instance: %w", err)
+	}
+	if instance == nil || instance.ID == nil {
+		return fmt.Errorf("database instance not found or missing ID")
+	}
+	d.SetId(*instance.ID)
+
+	// Set basic attributes
+	if err := g.setBasicAttributes(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Set service and plan information
+	if err := g.setServiceInfo(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Set version information
+	g.setVersionInfo(d, instance)
+
+	// Set groups information
+	if err := g.setGroupsInfo(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Clear Gen2 unsupported attributes
+	g.clearUnsupportedAttributes(d)
+
+	return nil
+}
+
+// setBasicAttributes sets basic instance attributes including tags, name, status, location, and resource controller attributes.
+// Uses shared helper functions to reduce duplication with resource file.
+func (g *dataSourceIBMDatabaseGen2Backend) setBasicAttributes(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	// Data sources don't need service_endpoints or resource_controller_url
+	return setGen2BasicAttributes(d, instance, meta, false, false)
+}
+
+// setServiceInfo retrieves and sets service and plan information from Global Catalog.
+// Clears admin user attribute as it's not available in Gen2.
+func (g *dataSourceIBMDatabaseGen2Backend) setServiceInfo(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	return setGen2ServiceInfo(d, instance, meta)
+}
+
+// setVersionInfo extracts and sets version information from instance extensions.
+// Also sets platform_options if available.
+func (g *dataSourceIBMDatabaseGen2Backend) setVersionInfo(d *schema.ResourceData, instance *rc.ResourceInstance) {
+	// Use shared Gen2 helper function
+	// Data sources include platform_options
+	setGen2VersionInfo(d, instance, true)
+}
+
+// setGroupsInfo retrieves and sets groups information from catalog.
+// Combines instance extensions with catalog metadata to build group configurations.
+func (g *dataSourceIBMDatabaseGen2Backend) setGroupsInfo(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	return setGen2GroupsInfo(d, instance, meta)
+}
+
+// clearUnsupportedAttributes clears attributes not supported in Gen2.
+// Sets auto_scaling and allowlist to nil to prevent stale Classic values.
+func (g *dataSourceIBMDatabaseGen2Backend) clearUnsupportedAttributes(d *schema.ResourceData) {
+	// Use shared Gen2 helper function
+	clearGen2UnsupportedAttributes(d)
 }

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -1,0 +1,396 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package database
+
+import (
+	"testing"
+
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDataSourceGen2BackendClearsUnsupportedAttributes verifies that Gen2 data source
+// properly clears Classic-only attributes from state.
+// This is critical for the migration scenario where a data source previously resolved
+// to a Classic instance and now resolves to a Gen2 instance.
+func TestDataSourceGen2BackendClearsUnsupportedAttributes(t *testing.T) {
+	// Create a resource data with Classic attributes set
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":              "test-db",
+		"resource_group_id": "test-rg-id",
+		"location":          "us-south",
+	})
+
+	// Simulate stale Classic values in state
+	d.Set("adminuser", "admin")
+	d.Set("auto_scaling", []interface{}{
+		map[string]interface{}{
+			"disk": []interface{}{
+				map[string]interface{}{
+					"capacity_enabled":             true,
+					"free_space_less_than_percent": 10,
+					"io_above_percent":             90,
+					"io_enabled":                   true,
+					"io_over_period":               "5m",
+					"rate_increase_percent":        10,
+					"rate_limit_mb_per_member":     3670016,
+					"rate_period_seconds":          900,
+					"rate_units":                   "mb",
+				},
+			},
+			"memory": []interface{}{
+				map[string]interface{}{
+					"io_above_percent":         90,
+					"io_enabled":               true,
+					"io_over_period":           "5m",
+					"rate_increase_percent":    10,
+					"rate_limit_mb_per_member": 114688,
+					"rate_period_seconds":      900,
+					"rate_units":               "mb",
+				},
+			},
+		},
+	})
+	d.Set("allowlist", []interface{}{
+		map[string]interface{}{
+			"address":     "192.168.1.1/32",
+			"description": "Test allowlist entry",
+		},
+	})
+	d.Set("users", []interface{}{
+		map[string]interface{}{
+			"name":     "testuser",
+			"password": "testpass",
+		},
+	})
+	d.Set("configuration_schema", "some_schema_string")
+
+	// Create Gen2 backend and clear unsupported attributes
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.clearUnsupportedAttributes(d)
+
+	// Verify Classic-only attributes are cleared to their zero values
+	// Note: Terraform SDK's d.Set(key, nil) sets values to their zero values, not actual nil
+	adminuser := d.Get("adminuser")
+	assert.Equal(t, "", adminuser, "adminuser should be empty string for Gen2")
+
+	autoScaling := d.Get("auto_scaling")
+	// TypeList becomes empty slice when set to nil
+	assert.Equal(t, []interface{}{}, autoScaling, "auto_scaling should be empty slice for Gen2")
+
+	allowlist := d.Get("allowlist")
+	// TypeSet becomes empty Set when set to nil - check it's not nil and has zero length
+	assert.NotNil(t, allowlist, "allowlist should not be nil (it's an empty Set)")
+	if allowlistSet, ok := allowlist.(*schema.Set); ok {
+		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty for Gen2")
+	}
+
+	users := d.Get("users")
+	// TypeSet becomes empty Set when set to nil
+	assert.NotNil(t, users, "users should not be nil (it's an empty Set)")
+	if usersSet, ok := users.(*schema.Set); ok {
+		assert.Equal(t, 0, usersSet.Len(), "users Set should be empty for Gen2")
+	}
+
+	configSchema := d.Get("configuration_schema")
+	assert.Equal(t, "", configSchema, "configuration_schema should be empty string for Gen2")
+}
+
+// TestDataSourceGen2BackendSetBasicAttributes verifies that basic attributes
+// are properly set for Gen2 data sources.
+func TestDataSourceGen2BackendSetBasicAttributes(t *testing.T) {
+	// Create a mock instance
+	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
+	instanceName := "test-db-gen2"
+	instanceState := "active"
+	resourceGroupID := "test-rg-id"
+	location := "us-south"
+
+	instance := &rc.ResourceInstance{
+		ID:              &instanceID,
+		Name:            &instanceName,
+		State:           &instanceState,
+		ResourceGroupID: &resourceGroupID,
+		RegionID:        &location,
+	}
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+
+	// Note: setBasicAttributes requires actual API calls, so we're testing
+	// that the method exists and can be called without panicking
+	assert.NotNil(t, backend, "Gen2 backend should not be nil")
+	assert.NotNil(t, instance, "Instance should not be nil")
+}
+
+// TestDataSourceGen2BackendVersionInfo verifies version information handling
+func TestDataSourceGen2BackendVersionInfo(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+	})
+
+	// Create a mock instance with version in extensions
+	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
+	resourceID := "databases-for-postgresql"
+	extensions := map[string]interface{}{
+		"version": "14.5",
+	}
+
+	instance := &rc.ResourceInstance{
+		ID:         &instanceID,
+		ResourceID: &resourceID,
+		Extensions: extensions,
+	}
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.setVersionInfo(d, instance)
+
+	// Verify version is set
+	// Note: Version extraction requires ResourceID to determine database type
+	// Since we're using "databases-for-postgresql", it should extract the version
+	version := d.Get("version")
+	// The version may not be set if the extraction logic doesn't recognize the format
+	// Just verify it doesn't panic
+	assert.NotNil(t, version, "Version should not be nil")
+}
+
+// TestDataSourceGen2BackendClearUnsupportedAttributesIdempotent verifies that
+// clearing unsupported attributes multiple times doesn't cause issues
+func TestDataSourceGen2BackendClearUnsupportedAttributesIdempotent(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+	})
+
+	// Set Classic attributes
+	d.Set("adminuser", "admin")
+	d.Set("auto_scaling", []interface{}{
+		map[string]interface{}{
+			"disk": []interface{}{
+				map[string]interface{}{
+					"capacity_enabled": true,
+				},
+			},
+		},
+	})
+	d.Set("allowlist", []interface{}{
+		map[string]interface{}{
+			"address": "192.168.1.1/32",
+		},
+	})
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+
+	// Clear multiple times
+	backend.clearUnsupportedAttributes(d)
+	backend.clearUnsupportedAttributes(d)
+	backend.clearUnsupportedAttributes(d)
+
+	// Verify attributes remain cleared (zero values)
+	assert.Equal(t, "", d.Get("adminuser"), "adminuser should remain empty")
+	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should remain empty slice")
+	allowlist := d.Get("allowlist")
+	if allowlistSet, ok := allowlist.(*schema.Set); ok {
+		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should remain empty")
+	}
+}
+
+// TestDataSourceGen2BackendDoesNotClearSupportedAttributes verifies that
+// Gen2-supported attributes are not affected by clearUnsupportedAttributes
+func TestDataSourceGen2BackendDoesNotClearSupportedAttributes(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+		"service":  "databases-for-postgresql",
+		"plan":     "standard",
+	})
+
+	// Set some Gen2-supported attributes
+	d.Set("version", "14.5")
+	d.Set("status", "active")
+	d.Set("guid", "test-guid")
+
+	// Also set Classic-only attributes
+	d.Set("adminuser", "admin")
+	d.Set("allowlist", []interface{}{
+		map[string]interface{}{
+			"address": "192.168.1.1/32",
+		},
+	})
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.clearUnsupportedAttributes(d)
+
+	// Verify Gen2-supported attributes are preserved
+	assert.Equal(t, "14.5", d.Get("version"), "version should be preserved")
+	assert.Equal(t, "active", d.Get("status"), "status should be preserved")
+	assert.Equal(t, "test-guid", d.Get("guid"), "guid should be preserved")
+	assert.Equal(t, "databases-for-postgresql", d.Get("service"), "service should be preserved")
+	assert.Equal(t, "standard", d.Get("plan"), "plan should be preserved")
+
+	// Verify Classic-only attributes are cleared (zero values)
+	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty")
+	allowlist := d.Get("allowlist")
+	if allowlistSet, ok := allowlist.(*schema.Set); ok {
+		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty")
+	}
+}
+
+// TestDataSourceGen2BackendNewInstance verifies that a new Gen2 backend can be created
+func TestDataSourceGen2BackendNewInstance(t *testing.T) {
+	backend := newDataSourceIBMDatabaseGen2Backend()
+	assert.NotNil(t, backend, "Gen2 backend should not be nil")
+
+	// Verify it implements the interface
+	var _ dataSourceIBMDatabaseBackend = backend
+}
+
+// TestDataSourceGen2BackendHandlesNilInstance verifies proper error handling
+// when instance is nil
+func TestDataSourceGen2BackendHandlesNilInstance(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+	})
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+
+	// Test with nil instance - should not panic
+	// The actual setVersionInfo checks for nil Extensions, not nil instance
+	// So we create an instance with nil extensions
+	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
+	instance := &rc.ResourceInstance{
+		ID:         &instanceID,
+		Extensions: nil,
+	}
+
+	backend.setVersionInfo(d, instance)
+
+	// Should not panic and version should remain unset
+	version := d.Get("version")
+	assert.Equal(t, "", version, "Version should be empty string when extensions are nil")
+}
+
+// TestDataSourceGen2BackendHandlesEmptyExtensions verifies handling of
+// instances without extensions
+func TestDataSourceGen2BackendHandlesEmptyExtensions(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+	})
+
+	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
+	instance := &rc.ResourceInstance{
+		ID:         &instanceID,
+		Extensions: nil, // No extensions
+	}
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.setVersionInfo(d, instance)
+
+	// Should handle gracefully without panicking
+	version := d.Get("version")
+	assert.Equal(t, "", version, "Version should be empty when extensions are nil")
+}
+
+// TestDataSourceGen2BackendClearAttributesWithEmptyState verifies clearing
+// attributes when they're already empty
+func TestDataSourceGen2BackendClearAttributesWithEmptyState(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":     "test-db",
+		"location": "us-south",
+	})
+
+	// Don't set any Classic attributes - they should already be nil/empty
+
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.clearUnsupportedAttributes(d)
+
+	// Should handle gracefully (zero values)
+	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty")
+	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should be empty slice")
+	allowlist := d.Get("allowlist")
+	if allowlistSet, ok := allowlist.(*schema.Set); ok {
+		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty")
+	}
+}
+
+// TestDataSourceGen2BackendMigrationScenario simulates the full migration scenario
+// where a data source switches from Classic to Gen2
+func TestDataSourceGen2BackendMigrationScenario(t *testing.T) {
+	resourceSchema := DataSourceIBMDatabaseInstance().Schema
+
+	// Step 1: Simulate Classic data source state
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+		"name":              "test-db",
+		"resource_group_id": "test-rg-id",
+		"location":          "us-south",
+	})
+
+	// Set Classic-specific attributes
+	d.Set("adminuser", "admin")
+	d.Set("auto_scaling", []interface{}{
+		map[string]interface{}{
+			"disk": []interface{}{
+				map[string]interface{}{
+					"capacity_enabled":             true,
+					"free_space_less_than_percent": 10,
+					"io_above_percent":             90,
+					"io_enabled":                   true,
+					"io_over_period":               "5m",
+					"rate_increase_percent":        10,
+					"rate_limit_mb_per_member":     3670016,
+					"rate_period_seconds":          900,
+					"rate_units":                   "mb",
+				},
+			},
+		},
+	})
+	d.Set("allowlist", []interface{}{
+		map[string]interface{}{
+			"address":     "192.168.1.1/32",
+			"description": "Test allowlist",
+		},
+	})
+
+	// Set common attributes
+	d.Set("service", "databases-for-postgresql")
+	d.Set("plan", "standard")
+	d.Set("status", "active")
+	d.Set("version", "14.5")
+
+	// Verify Classic attributes are set
+	assert.Equal(t, "admin", d.Get("adminuser"), "adminuser should be set initially")
+	assert.NotNil(t, d.Get("auto_scaling"), "auto_scaling should be set initially")
+	assert.NotNil(t, d.Get("allowlist"), "allowlist should be set initially")
+
+	// Step 2: Simulate migration to Gen2 - clear unsupported attributes
+	backend := &dataSourceIBMDatabaseGen2Backend{}
+	backend.clearUnsupportedAttributes(d)
+
+	// Step 3: Verify migration results
+	// Classic-only attributes should be cleared to zero values
+	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty after Gen2 migration")
+	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should be empty slice after Gen2 migration")
+	allowlist := d.Get("allowlist")
+	if allowlistSet, ok := allowlist.(*schema.Set); ok {
+		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty after Gen2 migration")
+	}
+
+	// Common attributes should be preserved
+	assert.Equal(t, "databases-for-postgresql", d.Get("service"), "service should be preserved")
+	assert.Equal(t, "standard", d.Get("plan"), "plan should be preserved")
+	assert.Equal(t, "active", d.Get("status"), "status should be preserved")
+	assert.Equal(t, "14.5", d.Get("version"), "version should be preserved")
+}
+
+// Made with Bob

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -1,396 +1,171 @@
 // Copyright IBM Corp. 2024 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
-package database
+package database_test
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
-	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stretchr/testify/assert"
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TestDataSourceGen2BackendClearsUnsupportedAttributes verifies that Gen2 data source
-// properly clears Classic-only attributes from state.
-// This is critical for the migration scenario where a data source previously resolved
-// to a Classic instance and now resolves to a Gen2 instance.
-func TestDataSourceGen2BackendClearsUnsupportedAttributes(t *testing.T) {
-	// Create a resource data with Classic attributes set
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":              "test-db",
-		"resource_group_id": "test-rg-id",
-		"location":          "us-south",
-	})
+// TestAccIBMDatabaseDataSourceGen2Basic tests basic Gen2 data source read
+func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
+	testName := fmt.Sprintf("tf-gen2-db-%s", acctest.RandString(16))
+	dataName := "data.ibm_database." + testName
 
-	// Simulate stale Classic values in state
-	d.Set("adminuser", "admin")
-	d.Set("auto_scaling", []interface{}{
-		map[string]interface{}{
-			"disk": []interface{}{
-				map[string]interface{}{
-					"capacity_enabled":             true,
-					"free_space_less_than_percent": 10,
-					"io_above_percent":             90,
-					"io_enabled":                   true,
-					"io_over_period":               "5m",
-					"rate_increase_percent":        10,
-					"rate_limit_mb_per_member":     3670016,
-					"rate_period_seconds":          900,
-					"rate_units":                   "mb",
-				},
-			},
-			"memory": []interface{}{
-				map[string]interface{}{
-					"io_above_percent":         90,
-					"io_enabled":               true,
-					"io_over_period":           "5m",
-					"rate_increase_percent":    10,
-					"rate_limit_mb_per_member": 114688,
-					"rate_period_seconds":      900,
-					"rate_units":               "mb",
-				},
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataName, "name", testName),
+					resource.TestCheckResourceAttr(dataName, "service", "databases-for-mongodb"),
+					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(dataName, "location", "ca-mon"),
+					resource.TestCheckResourceAttrSet(dataName, "status"),
+					resource.TestCheckResourceAttrSet(dataName, "version"),
+					resource.TestCheckResourceAttrSet(dataName, "guid"),
+					resource.TestCheckResourceAttr(dataName, "groups.#", "1"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.cpu.0.allocation_count"),
+					// Verify Gen2-unsupported attributes are NOT set
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+				),
 			},
 		},
 	})
-	d.Set("allowlist", []interface{}{
-		map[string]interface{}{
-			"address":     "192.168.1.1/32",
-			"description": "Test allowlist entry",
-		},
-	})
-	d.Set("users", []interface{}{
-		map[string]interface{}{
-			"name":     "testuser",
-			"password": "testpass",
-		},
-	})
-	d.Set("configuration_schema", "some_schema_string")
-
-	// Create Gen2 backend and clear unsupported attributes
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.clearUnsupportedAttributes(d)
-
-	// Verify Classic-only attributes are cleared to their zero values
-	// Note: Terraform SDK's d.Set(key, nil) sets values to their zero values, not actual nil
-	adminuser := d.Get("adminuser")
-	assert.Equal(t, "", adminuser, "adminuser should be empty string for Gen2")
-
-	autoScaling := d.Get("auto_scaling")
-	// TypeList becomes empty slice when set to nil
-	assert.Equal(t, []interface{}{}, autoScaling, "auto_scaling should be empty slice for Gen2")
-
-	allowlist := d.Get("allowlist")
-	// TypeSet becomes empty Set when set to nil - check it's not nil and has zero length
-	assert.NotNil(t, allowlist, "allowlist should not be nil (it's an empty Set)")
-	if allowlistSet, ok := allowlist.(*schema.Set); ok {
-		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty for Gen2")
-	}
-
-	users := d.Get("users")
-	// TypeSet becomes empty Set when set to nil
-	assert.NotNil(t, users, "users should not be nil (it's an empty Set)")
-	if usersSet, ok := users.(*schema.Set); ok {
-		assert.Equal(t, 0, usersSet.Len(), "users Set should be empty for Gen2")
-	}
-
-	configSchema := d.Get("configuration_schema")
-	assert.Equal(t, "", configSchema, "configuration_schema should be empty string for Gen2")
 }
 
-// TestDataSourceGen2BackendSetBasicAttributes verifies that basic attributes
-// are properly set for Gen2 data sources.
-func TestDataSourceGen2BackendSetBasicAttributes(t *testing.T) {
-	// Create a mock instance
-	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
-	instanceName := "test-db-gen2"
-	instanceState := "active"
-	resourceGroupID := "test-rg-id"
-	location := "us-south"
+// TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes validates that
+// Gen2-unsupported attributes remain empty even when explicitly checked
+func TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes(t *testing.T) {
+	testName := fmt.Sprintf("tf-gen2-unsup-%s", acctest.RandString(16))
+	dataName := "data.ibm_database." + testName
 
-	instance := &rc.ResourceInstance{
-		ID:              &instanceID,
-		Name:            &instanceName,
-		State:           &instanceState,
-		ResourceGroupID: &resourceGroupID,
-		RegionID:        &location,
-	}
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-
-	// Note: setBasicAttributes requires actual API calls, so we're testing
-	// that the method exists and can be called without panicking
-	assert.NotNil(t, backend, "Gen2 backend should not be nil")
-	assert.NotNil(t, instance, "Instance should not be nil")
-}
-
-// TestDataSourceGen2BackendVersionInfo verifies version information handling
-func TestDataSourceGen2BackendVersionInfo(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-	})
-
-	// Create a mock instance with version in extensions
-	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
-	resourceID := "databases-for-postgresql"
-	extensions := map[string]interface{}{
-		"version": "14.5",
-	}
-
-	instance := &rc.ResourceInstance{
-		ID:         &instanceID,
-		ResourceID: &resourceID,
-		Extensions: extensions,
-	}
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.setVersionInfo(d, instance)
-
-	// Verify version is set
-	// Note: Version extraction requires ResourceID to determine database type
-	// Since we're using "databases-for-postgresql", it should extract the version
-	version := d.Get("version")
-	// The version may not be set if the extraction logic doesn't recognize the format
-	// Just verify it doesn't panic
-	assert.NotNil(t, version, "Version should not be nil")
-}
-
-// TestDataSourceGen2BackendClearUnsupportedAttributesIdempotent verifies that
-// clearing unsupported attributes multiple times doesn't cause issues
-func TestDataSourceGen2BackendClearUnsupportedAttributesIdempotent(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-	})
-
-	// Set Classic attributes
-	d.Set("adminuser", "admin")
-	d.Set("auto_scaling", []interface{}{
-		map[string]interface{}{
-			"disk": []interface{}{
-				map[string]interface{}{
-					"capacity_enabled": true,
-				},
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
+				Check: resource.ComposeTestCheckFunc(
+					// Explicitly verify each unsupported attribute is empty
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+				),
 			},
 		},
 	})
-	d.Set("allowlist", []interface{}{
-		map[string]interface{}{
-			"address": "192.168.1.1/32",
-		},
-	})
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-
-	// Clear multiple times
-	backend.clearUnsupportedAttributes(d)
-	backend.clearUnsupportedAttributes(d)
-	backend.clearUnsupportedAttributes(d)
-
-	// Verify attributes remain cleared (zero values)
-	assert.Equal(t, "", d.Get("adminuser"), "adminuser should remain empty")
-	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should remain empty slice")
-	allowlist := d.Get("allowlist")
-	if allowlistSet, ok := allowlist.(*schema.Set); ok {
-		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should remain empty")
-	}
 }
 
-// TestDataSourceGen2BackendDoesNotClearSupportedAttributes verifies that
-// Gen2-supported attributes are not affected by clearUnsupportedAttributes
-func TestDataSourceGen2BackendDoesNotClearSupportedAttributes(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-		"service":  "databases-for-postgresql",
-		"plan":     "standard",
-	})
-
-	// Set some Gen2-supported attributes
-	d.Set("version", "14.5")
-	d.Set("status", "active")
-	d.Set("guid", "test-guid")
-
-	// Also set Classic-only attributes
-	d.Set("adminuser", "admin")
-	d.Set("allowlist", []interface{}{
-		map[string]interface{}{
-			"address": "192.168.1.1/32",
-		},
-	})
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.clearUnsupportedAttributes(d)
-
-	// Verify Gen2-supported attributes are preserved
-	assert.Equal(t, "14.5", d.Get("version"), "version should be preserved")
-	assert.Equal(t, "active", d.Get("status"), "status should be preserved")
-	assert.Equal(t, "test-guid", d.Get("guid"), "guid should be preserved")
-	assert.Equal(t, "databases-for-postgresql", d.Get("service"), "service should be preserved")
-	assert.Equal(t, "standard", d.Get("plan"), "plan should be preserved")
-
-	// Verify Classic-only attributes are cleared (zero values)
-	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty")
-	allowlist := d.Get("allowlist")
-	if allowlistSet, ok := allowlist.(*schema.Set); ok {
-		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty")
-	}
-}
-
-// TestDataSourceGen2BackendNewInstance verifies that a new Gen2 backend can be created
-func TestDataSourceGen2BackendNewInstance(t *testing.T) {
-	backend := newDataSourceIBMDatabaseGen2Backend()
-	assert.NotNil(t, backend, "Gen2 backend should not be nil")
-
-	// Verify it implements the interface
-	var _ dataSourceIBMDatabaseBackend = backend
-}
-
-// TestDataSourceGen2BackendHandlesNilInstance verifies proper error handling
-// when instance is nil
-func TestDataSourceGen2BackendHandlesNilInstance(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-	})
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-
-	// Test with nil instance - should not panic
-	// The actual setVersionInfo checks for nil Extensions, not nil instance
-	// So we create an instance with nil extensions
-	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
-	instance := &rc.ResourceInstance{
-		ID:         &instanceID,
-		Extensions: nil,
-	}
-
-	backend.setVersionInfo(d, instance)
-
-	// Should not panic and version should remain unset
-	version := d.Get("version")
-	assert.Equal(t, "", version, "Version should be empty string when extensions are nil")
-}
-
-// TestDataSourceGen2BackendHandlesEmptyExtensions verifies handling of
-// instances without extensions
-func TestDataSourceGen2BackendHandlesEmptyExtensions(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-	})
-
-	instanceID := "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id::"
-	instance := &rc.ResourceInstance{
-		ID:         &instanceID,
-		Extensions: nil, // No extensions
-	}
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.setVersionInfo(d, instance)
-
-	// Should handle gracefully without panicking
-	version := d.Get("version")
-	assert.Equal(t, "", version, "Version should be empty when extensions are nil")
-}
-
-// TestDataSourceGen2BackendClearAttributesWithEmptyState verifies clearing
-// attributes when they're already empty
-func TestDataSourceGen2BackendClearAttributesWithEmptyState(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":     "test-db",
-		"location": "us-south",
-	})
-
-	// Don't set any Classic attributes - they should already be nil/empty
-
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.clearUnsupportedAttributes(d)
-
-	// Should handle gracefully (zero values)
-	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty")
-	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should be empty slice")
-	allowlist := d.Get("allowlist")
-	if allowlistSet, ok := allowlist.(*schema.Set); ok {
-		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty")
-	}
-}
-
-// TestDataSourceGen2BackendMigrationScenario simulates the full migration scenario
-// where a data source switches from Classic to Gen2
-func TestDataSourceGen2BackendMigrationScenario(t *testing.T) {
-	resourceSchema := DataSourceIBMDatabaseInstance().Schema
-
-	// Step 1: Simulate Classic data source state
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"name":              "test-db",
-		"resource_group_id": "test-rg-id",
-		"location":          "us-south",
-	})
-
-	// Set Classic-specific attributes
-	d.Set("adminuser", "admin")
-	d.Set("auto_scaling", []interface{}{
-		map[string]interface{}{
-			"disk": []interface{}{
-				map[string]interface{}{
-					"capacity_enabled":             true,
-					"free_space_less_than_percent": 10,
-					"io_above_percent":             90,
-					"io_enabled":                   true,
-					"io_over_period":               "5m",
-					"rate_increase_percent":        10,
-					"rate_limit_mb_per_member":     3670016,
-					"rate_period_seconds":          900,
-					"rate_units":                   "mb",
-				},
+// TestAccIBMDatabaseDataSourceGen2InvalidInput tests error handling
+// for invalid database name
+func TestAccIBMDatabaseDataSourceGen2InvalidInput(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidConfig(),
+				ExpectError: regexp.MustCompile("No resource instance found"),
 			},
 		},
 	})
-	d.Set("allowlist", []interface{}{
-		map[string]interface{}{
-			"address":     "192.168.1.1/32",
-			"description": "Test allowlist",
-		},
-	})
+}
 
-	// Set common attributes
-	d.Set("service", "databases-for-postgresql")
-	d.Set("plan", "standard")
-	d.Set("status", "active")
-	d.Set("version", "14.5")
+func testAccCheckIBMDatabaseDataSourceGen2Config(name string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
 
-	// Verify Classic attributes are set
-	assert.Equal(t, "admin", d.Get("adminuser"), "adminuser should be set initially")
-	assert.NotNil(t, d.Get("auto_scaling"), "auto_scaling should be set initially")
-	assert.NotNil(t, d.Get("allowlist"), "allowlist should be set initially")
+resource "ibm_database" "db" {
+  name              = "%[1]s"
+  plan              = "standard-gen2"
+  location          = "ca-mon"
+  service           = "databases-for-mongodb"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "bx3d.4x20"
+    }
+    disk {
+      allocation_mb = 20480
+    }
+  }
 
-	// Step 2: Simulate migration to Gen2 - clear unsupported attributes
-	backend := &dataSourceIBMDatabaseGen2Backend{}
-	backend.clearUnsupportedAttributes(d)
+  tags = ["gen2-test"]
+}
 
-	// Step 3: Verify migration results
-	// Classic-only attributes should be cleared to zero values
-	assert.Equal(t, "", d.Get("adminuser"), "adminuser should be empty after Gen2 migration")
-	assert.Equal(t, []interface{}{}, d.Get("auto_scaling"), "auto_scaling should be empty slice after Gen2 migration")
-	allowlist := d.Get("allowlist")
-	if allowlistSet, ok := allowlist.(*schema.Set); ok {
-		assert.Equal(t, 0, allowlistSet.Len(), "allowlist Set should be empty after Gen2 migration")
-	}
+data "ibm_database" "%[1]s" {
+  name              = ibm_database.db.name
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  location          = ibm_database.db.location
+  service           = ibm_database.db.service
+}
+`, name)
+}
 
-	// Common attributes should be preserved
-	assert.Equal(t, "databases-for-postgresql", d.Get("service"), "service should be preserved")
-	assert.Equal(t, "standard", d.Get("plan"), "plan should be preserved")
-	assert.Equal(t, "active", d.Get("status"), "status should be preserved")
-	assert.Equal(t, "14.5", d.Get("version"), "version should be preserved")
+func testAccCheckIBMDatabaseDataSourceGen2InvalidConfig() string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+data "ibm_database" "nonexistent" {
+  name              = "this-database-does-not-exist-gen2-%s"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  location          = "ca-mon"
+  service           = "databases-for-mongodb"
+}
+`, acctest.RandString(8))
+}
+
+func testAccCheckIBMDatabaseGen2CheckPlansConfig(service string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "gen2_check" {
+  name              = "tf-gen2-check-%s"
+  plan              = "standard-gen2"
+  location          = "ca-mon"
+  service           = "%s"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "bx3d.4x20"
+    }
+    disk {
+      allocation_mb = 20480
+    }
+  }
+
+  tags = ["gen2-availability-check"]
+}
+`, acctest.RandString(8), service)
 }
 
 // Made with Bob

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -36,6 +36,14 @@ const (
 	// Instance states - shared across Classic and Gen2
 	instanceStateRemoved = "removed"
 
+	// Database instance status constants
+	databaseInstanceSuccessStatus      = "active"
+	databaseInstanceProvisioningStatus = "provisioning"
+	databaseInstanceProgressStatus     = "in progress"
+	databaseInstanceInactiveStatus     = "inactive"
+	databaseInstanceFailStatus         = "failed"
+	databaseInstanceRemovedStatus      = "removed"
+
 	// Gen2 database operation keys
 	deploymentKind     = "deployment"
 	dataservicesKey    = "dataservices"
@@ -149,6 +157,33 @@ func extractLocationFromCRN(crn *string) (string, error) {
 		return "", fmt.Errorf("invalid CRN format: expected at least 6 parts, got %d", len(parts))
 	}
 	return parts[5], nil
+}
+
+// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
+// Catalog CRN format: crn:v1:bluemix:public:globalcatalog::::deployment:deployment-id
+// Returns the deployment ID or an error if the CRN format is invalid.
+func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
+	if catalogCRN == "" {
+		return "", fmt.Errorf("invalid catalog CRN format: empty CRN")
+	}
+
+	// Split by "deployment:" to extract the deployment ID
+	parts := strings.Split(catalogCRN, "deployment:")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid catalog CRN format: expected exactly one 'deployment:' prefix")
+	}
+
+	deploymentID := parts[1]
+	if deploymentID == "" {
+		return "", fmt.Errorf("empty deployment ID in catalog CRN")
+	}
+
+	// Check for multiple deployment prefixes (invalid format)
+	if strings.Contains(deploymentID, "deployment:") {
+		return "", fmt.Errorf("invalid catalog CRN format: multiple 'deployment:' prefixes found")
+	}
+
+	return deploymentID, nil
 }
 
 // wrapAPIError wraps an API error with operation context and response details.

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -34,13 +34,7 @@ const (
 	defaultMemberCount = 3
 
 	// Instance states - shared across Classic and Gen2
-	instanceStateRemoved               = "removed"
-	databaseInstanceSuccessStatus      = "active"
-	databaseInstanceProvisioningStatus = "provisioning"
-	databaseInstanceProgressStatus     = "in progress"
-	databaseInstanceInactiveStatus     = "inactive"
-	databaseInstanceFailStatus         = "failed"
-	databaseInstanceRemovedStatus      = "removed"
+	instanceStateRemoved = "removed"
 
 	// Gen2 database operation keys
 	deploymentKind     = "deployment"
@@ -49,7 +43,9 @@ const (
 	resourcesKey       = "resources"
 	platformOptionsKey = "platform_options"
 	adminUserKey       = "adminuser"
+	autoScalingKey     = "auto_scaling"
 	allowlistKey       = "allowlist"
+	databaseUserType   = "database"
 )
 
 type TimeoutHelper struct {
@@ -373,31 +369,12 @@ func buildHostFlavorConfig(hostFlavorID string) []map[string]interface{} {
 	return []map[string]interface{}{hostflavor}
 }
 
-// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
-func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
-	// Split by "deployment:" to get the deployment ID
-	parts := strings.Split(catalogCRN, "deployment:")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid catalog CRN format: %s", catalogCRN)
-	}
-	deploymentID := strings.TrimSpace(parts[1])
-	if deploymentID == "" {
-		return "", fmt.Errorf("empty deployment ID in catalog CRN: %s", catalogCRN)
-	}
-	return deploymentID, nil
-}
-
 // getInitialNodeCountGen2 retrieves the default member count for Gen2 plans from Global Catalog.
 // Returns the member count from the catalog metadata, or a default value of 3 if not found.
-func getInitialNodeCountGen2(catalogCRN string, meta interface{}) (int, error) {
+func getInitialNodeCountGen2(deploymentID string, meta interface{}) (int, error) {
 	globalClient, err := meta.(conns.ClientSession).GlobalCatalogV1API()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get global catalog client: %w", err)
-	}
-
-	deploymentID, err := extractDeploymentIDFromCRN(catalogCRN)
-	if err != nil {
-		return 0, fmt.Errorf("failed to extract deployment ID from catalog CRN: %w", err)
 	}
 
 	options := &globalcatalogv1.GetCatalogEntryOptions{
@@ -532,6 +509,42 @@ func getResourceManagerClient(meta interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("failed to get resource manager client: %w", err)
 	}
 	return client, nil
+}
+
+// setTagsWithLogging retrieves and sets tags for a resource, logging errors instead of failing.
+// Returns error only for critical failures, logs warnings for non-critical issues.
+func setTagsWithLogging(d *schema.ResourceData, crn string, meta interface{}) error {
+	tags, err := flex.GetTagsUsingCRN(meta, crn)
+	if err != nil {
+		log.Printf("[WARN] Failed to retrieve tags for resource %s: %v", crn, err)
+	}
+	return d.Set("tags", tags)
+}
+
+// buildResourceControllerURL constructs the resource controller URL for a given CRN.
+// Standardizes URL building across resources and data sources.
+func buildResourceControllerURL(meta interface{}, crn string) (string, error) {
+	rcontroller, err := flex.GetBaseController(meta)
+	if err != nil {
+		return "", fmt.Errorf("failed to get base controller: %w", err)
+	}
+	return rcontroller + "/services/" + url.QueryEscape(crn), nil
+}
+
+// setResourceControllerAttributes sets common flex resource controller attributes.
+// Reduces duplication of setting name, CRN, status, and controller URL.
+func setResourceControllerAttributes(d *schema.ResourceData, name, crn, state string, meta interface{}) error {
+	d.Set(flex.ResourceName, name)
+	d.Set(flex.ResourceCRN, crn)
+	d.Set(flex.ResourceStatus, state)
+
+	controllerURL, err := buildResourceControllerURL(meta, crn)
+	if err != nil {
+		return err
+	}
+	d.Set(flex.ResourceControllerURL, controllerURL)
+
+	return nil
 }
 
 // setGen2BasicAttributes sets basic instance attributes including tags, name, status, location, and resource controller attributes.

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -763,12 +763,25 @@ func setGen2GroupsInfo(d *schema.ResourceData, instance *rc.ResourceInstance, me
 // to avoid drift detection when users have these in their configuration.
 // This function is shared between data source and resource implementations.
 func clearGen2UnsupportedAttributes(d *schema.ResourceData) {
+	// Admin user is not supported in Gen2 (no default admin user)
+	d.Set("adminuser", nil)
+
+	// Admin password is not supported in Gen2
+	d.Set("adminpassword", nil)
+
 	// Allowlist is not supported in Gen2
 	d.Set(allowlistKey, nil)
 
 	// Users management is not supported in Gen2 (use ibm_resource_key instead)
 	d.Set("users", nil)
 
+	// Auto scaling is not supported in Gen2
+	d.Set("auto_scaling", nil)
+
 	// Configuration schema is not supported in Gen2
 	d.Set("configuration_schema", nil)
+
+	// Note: backup_encryption_key_crn within platform_options is also not supported in Gen2,
+	// but platform_options is handled by the data source implementation which only sets
+	// disk_encryption_key_crn for Gen2 instances
 }

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -292,6 +292,15 @@ func TestIsGen2Plan(t *testing.T) {
 // TestClearGen2UnsupportedAttributes tests the clearGen2UnsupportedAttributes function
 func TestClearGen2UnsupportedAttributes(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"adminuser": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"adminpassword": {
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+		},
 		"auto_scaling": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -333,6 +342,8 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 			Optional: true,
 		},
 	}, map[string]interface{}{
+		"adminuser":            "admin",
+		"adminpassword":        "password123",
 		"auto_scaling":         []interface{}{map[string]interface{}{"enabled": true}},
 		"allowlist":            []interface{}{map[string]interface{}{"address": "1.2.3.4"}},
 		"users":                []interface{}{map[string]interface{}{"name": "user1"}},
@@ -341,12 +352,18 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	clearGen2UnsupportedAttributes(d)
 
-	// auto_scaling is NOT cleared by clearGen2UnsupportedAttributes to avoid drift detection
-	// It should retain its original value
-	autoScaling := d.Get("auto_scaling")
-	require.NotEmpty(t, autoScaling, "auto_scaling should NOT be cleared (kept to avoid drift)")
+	// Verify all Gen2 unsupported attributes are cleared (d.Set(key, nil) results in empty values, not nil)
 
-	// Verify attributes that ARE cleared (d.Set(key, nil) results in empty values, not nil)
+	adminuser := d.Get("adminuser")
+	require.Equal(t, "", adminuser, "adminuser should be empty string after clearing")
+
+	adminpassword := d.Get("adminpassword")
+	require.Equal(t, "", adminpassword, "adminpassword should be empty string after clearing")
+
+	autoScaling := d.Get("auto_scaling")
+	require.NotNil(t, autoScaling, "auto_scaling should be set to empty value")
+	require.Empty(t, autoScaling, "auto_scaling should be empty after clearing")
+
 	allowlist := d.Get("allowlist")
 	require.NotNil(t, allowlist, "allowlist should be set to empty value")
 	require.Empty(t, allowlist, "allowlist should be empty after clearing")
@@ -357,6 +374,9 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	configSchema := d.Get("configuration_schema")
 	require.Equal(t, "", configSchema, "configuration_schema should be empty string after clearing")
+
+	// Note: platform_options.backup_encryption_key_crn is also not supported in Gen2,
+	// but it's handled by the data source implementation which only sets disk_encryption_key_crn
 }
 
 func TestExtractDeploymentIDFromCRN(t *testing.T) {

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -5,7 +5,6 @@ package database
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -358,33 +357,6 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	configSchema := d.Get("configuration_schema")
 	require.Equal(t, "", configSchema, "configuration_schema should be empty string after clearing")
-}
-
-// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
-// Catalog CRN format: crn:v1:bluemix:public:globalcatalog::::deployment:deployment-id
-// Returns the deployment ID or an error if the CRN format is invalid.
-func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
-	if catalogCRN == "" {
-		return "", fmt.Errorf("invalid catalog CRN format: empty CRN")
-	}
-
-	// Split by "deployment:" to extract the deployment ID
-	parts := strings.Split(catalogCRN, "deployment:")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid catalog CRN format: expected exactly one 'deployment:' prefix")
-	}
-
-	deploymentID := parts[1]
-	if deploymentID == "" {
-		return "", fmt.Errorf("empty deployment ID in catalog CRN")
-	}
-
-	// Check for multiple deployment prefixes (invalid format)
-	if strings.Contains(deploymentID, "deployment:") {
-		return "", fmt.Errorf("invalid catalog CRN format: multiple 'deployment:' prefixes found")
-	}
-
-	return deploymentID, nil
 }
 
 func TestExtractDeploymentIDFromCRN(t *testing.T) {

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -357,6 +358,33 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	configSchema := d.Get("configuration_schema")
 	require.Equal(t, "", configSchema, "configuration_schema should be empty string after clearing")
+}
+
+// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
+// Catalog CRN format: crn:v1:bluemix:public:globalcatalog::::deployment:deployment-id
+// Returns the deployment ID or an error if the CRN format is invalid.
+func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
+	if catalogCRN == "" {
+		return "", fmt.Errorf("invalid catalog CRN format: empty CRN")
+	}
+
+	// Split by "deployment:" to extract the deployment ID
+	parts := strings.Split(catalogCRN, "deployment:")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid catalog CRN format: expected exactly one 'deployment:' prefix")
+	}
+
+	deploymentID := parts[1]
+	if deploymentID == "" {
+		return "", fmt.Errorf("empty deployment ID in catalog CRN")
+	}
+
+	// Check for multiple deployment prefixes (invalid format)
+	if strings.Contains(deploymentID, "deployment:") {
+		return "", fmt.Errorf("invalid catalog CRN format: multiple 'deployment:' prefixes found")
+	}
+
+	return deploymentID, nil
 }
 
 func TestExtractDeploymentIDFromCRN(t *testing.T) {

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -36,13 +36,7 @@ import (
 )
 
 const (
-	databaseInstanceSuccessStatus      = "active"
-	databaseInstanceProvisioningStatus = "provisioning"
-	databaseInstanceProgressStatus     = "in progress"
-	databaseInstanceInactiveStatus     = "inactive"
-	databaseInstanceFailStatus         = "failed"
-	databaseInstanceRemovedStatus      = "removed"
-	databaseInstanceReclamation        = "pending_reclamation"
+	databaseInstanceReclamation = "pending_reclamation"
 )
 
 const (

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -36,7 +36,13 @@ import (
 )
 
 const (
-	databaseInstanceReclamation = "pending_reclamation"
+	databaseInstanceSuccessStatus      = "active"
+	databaseInstanceProvisioningStatus = "provisioning"
+	databaseInstanceProgressStatus     = "in progress"
+	databaseInstanceInactiveStatus     = "inactive"
+	databaseInstanceFailStatus         = "failed"
+	databaseInstanceRemovedStatus      = "removed"
+	databaseInstanceReclamation        = "pending_reclamation"
 )
 
 const (

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -75,7 +75,38 @@ In addition to all argument references list, you can access the following attrib
     - `rate_period_seconds`- (Integer) Auto scaling rate period in seconds.
     - `rate_units` - (String) Auto scaling rate in units.
 - `allowlist`  - (List) A list of allowed IP addresses or ranges.
+- `users` - (List) A list of users configured for the database.
 
 
 **Note**
-The provider only exports the admin user ID and associated connection string. It does not export any user IDs that are configured for the instance in addition. 
+The provider only exports the admin user ID and associated connection string. It does not export any user IDs that are configured for the instance in addition.
+
+
+## Gen2 Support
+This data source supports both Classic and Gen2 database instances. The backend is automatically selected based on the database plan.
+
+### Gen2 Limitations
+The following attributes are not supported for Gen2 databases:
+- `adminuser` - Gen2 databases do not create a default admin user. Use `ibm_resource_key` to manage credentials.
+- `adminpassword` - Not available for Gen2 databases. Use `ibm_resource_key` to manage credentials.
+- `users` - User management is not supported. Use `ibm_resource_key` to manage credentials.
+- `allowlist` - IP allowlisting is not supported for Gen2 databases. Use Context-Based Restrictions (`ibm_cbr_rule`) for IP allowlisting in Gen2.
+- `auto_scaling` - Auto-scaling configuration is not currently supported for Gen2 databases.
+- `configuration_schema` - Configuration schema is not available for Gen2 databases.
+- `platform_options.backup_encryption_key_crn` - Backup encryption key is not supported for Gen2 databases (only `disk_encryption_key_crn` is supported).
+
+### Gen2 Example
+```terraform
+data "ibm_database" "postgres_gen2" {
+  name     = "my-postgres-gen2"
+  location = "us-south"
+  service  = "databases-for-postgresql"
+}
+
+# Use ibm_resource_key to manage credentials for Gen2 databases
+resource "ibm_resource_key" "db_credentials" {
+  name                 = "my-db-credentials"
+  resource_instance_id = data.ibm_database.postgres_gen2.id
+  role                 = "Administrator"
+}
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Issue Ticket [https://github.ibm.com/compose/App/issues/2857](https://github.ibm.com/compose/App/issues/2857)

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
