### PR TITLE
Support network plugin selection at VPC cluster creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM-Cloud/terraform-provider-ibm
 go 1.25.2
 
 require (
-	github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31
+	github.com/IBM-Cloud/bluemix-go v0.0.0-20260526083905-8316c06b6742
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
 	github.com/IBM-Cloud/power-go-client v1.15.0
 	github.com/IBM/appconfiguration-go-admin-sdk v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31 h1:3ITr1iuk27+eZp7mIZYREU6MNnHxCXVZ3avoED5WniQ=
-github.com/IBM-Cloud/bluemix-go v0.0.0-20251201140418-17dfa457ce31/go.mod h1:lU1/3aolIs4y062yTTokFEiIEssAZqqjdj/5qvkBeq8=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20260526083905-8316c06b6742 h1:kZvz/rf6HICgTwfX6B+Qe1C/+I5vCUvIzFIKf/BXXNE=
+github.com/IBM-Cloud/bluemix-go v0.0.0-20260526083905-8316c06b6742/go.mod h1:S4FkCceVf+RgMsWU0mT1Khg8/fGFGGX95E+kbuxcMLQ=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/power-go-client v1.15.0 h1:bXkcx9DlhCmNr9w2xHI9lpzjkfM7uLVviaQGDAg0U50=

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -230,6 +230,12 @@ func DataSourceIBMContainerVPCCluster() *schema.Resource {
 				Description: "Custom subnet CIDR to provide private IP addresses for pods",
 				Computed:    true,
 			},
+			"network_plugin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Container Network Interface (CNI) plugin for the cluster. Requires OpenShift >= 4.20. Supported values: 'Calico' (default), 'OVNKubernetes'",
+				Computed:    true,
+			},
 			"ingress_hostname": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -430,6 +436,7 @@ func dataSourceIBMContainerClusterVPCRead(d *schema.ResourceData, meta interface
 	d.Set("worker_count", cls.WorkerCount)
 	d.Set("service_subnet", cls.ServiceSubnet)
 	d.Set("pod_subnet", cls.PodSubnet)
+	d.Set("network_plugin", cls.NetworkPlugin)
 	d.Set("state", cls.State)
 	d.Set("resource_group_id", cls.ResourceGroupID)
 	d.Set("public_service_endpoint_url", cls.ServiceEndpoints.PublicServiceEndpointURL)

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster.go
@@ -205,6 +205,14 @@ func ResourceIBMContainerVpcCluster() *schema.Resource {
 				Computed:    true,
 			},
 
+			"network_plugin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The Container Network Interface (CNI) plugin for the cluster. Requires OpenShift >= 4.20. Supported values: 'Calico' (default), 'OVNKubernetes'",
+				Computed:    true,
+			},
+
 			"worker_count": {
 				Type:             schema.TypeInt,
 				Optional:         true,
@@ -640,6 +648,11 @@ func resourceIBMContainerVpcClusterCreate(d *schema.ResourceData, meta interface
 		DisableOutboundTrafficProtection: disableOutboundTrafficProtection,
 	}
 
+	// Update params with CNI plugin option if provided
+	if v, ok := d.GetOk("network_plugin"); ok {
+		params.NetworkPlugin = v.(string)
+	}
+
 	// Update params with Entitlement option if provided
 	if v, ok := d.GetOk("entitlement"); ok {
 		params.DefaultWorkerPoolEntitlement = v.(string)
@@ -986,6 +999,7 @@ func resourceIBMContainerVpcClusterRead(d *schema.ResourceData, meta interface{}
 		d.Set("disable_public_service_endpoint", true)
 	}
 	d.Set("image_security_enforcement", cls.ImageSecurityEnabled)
+	d.Set("network_plugin", cls.NetworkPlugin)
 
 	tags, err := flex.GetTagsUsingCRN(meta, cls.CRN)
 	if err != nil {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -621,7 +621,7 @@ resource "ibm_container_vpc_cluster" "cluster" {
 }`, name, disable_outbound_traffic_protection)
 }
 
-// preveously you have to create securitygroups and use them instead
+// previously you had to create securitygroups and use them instead
 func testAccCheckIBMContainerVpcClusterSecurityGroups(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "resource_group" {

--- a/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
+++ b/ibm/service/kubernetes/resource_ibm_container_vpc_cluster_test.go
@@ -848,6 +848,54 @@ func TestAccIBMContainerVpcClusterKMSEnvvar(t *testing.T) {
 	})
 }
 
+func TestAccIBMContainerVpcClusterNetworkPluginNotConfigured(t *testing.T) {
+	name := fmt.Sprintf("tf-vpc-cluster-%d", acctest.RandIntRange(10, 100))
+	defaultNetworkPlugin := "Calico"
+	var conf *v2.ClusterInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMContainerVpcClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVpcClusterNetworkPlugin(name, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMContainerVpcExists("ibm_container_vpc_cluster.cluster", conf),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.cluster", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.cluster", "network_plugin", defaultNetworkPlugin),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMContainerVpcClusterNetworkPluginConfigured(t *testing.T) {
+	name := fmt.Sprintf("tf-vpc-cluster-%d", acctest.RandIntRange(10, 100))
+	networkPlugin := "OVNKubernetes"
+	var conf *v2.ClusterInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMContainerVpcClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMContainerVpcClusterNetworkPlugin(name, networkPlugin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMContainerVpcExists("ibm_container_vpc_cluster.cluster", conf),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.cluster", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_container_vpc_cluster.cluster", "network_plugin", networkPlugin),
+				),
+			},
+		},
+	})
+}
+
 // You need to set up env vars:
 // export IBM_CLUSTER_VPC_ID
 // export IBM_CLUSTER_VPC_SUBNET_ID
@@ -955,4 +1003,42 @@ func testAccCheckIBMContainerVpcClusterKMSEnvvar(name string) string {
 	`, name, acc.IksClusterVpcID, acc.IksClusterResourceGroupID, acc.IksClusterSubnetID, acc.KmsInstanceID, acc.CrkID)
 	fmt.Println(config)
 	return config
+}
+
+func testAccCheckIBMContainerVpcClusterNetworkPlugin(name, networkPlugin string) string {
+	region := acc.Region()
+
+	// networkPlugin is omitted from the config if the param is an empty string
+	networkPluginConfig := ""
+	if networkPlugin != "" {
+		networkPluginConfig = fmt.Sprintf(`network_plugin = "%s"`, networkPlugin)
+	}
+
+	return fmt.Sprintf(`
+data "ibm_resource_group" "resource_group" {
+	is_default = "true"
+}
+resource "ibm_is_vpc" "vpc" {
+	name = "%[1]s"
+}
+resource "ibm_is_subnet" "subnet" {
+	name                     = "%[1]s"
+	vpc                      = ibm_is_vpc.vpc.id
+	zone                     = "%[2]s-1"
+	total_ipv4_address_count = 256
+}
+resource "ibm_container_vpc_cluster" "cluster" {
+	name              = "%[1]s"
+	vpc_id            = ibm_is_vpc.vpc.id
+	flavor            = "cx2.2x4"
+	worker_count      = 1
+	kube_version      = "4.20_openshift"
+	wait_till         = "OneWorkerNodeReady"
+	resource_group_id = data.ibm_resource_group.resource_group.id
+	zones {
+		subnet_id = ibm_is_subnet.subnet.id
+		name      = "%[2]s-1"
+	}
+	%[3]s
+}`, name, region, networkPluginConfig)
 }

--- a/website/docs/r/container_vpc_cluster.html.markdown
+++ b/website/docs/r/container_vpc_cluster.html.markdown
@@ -221,6 +221,7 @@ Review the argument references that you can specify for your resource.
 - `security_groups` - (Optional, List) Enables users to define specific security groups for their workers.
 - `disable_outbound_traffic_protection` - (Optional, Bool) Include this option to allow public outbound access from the cluster workers. By default, public outbound access is blocked in OpenShift versions 4.15 and later and Kubernetes versions 1.30 and later. This option is usable only from OpenShift versions 4.15 and later and Kubernetes versions 1.30 and later.
 - `enable_secure_by_default` - (Optional, Bool) Enables Secure-by-default security group configuration. Once the upgrade begins, it cannot be undone. During the upgrade, network traffic to your cluster may temporarily be blocked. This option is usable only from OpenShift versions 4.15 and later and Kubernetes versions 1.30 and later.
+- `network_plugin` - (Optional, Forces new resource, String) The Container Network Interface (CNI) plugin for the cluster. Requires OpenShift >= 4.20. Supported values are `Calico` (default) and `OVNKubernetes`.
 
 **Note**
 
@@ -251,6 +252,7 @@ In addition to all argument reference list, you can access the following attribu
 - `vpe_service_endpoint_url` - (String) The virtual private endpoint URL.
 - `public_service_endpoint_url` - (String) The public service endpoint URL.
 - `state` - (String) The state of the VPC cluster.
+- `network_plugin` - The Container Network Interface (CNI) plugin configured for the cluster.
 
 
 ## Import


### PR DESCRIPTION
ROKS 4.20+ supports CNI selection at VPC cluster creation. This change adds that functionality to the terraform provider.

Related pull request: https://github.com/IBM-Cloud/bluemix-go/pull/493

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterNetworkPluginConfigured'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVpcClusterNetworkPluginConfigured -timeout 700m 
(...)
--- PASS: TestAccIBMContainerVpcClusterNetworkPluginConfigured (2541.69s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	2544.007s

$ make testacc TEST=./ibm/service/kubernetes TESTARGS='-run=TestAccIBMContainerVpcClusterNetworkPluginNotConfigured'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/kubernetes -v -run=TestAccIBMContainerVpcClusterNetworkPluginNotConfigured -timeout 700m
(...)
--- PASS: TestAccIBMContainerVpcClusterNetworkPluginNotConfigured (2611.11s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/kubernetes	2613.616s
...
```
