### PR TITLE
fix(vsi-downsize): Support VSI downsize across families along with vo…

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -7822,24 +7822,95 @@ func instanceUpdate(context context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
-	if d.HasChange(isInstanceProfile) && !d.IsNewResource() {
+	// Check if profile or total_volume_bandwidth are changing
+	profileChanged := d.HasChange(isInstanceProfile)
+	bandwidthChanged := d.HasChange(isInstanceTotalVolumeBandwidth)
 
-		getinsOptions := &vpcv1.GetInstanceOptions{
+	if (profileChanged || bandwidthChanged) && !d.IsNewResource() {
+		var needsRestart bool = false
+
+		// If profile is changing, we need to stop and restart the instance
+		if profileChanged {
+			needsRestart = true
+			getinsOptions := &vpcv1.GetInstanceOptions{
+				ID: &id,
+			}
+			instance, response, err := instanceC.GetInstanceWithContext(context, getinsOptions)
+			if err != nil {
+				if response != nil && response.StatusCode == 404 {
+					d.SetId("")
+					return nil
+				}
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetInstanceWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+
+			if instance != nil && *instance.Status == "running" {
+				actiontype := "stop"
+				createinsactoptions := &vpcv1.CreateInstanceActionOptions{
+					InstanceID: &id,
+					Type:       &actiontype,
+				}
+				_, response, err = instanceC.CreateInstanceActionWithContext(context, createinsactoptions)
+				if err != nil {
+					if response != nil && response.StatusCode == 404 {
+						return nil
+					}
+					tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateInstanceActionWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
+					log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+					return tfErr.GetDiag()
+				}
+				_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
+				if err != nil {
+					tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForInstanceActionStop failed: %s", err.Error()), "ibm_is_instance", "update")
+					log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+					return tfErr.GetDiag()
+				}
+			}
+		}
+
+		// Create a combined patch with both profile and bandwidth changes
+		updnetoptions := &vpcv1.UpdateInstanceOptions{
 			ID: &id,
 		}
-		instance, response, err := instanceC.GetInstanceWithContext(context, getinsOptions)
-		if err != nil {
-			if response != nil && response.StatusCode == 404 {
-				d.SetId("")
-				return nil
+
+		instancePatchModel := &vpcv1.InstancePatch{}
+
+		// Add profile to patch if it's changing
+		if profileChanged {
+			instanceProfile := d.Get(isInstanceProfile).(string)
+			profile := &vpcv1.InstancePatchProfile{
+				Name: &instanceProfile,
 			}
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetInstanceWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
+			instancePatchModel.Profile = profile
+		}
+
+		// Add total_volume_bandwidth to patch if it's changing
+		if bandwidthChanged {
+			totalVolBandwidth := int64(d.Get(isInstanceTotalVolumeBandwidth).(int))
+			instancePatchModel.TotalVolumeBandwidth = &totalVolBandwidth
+		}
+
+		// Convert to patch and apply
+		instancePatch, err := instancePatchModel.AsPatch()
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("instancePatchModel.AsPatch() failed: %s", err.Error()), "ibm_is_instance", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		updnetoptions.InstancePatch = instancePatch
+
+		_, response, err := instanceC.UpdateInstanceWithContext(context, updnetoptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateInstanceWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
 
-		if instance != nil && *instance.Status == "running" {
-			actiontype := "stop"
+		// If profile was changed, restart the instance
+		if needsRestart {
+			actiontype := "start"
 			createinsactoptions := &vpcv1.CreateInstanceActionOptions{
 				InstanceID: &id,
 				Type:       &actiontype,
@@ -7853,84 +7924,12 @@ func instanceUpdate(context context.Context, d *schema.ResourceData, meta interf
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 				return tfErr.GetDiag()
 			}
-			_, err = isWaitForInstanceActionStop(instanceC, d.Timeout(schema.TimeoutUpdate), id, d)
+			_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
 			if err != nil {
-				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForInstanceActionStop failed: %s", err.Error()), "ibm_is_instance", "update")
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForInstanceAvailable failed: %s", err.Error()), "ibm_is_instance", "update")
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 				return tfErr.GetDiag()
 			}
-		}
-
-		updnetoptions := &vpcv1.UpdateInstanceOptions{
-			ID: &id,
-		}
-
-		instanceProfile := d.Get(isInstanceProfile).(string)
-		profile := &vpcv1.InstancePatchProfile{
-			Name: &instanceProfile,
-		}
-		instanceProfilePatchModel := &vpcv1.InstancePatch{
-			Profile: profile,
-		}
-		instancePatch, err := instanceProfilePatchModel.AsPatch()
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("instanceProfilePatchModel.AsPatch() failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
-		}
-		updnetoptions.InstancePatch = instancePatch
-
-		_, response, err = instanceC.UpdateInstanceWithContext(context, updnetoptions)
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateInstanceWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
-		}
-
-		actiontype := "start"
-		createinsactoptions := &vpcv1.CreateInstanceActionOptions{
-			InstanceID: &id,
-			Type:       &actiontype,
-		}
-		_, response, err = instanceC.CreateInstanceActionWithContext(context, createinsactoptions)
-		if err != nil {
-			if response != nil && response.StatusCode == 404 {
-				return nil
-			}
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateInstanceActionWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
-		}
-		_, err = isWaitForInstanceAvailable(instanceC, d.Id(), d.Timeout(schema.TimeoutUpdate), d)
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("isWaitForInstanceAvailable failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
-		}
-
-	}
-	if d.HasChange(isInstanceTotalVolumeBandwidth) && !d.IsNewResource() {
-		totalVolBandwidth := int64(d.Get(isInstanceTotalVolumeBandwidth).(int))
-		updnetoptions := &vpcv1.UpdateInstanceOptions{
-			ID: &id,
-		}
-
-		instanceTotalVolumeBandwidthPatchModel := &vpcv1.InstancePatch{
-			TotalVolumeBandwidth: &totalVolBandwidth,
-		}
-		instancePatch, err := instanceTotalVolumeBandwidthPatchModel.AsPatch()
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("instanceTotalVolumeBandwidthPatchModel.AsPatch() failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
-		}
-		updnetoptions.InstancePatch = instancePatch
-
-		_, _, err = instanceC.UpdateInstanceWithContext(context, updnetoptions)
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateInstanceWithContext failed: %s", err.Error()), "ibm_is_instance", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
 		}
 	}
 

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -4443,6 +4443,61 @@ func testAccCheckIBMISInstanceConfigWithProfileAndBandwidth(vpcname, subnetname,
 	}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, profile, bandwidth, prefix, acc.ISZoneName)
 }
 
+// Test for downsizing profile with bandwidth adjustment
+func TestAccIBMISInstance_ProfileDownsizeWithBandwidth(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instance-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+	initialProfile := "cx2-48x96" // Larger profile with high bandwidth capacity
+	downsizedProfile := "cx2-4x8" // Smaller profile with lower bandwidth capacity
+	initialBandwidth := 20000     // High bandwidth valid for larger profile
+	downsizedBandwidth := 2000    // Reduced bandwidth to fit smaller profile
+	prefix := fmt.Sprintf("tf-prefix-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceConfigWithProfileAndBandwidth(
+					vpcname, subnetname, sshname, publicKey, name, prefix, initialProfile, initialBandwidth),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "profile", initialProfile),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "total_volume_bandwidth", fmt.Sprintf("%d", initialBandwidth)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+			{
+				Config: testAccCheckIBMISInstanceConfigWithProfileAndBandwidth(
+					vpcname, subnetname, sshname, publicKey, name, prefix, downsizedProfile, downsizedBandwidth),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "profile", downsizedProfile),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "total_volume_bandwidth", fmt.Sprintf("%d", downsizedBandwidth)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+				),
+			},
+		},
+	})
+}
+
 // volume tags
 
 func TestAccIBMISInstance_volumeTags(t *testing.T) {

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -960,8 +960,12 @@ Review the argument references that you can specify for your resource.
 
   **NOTE:**
   When the `profile` is changed, the VSI is restarted. The new profile must:
-    1. Have matching instance disk support. Any disks associated with the current profile will be deleted, and any disks associated with the requested profile will be created.        
+    1. Have matching instance disk support. Any disks associated with the current profile will be deleted, and any disks associated with the requested profile will be created.
     2. Be compatible with any placement_target(`dedicated_host`, `dedicated_host_group`, `placement_group`) constraints. For example, if the instance is placed on a dedicated host, the requested profile family must be the same as the dedicated host family.
+    3. Have the same `vcpu.architecture` (e.g., amd64 or s390x).
+    4. Support the current number of network attachments or network interfaces.
+    5. Have the `volume_bandwidth_qos_mode` listed in its `volume_bandwidth_qos_modes`.
+    6. **When downsizing to a profile with lower bandwidth capacity, you must also adjust `total_volume_bandwidth` to fit within the new profile's limits.** The instance's storage bandwidth must be at least 500 Mbps less than the target profile's total bandwidth. Both `profile` and `total_volume_bandwidth` can be updated in the same Terraform apply operation.
 
 - `reservation_affinity` - (Optional, List) The reservation affinity for the instance
   Nested scheme for `reservation_affinity`:


### PR DESCRIPTION
…lume bandwidth

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
