### PR TITLE
Feat 2857:  Implement Gen2 Support for `ibm_database` datasource

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -226,7 +226,6 @@ var (
 	IksClusterSubnetID        string
 	IksClusterResourceGroupID string
 	IcdDbDeploymentId         string
-	IcdDbGen2DeploymentId     string
 	IcdDbBackupId             string
 	IcdDbTaskId               string
 	KmsInstanceID             string
@@ -1195,12 +1194,6 @@ func init() {
 	if IcdDbDeploymentId == "" {
 		IcdDbDeploymentId = "crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::"
 		fmt.Println("[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'")
-	}
-
-	IcdDbGen2DeploymentId = os.Getenv("ICD_DB_GEN2_DEPLOYMENT_ID")
-	if IcdDbGen2DeploymentId == "" {
-		IcdDbGen2DeploymentId = "my-postgres-gen2"
-		fmt.Println("[INFO] Set the environment variable ICD_DB_GEN2_DEPLOYMENT_ID for testing Gen2 databases else it is set to default value 'my-postgres-gen2'")
 	}
 
 	IcdDbBackupId = os.Getenv("ICD_DB_BACKUP_ID")

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -226,6 +226,7 @@ var (
 	IksClusterSubnetID        string
 	IksClusterResourceGroupID string
 	IcdDbDeploymentId         string
+	IcdDbGen2DeploymentId     string
 	IcdDbBackupId             string
 	IcdDbTaskId               string
 	KmsInstanceID             string
@@ -1194,6 +1195,12 @@ func init() {
 	if IcdDbDeploymentId == "" {
 		IcdDbDeploymentId = "crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::"
 		fmt.Println("[INFO] Set the environment variable ICD_DB_DEPLOYMENT_ID for testing ibm_cloud_databases else it is set to default value 'crn:v1:bluemix:public:databases-for-redis:au-syd:a/40ddc34a953a8c02f10987b59085b60e:5042afe1-72c2-4231-89cc-c949e5d56251::'")
+	}
+
+	IcdDbGen2DeploymentId = os.Getenv("ICD_DB_GEN2_DEPLOYMENT_ID")
+	if IcdDbGen2DeploymentId == "" {
+		IcdDbGen2DeploymentId = "my-postgres-gen2"
+		fmt.Println("[INFO] Set the environment variable ICD_DB_GEN2_DEPLOYMENT_ID for testing Gen2 databases else it is set to default value 'my-postgres-gen2'")
 	}
 
 	IcdDbBackupId = os.Getenv("ICD_DB_BACKUP_ID")

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -92,12 +92,12 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Computed:    true,
 			},
 			"adminuser": {
-				Description: "The admin user id for the instance",
+				Description: "The admin user id for the instance. Note: In Gen2, there is no default admin user. Users should manage credentials using the ibm_resource_key resource (https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_key).",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"adminpassword": {
-				Description: "The admin user id for the instance",
+				Description: "The admin user id for the instance. Note: This attribute is not supported for Gen2 database instances",
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
@@ -119,7 +119,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 							Computed:    true,
 						},
 						"backup_encryption_key_crn": {
-							Description: "Backup encryption key crn",
+							Description: "Backup encryption key crn. Note: This attribute is not supported for Gen2 database instances",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
@@ -133,8 +133,9 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"users": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Database users. Note: This attribute is not supported for Gen2 database instances.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -152,8 +153,9 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 				},
 			},
 			"allowlist": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Allowlist for database access. Note: This attribute is not supported for Gen2 database instances.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address": {
@@ -326,7 +328,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 			},
 			"auto_scaling": {
 				Type:        schema.TypeList,
-				Description: "ICD Auto Scaling",
+				Description: "ICD Auto Scaling. Note: This attribute is currently not supported for Gen2 database instances.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -486,7 +488,7 @@ func DataSourceIBMDatabaseInstance() *schema.Resource {
 			"configuration_schema": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The configuration schema in JSON format",
+				Description: "The configuration schema in JSON format, Note: This attribute is currently not supported for Gen2 database instances.",
 			},
 			flex.ResourceName: {
 				Type:        schema.TypeString,

--- a/ibm/service/database/data_source_ibm_database.go
+++ b/ibm/service/database/data_source_ibm_database.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
@@ -39,7 +41,7 @@ func pickDataSourceBackend(d *schema.ResourceData, meta interface{}) (dataSource
 
 func DataSourceIBMDatabaseInstance() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceIBMDatabaseInstanceRead,
+		ReadContext: dataSourceIBMDatabaseInstanceRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -621,13 +623,17 @@ func findInstance(d *schema.ResourceData, meta interface{}) (*rc.ResourceInstanc
 	return &filteredInstances[0], nil
 }
 
-func dataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceIBMDatabaseInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	b, err := pickDataSourceBackend(d, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return b.Read(d, meta)
+	err = b.Read(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 func classicDataSourceIBMDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {

--- a/ibm/service/database/data_source_ibm_database_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_gen2.go
@@ -3,6 +3,8 @@ package database
 import (
 	"fmt"
 
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -12,18 +14,92 @@ func newDataSourceIBMDatabaseGen2Backend() dataSourceIBMDatabaseBackend {
 	return &dataSourceIBMDatabaseGen2Backend{}
 }
 
+// Read retrieves and populates the state for a Gen2 database instance data source.
+// It handles the migration scenario where a data source may have previously resolved
+// to a Classic instance and now resolves to a Gen2 instance, ensuring stale Classic-only
+// attributes are properly cleared from state.
+//
+// IMPORTANT: Gen2 Migration Edge Case
+// =====================================
+// When a data source previously resolved to a Classic instance and later resolves
+// to a Gen2 instance (e.g., due to filter changes), Terraform does not automatically
+// clear attributes that are no longer set. This differs from resources which would
+// trigger ForceNew on such changes.
+//
+// Result: Gen2-unsupported attributes (adminuser, auto_scaling, allowlist) may
+// persist with stale Classic values in state.
+//
+// Mitigation: These attributes are explicitly set to nil below to ensure state
+// consistency. This is the recommended approach as fully resetting data source
+// state is considered an anti-pattern in Terraform.
 func (g *dataSourceIBMDatabaseGen2Backend) Read(d *schema.ResourceData, meta interface{}) error {
-	// NOTE - Edge case: potential stale values for unsupported Gen2 attributes.
-	// If this data source was previously resolved to a Classic instance, all
-	// attributes (including ones not supported by Gen2) would have been set.
-	// If the same filters later resolve to a Gen2 instance (e.g., name/location/service),
-	// Terraform will not automatically clear attributes that are no longer set,
-	// unlike a resource which would ForceNew on such changes.
-	// As a result, the Gen2 read path may only set supported attributes while
-	// previously populated Classic-only attributes remain stale in state.
-	// There is no clean mechanism to fully reset datasource state, and doing so
-	// is generally considered an anti-pattern.
-	// If this becomes an issue, unsupported attributes could be explicitly set
-	// to null via d.Set() to ensure stale values are cleared.
-	return fmt.Errorf("gen2 backend not implemented yet")
+	// Find the database instance
+	instance, err := findInstance(d, meta)
+	if err != nil {
+		return fmt.Errorf("failed to find database instance: %w", err)
+	}
+	if instance == nil || instance.ID == nil {
+		return fmt.Errorf("database instance not found or missing ID")
+	}
+	d.SetId(*instance.ID)
+
+	// Set basic attributes
+	if err := g.setBasicAttributes(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Set service and plan information
+	if err := g.setServiceInfo(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Set version information
+	g.setVersionInfo(d, instance)
+
+	// Set groups information
+	if err := g.setGroupsInfo(d, instance, meta); err != nil {
+		return err
+	}
+
+	// Clear Gen2 unsupported attributes
+	g.clearUnsupportedAttributes(d)
+
+	return nil
+}
+
+// setBasicAttributes sets basic instance attributes including tags, name, status, location, and resource controller attributes.
+// Uses shared helper functions to reduce duplication with resource file.
+func (g *dataSourceIBMDatabaseGen2Backend) setBasicAttributes(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	// Data sources don't need service_endpoints or resource_controller_url
+	return setGen2BasicAttributes(d, instance, meta, false, false)
+}
+
+// setServiceInfo retrieves and sets service and plan information from Global Catalog.
+// Clears admin user attribute as it's not available in Gen2.
+func (g *dataSourceIBMDatabaseGen2Backend) setServiceInfo(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	return setGen2ServiceInfo(d, instance, meta)
+}
+
+// setVersionInfo extracts and sets version information from instance extensions.
+// Also sets platform_options if available.
+func (g *dataSourceIBMDatabaseGen2Backend) setVersionInfo(d *schema.ResourceData, instance *rc.ResourceInstance) {
+	// Use shared Gen2 helper function
+	// Data sources include platform_options
+	setGen2VersionInfo(d, instance, true)
+}
+
+// setGroupsInfo retrieves and sets groups information from catalog.
+// Combines instance extensions with catalog metadata to build group configurations.
+func (g *dataSourceIBMDatabaseGen2Backend) setGroupsInfo(d *schema.ResourceData, instance *rc.ResourceInstance, meta interface{}) error {
+	// Use shared Gen2 helper function
+	return setGen2GroupsInfo(d, instance, meta)
+}
+
+// clearUnsupportedAttributes clears attributes not supported in Gen2.
+// Sets auto_scaling and allowlist to nil to prevent stale Classic values.
+func (g *dataSourceIBMDatabaseGen2Backend) clearUnsupportedAttributes(d *schema.ResourceData) {
+	// Use shared Gen2 helper function
+	clearGen2UnsupportedAttributes(d)
 }

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -37,10 +37,10 @@ func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataName, "name", testName),
 					resource.TestCheckResourceAttr(dataName, "service", "databases-for-postgresql"),
 					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
-					// Verify Gen2-specific behavior: no adminuser, auto_scaling, or allowlist
-					resource.TestCheckNoResourceAttr(dataName, "adminuser"),
-					resource.TestCheckNoResourceAttr(dataName, "auto_scaling"),
-					resource.TestCheckNoResourceAttr(dataName, "allowlist"),
+					// Verify Gen2-specific behavior: adminuser, auto_scaling, and allowlist are empty/nil
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
 					// Verify groups are set
 					resource.TestCheckResourceAttrSet(dataName, "groups.#"),
 				),

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -9,30 +9,64 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
+	t.Parallel()
+	var databaseInstanceOne string
+	testName := acc.IcdDbGen2DeploymentId
+	dataName := "data.ibm_database.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckIBMDatabaseDataSourceGen2ConfigBasic(),
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "id"),
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "name"),
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "status"),
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "version"),
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "guid"),
-					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "location"),
+					testAccCheckIBMDatabaseInstanceExists(dataName, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(dataName, "name", testName),
+					resource.TestCheckResourceAttr(dataName, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttrSet(dataName, "location"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
 					// Test Gen2-specific behavior: unsupported attributes should be empty
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "adminuser", ""),
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "adminpassword", ""),
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "users.#", "0"),
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "allowlist.#", "0"),
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "auto_scaling.#", "0"),
-					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "configuration_schema", ""),
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
+					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMDatabaseDataSourceGen2WithResourceGroupID(t *testing.T) {
+	t.Parallel()
+	var databaseInstanceOne string
+	testName := acc.IcdDbGen2DeploymentId
+	dataName := "data.ibm_database.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2ConfigWithResourceGroup(testName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(dataName, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(dataName, "name", testName),
+					resource.TestCheckResourceAttr(dataName, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttrSet(dataName, "location"),
+					resource.TestCheckResourceAttrSet(dataName, "resource_group_id"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
 				),
 			},
 		},
@@ -44,7 +78,7 @@ func TestAccIBMDatabaseDataSourceGen2InvalidInput(t *testing.T) {
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidConfig(),
 				ExpectError: regexp.MustCompile("No resource instance found"),
 			},
@@ -57,7 +91,7 @@ func TestAccIBMDatabaseDataSourceGen2InvalidID(t *testing.T) {
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidIDConfig(),
 				ExpectError: regexp.MustCompile("No resource instance found|invalid"),
 			},
@@ -65,12 +99,20 @@ func TestAccIBMDatabaseDataSourceGen2InvalidID(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMDatabaseDataSourceGen2ConfigBasic() string {
+func testAccCheckIBMDatabaseDataSourceGen2Config(name string) string {
 	return fmt.Sprintf(`
-		data "ibm_database" "database_gen2" {
-			name = "%[1]s"
-		}
-	`, acc.IcdDbGen2DeploymentId)
+	data "ibm_database" "test" {
+		name = "%s"
+	}
+	`, name)
+}
+
+func testAccCheckIBMDatabaseDataSourceGen2ConfigWithResourceGroup(name string) string {
+	return fmt.Sprintf(`
+	data "ibm_database" "test" {
+		name = "%s"
+	}
+	`, name)
 }
 
 func testAccCheckIBMDatabaseDataSourceGen2InvalidConfig() string {

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -1,0 +1,169 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package database_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccIBMDatabaseDataSourceGen2Basic tests basic Gen2 data source read
+func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
+	testName := fmt.Sprintf("tf-gen2-db-%s", acctest.RandString(16))
+	dataName := "data.ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataName, "name", testName),
+					resource.TestCheckResourceAttr(dataName, "service", "databases-for-mongodb"),
+					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(dataName, "location", "ca-mon"),
+					resource.TestCheckResourceAttrSet(dataName, "status"),
+					resource.TestCheckResourceAttrSet(dataName, "version"),
+					resource.TestCheckResourceAttrSet(dataName, "guid"),
+					resource.TestCheckResourceAttr(dataName, "groups.#", "1"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
+					resource.TestCheckResourceAttrSet(dataName, "groups.0.cpu.0.allocation_count"),
+					// Verify Gen2-unsupported attributes are NOT set
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+				),
+			},
+		},
+	})
+}
+
+// TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes validates that
+// Gen2-unsupported attributes remain empty even when explicitly checked
+func TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes(t *testing.T) {
+	testName := fmt.Sprintf("tf-gen2-unsup-%s", acctest.RandString(16))
+	dataName := "data.ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
+				Check: resource.ComposeTestCheckFunc(
+					// Explicitly verify each unsupported attribute is empty
+					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
+					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
+					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
+					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+				),
+			},
+		},
+	})
+}
+
+// TestAccIBMDatabaseDataSourceGen2InvalidInput tests error handling
+// for invalid database name
+func TestAccIBMDatabaseDataSourceGen2InvalidInput(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidConfig(),
+				ExpectError: regexp.MustCompile("No resource instance found"),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDatabaseDataSourceGen2Config(name string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "db" {
+  name              = "%[1]s"
+  plan              = "standard-gen2"
+  location          = "ca-mon"
+  service           = "databases-for-mongodb"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "bx3d.4x20"
+    }
+    disk {
+      allocation_mb = 20480
+    }
+  }
+
+  tags = ["gen2-test"]
+}
+
+data "ibm_database" "%[1]s" {
+  name              = ibm_database.db.name
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  location          = ibm_database.db.location
+  service           = ibm_database.db.service
+}
+`, name)
+}
+
+func testAccCheckIBMDatabaseDataSourceGen2InvalidConfig() string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+data "ibm_database" "nonexistent" {
+  name              = "this-database-does-not-exist-gen2-%s"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  location          = "ca-mon"
+  service           = "databases-for-mongodb"
+}
+`, acctest.RandString(8))
+}
+
+func testAccCheckIBMDatabaseGen2CheckPlansConfig(service string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "gen2_check" {
+  name              = "tf-gen2-check-%s"
+  plan              = "standard-gen2"
+  location          = "ca-mon"
+  service           = "%s"
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "bx3d.4x20"
+    }
+    disk {
+      allocation_mb = 20480
+    }
+  }
+
+  tags = ["gen2-availability-check"]
+}
+`, acctest.RandString(8), service)
+}

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -10,13 +10,16 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// TestAccIBMDatabaseDataSourceGen2Basic tests the Gen2 database data source.
+// Note: This test creates a real database instance which can take 30-60 minutes.
+// Run with: go test -timeout 120m -run TestAccIBMDatabaseDataSourceGen2Basic ./ibm/service/database/...
 func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
 	t.Parallel()
-	var databaseInstanceOne string
-	testName := acc.IcdDbGen2DeploymentId
+	testName := fmt.Sprintf("tf-gen2-db-%s", acctest.RandString(10))
 	dataName := "data.ibm_database.test"
 
 	resource.Test(t, resource.TestCase{
@@ -26,47 +29,20 @@ func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
 			{
 				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMDatabaseInstanceExists(dataName, &databaseInstanceOne),
+					resource.TestCheckResourceAttrSet(dataName, "id"),
+					resource.TestCheckResourceAttrSet(dataName, "name"),
+					resource.TestCheckResourceAttrSet(dataName, "service"),
+					resource.TestCheckResourceAttrSet(dataName, "plan"),
+					resource.TestCheckResourceAttrSet(dataName, "location"),
 					resource.TestCheckResourceAttr(dataName, "name", testName),
 					resource.TestCheckResourceAttr(dataName, "service", "databases-for-postgresql"),
 					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
-					resource.TestCheckResourceAttrSet(dataName, "location"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
-					// Test Gen2-specific behavior: unsupported attributes should be empty
-					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
-					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
-					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIBMDatabaseDataSourceGen2WithResourceGroupID(t *testing.T) {
-	t.Parallel()
-	var databaseInstanceOne string
-	testName := acc.IcdDbGen2DeploymentId
-	dataName := "data.ibm_database.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMDatabaseDataSourceGen2ConfigWithResourceGroup(testName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIBMDatabaseInstanceExists(dataName, &databaseInstanceOne),
-					resource.TestCheckResourceAttr(dataName, "name", testName),
-					resource.TestCheckResourceAttr(dataName, "service", "databases-for-postgresql"),
-					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
-					resource.TestCheckResourceAttrSet(dataName, "location"),
-					resource.TestCheckResourceAttrSet(dataName, "resource_group_id"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
+					// Verify Gen2-specific behavior: no adminuser, auto_scaling, or allowlist
+					resource.TestCheckNoResourceAttr(dataName, "adminuser"),
+					resource.TestCheckNoResourceAttr(dataName, "auto_scaling"),
+					resource.TestCheckNoResourceAttr(dataName, "allowlist"),
+					// Verify groups are set
+					resource.TestCheckResourceAttrSet(dataName, "groups.#"),
 				),
 			},
 		},
@@ -101,16 +77,40 @@ func TestAccIBMDatabaseDataSourceGen2InvalidID(t *testing.T) {
 
 func testAccCheckIBMDatabaseDataSourceGen2Config(name string) string {
 	return fmt.Sprintf(`
-	data "ibm_database" "test" {
-		name = "%s"
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
 	}
-	`, name)
-}
 
-func testAccCheckIBMDatabaseDataSourceGen2ConfigWithResourceGroup(name string) string {
-	return fmt.Sprintf(`
+	resource "ibm_database" "test" {
+		resource_group_id = data.ibm_resource_group.test_acc.id
+		name              = "%[1]s"
+		service           = "databases-for-postgresql"
+		plan              = "standard-gen2"
+		location          = "ca-mon"
+		service_endpoints = "private"
+
+		group {
+			group_id = "member"
+
+			host_flavor {
+				id = "bx3d.4x20"
+			}
+
+			disk {
+				allocation_mb = 20480
+			}
+		}
+
+		timeouts {
+			create = "120m"
+			update = "60m"
+			delete = "60m"
+		}
+	}
+
 	data "ibm_database" "test" {
-		name = "%s"
+		resource_group_id = data.ibm_resource_group.test_acc.id
+		name              = ibm_database.test.name
 	}
 	`, name)
 }

--- a/ibm/service/database/data_source_ibm_database_gen2_test.go
+++ b/ibm/service/database/data_source_ibm_database_gen2_test.go
@@ -9,80 +9,42 @@ import (
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TestAccIBMDatabaseDataSourceGen2Basic tests basic Gen2 data source read
 func TestAccIBMDatabaseDataSourceGen2Basic(t *testing.T) {
-	testName := fmt.Sprintf("tf-gen2-db-%s", acctest.RandString(16))
-	dataName := "data.ibm_database." + testName
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
+			resource.TestStep{
+				Config: testAccCheckIBMDatabaseDataSourceGen2ConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataName, "name", testName),
-					resource.TestCheckResourceAttr(dataName, "service", "databases-for-mongodb"),
-					resource.TestCheckResourceAttr(dataName, "plan", "standard-gen2"),
-					resource.TestCheckResourceAttr(dataName, "location", "ca-mon"),
-					resource.TestCheckResourceAttrSet(dataName, "status"),
-					resource.TestCheckResourceAttrSet(dataName, "version"),
-					resource.TestCheckResourceAttrSet(dataName, "guid"),
-					resource.TestCheckResourceAttr(dataName, "groups.#", "1"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.memory.0.allocation_mb"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.disk.0.allocation_mb"),
-					resource.TestCheckResourceAttrSet(dataName, "groups.0.cpu.0.allocation_count"),
-					// Verify Gen2-unsupported attributes are NOT set
-					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
-					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
-					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "status"),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "version"),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "guid"),
+					resource.TestCheckResourceAttrSet("data.ibm_database.database_gen2", "location"),
+					// Test Gen2-specific behavior: unsupported attributes should be empty
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "adminuser", ""),
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "adminpassword", ""),
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "users.#", "0"),
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "allowlist.#", "0"),
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "auto_scaling.#", "0"),
+					resource.TestCheckResourceAttr("data.ibm_database.database_gen2", "configuration_schema", ""),
 				),
 			},
 		},
 	})
 }
 
-// TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes validates that
-// Gen2-unsupported attributes remain empty even when explicitly checked
-func TestAccIBMDatabaseDataSourceGen2UnsupportedAttributes(t *testing.T) {
-	testName := fmt.Sprintf("tf-gen2-unsup-%s", acctest.RandString(16))
-	dataName := "data.ibm_database." + testName
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckIBMDatabaseDataSourceGen2Config(testName),
-				Check: resource.ComposeTestCheckFunc(
-					// Explicitly verify each unsupported attribute is empty
-					resource.TestCheckResourceAttr(dataName, "adminuser", ""),
-					resource.TestCheckResourceAttr(dataName, "adminpassword", ""),
-					resource.TestCheckResourceAttr(dataName, "auto_scaling.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "allowlist.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "users.#", "0"),
-					resource.TestCheckResourceAttr(dataName, "configuration_schema", ""),
-				),
-			},
-		},
-	})
-}
-
-// TestAccIBMDatabaseDataSourceGen2InvalidInput tests error handling
-// for invalid database name
 func TestAccIBMDatabaseDataSourceGen2InvalidInput(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidConfig(),
 				ExpectError: regexp.MustCompile("No resource instance found"),
 			},
@@ -90,80 +52,39 @@ func TestAccIBMDatabaseDataSourceGen2InvalidInput(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMDatabaseDataSourceGen2Config(name string) string {
+func TestAccIBMDatabaseDataSourceGen2InvalidID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccCheckIBMDatabaseDataSourceGen2InvalidIDConfig(),
+				ExpectError: regexp.MustCompile("No resource instance found|invalid"),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDatabaseDataSourceGen2ConfigBasic() string {
 	return fmt.Sprintf(`
-data "ibm_resource_group" "test_acc" {
-  is_default = true
-}
-
-resource "ibm_database" "db" {
-  name              = "%[1]s"
-  plan              = "standard-gen2"
-  location          = "ca-mon"
-  service           = "databases-for-mongodb"
-  resource_group_id = data.ibm_resource_group.test_acc.id
-  
-  group {
-    group_id = "member"
-    host_flavor {
-      id = "bx3d.4x20"
-    }
-    disk {
-      allocation_mb = 20480
-    }
-  }
-
-  tags = ["gen2-test"]
-}
-
-data "ibm_database" "%[1]s" {
-  name              = ibm_database.db.name
-  resource_group_id = data.ibm_resource_group.test_acc.id
-  location          = ibm_database.db.location
-  service           = ibm_database.db.service
-}
-`, name)
+		data "ibm_database" "database_gen2" {
+			name = "%[1]s"
+		}
+	`, acc.IcdDbGen2DeploymentId)
 }
 
 func testAccCheckIBMDatabaseDataSourceGen2InvalidConfig() string {
-	return fmt.Sprintf(`
-data "ibm_resource_group" "test_acc" {
-  is_default = true
+	return `
+		data "ibm_database" "nonexistent" {
+			name = "this-database-does-not-exist-gen2-test"
+		}
+	`
 }
 
-data "ibm_database" "nonexistent" {
-  name              = "this-database-does-not-exist-gen2-%s"
-  resource_group_id = data.ibm_resource_group.test_acc.id
-  location          = "ca-mon"
-  service           = "databases-for-mongodb"
-}
-`, acctest.RandString(8))
-}
-
-func testAccCheckIBMDatabaseGen2CheckPlansConfig(service string) string {
-	return fmt.Sprintf(`
-data "ibm_resource_group" "test_acc" {
-  is_default = true
-}
-
-resource "ibm_database" "gen2_check" {
-  name              = "tf-gen2-check-%s"
-  plan              = "standard-gen2"
-  location          = "ca-mon"
-  service           = "%s"
-  resource_group_id = data.ibm_resource_group.test_acc.id
-  
-  group {
-    group_id = "member"
-    host_flavor {
-      id = "bx3d.4x20"
-    }
-    disk {
-      allocation_mb = 20480
-    }
-  }
-
-  tags = ["gen2-availability-check"]
-}
-`, acctest.RandString(8), service)
+func testAccCheckIBMDatabaseDataSourceGen2InvalidIDConfig() string {
+	return `
+		data "ibm_database" "invalid_id" {
+			name = "invalid@#$%^&*()id"
+		}
+	`
 }

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -161,10 +161,15 @@ func extractLocationFromCRN(crn *string) (string, error) {
 
 // extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
 // Catalog CRN format: crn:v1:bluemix:public:globalcatalog::::deployment:deployment-id
-// Returns the deployment ID or an error if the CRN format is invalid.
+// Some callers may already provide the deployment ID directly.
+// Returns the deployment ID or an error if the input is invalid.
 func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
 	if catalogCRN == "" {
 		return "", fmt.Errorf("invalid catalog CRN format: empty CRN")
+	}
+
+	if !strings.HasPrefix(catalogCRN, "crn:") {
+		return catalogCRN, nil
 	}
 
 	// Split by "deployment:" to extract the deployment ID
@@ -404,12 +409,20 @@ func buildHostFlavorConfig(hostFlavorID string) []map[string]interface{} {
 	return []map[string]interface{}{hostflavor}
 }
 
-// getInitialNodeCountGen2 retrieves the default member count for Gen2 plans from Global Catalog.
-// Returns the member count from the catalog metadata, or a default value of 3 if not found.
-func getInitialNodeCountGen2(deploymentID string, meta interface{}) (int, error) {
+// getInitialNodeCountGen2 retrieves the default member count for a Gen2 deployment from Global Catalog.
+// The input may be either a deployment catalog CRN or a deployment ID.
+// Returns the member count from the catalog metadata, or a default value if not found.
+// If the deployment reference is not a valid Global Catalog entry ID in the current environment,
+// fall back to the provider default instead of failing create.
+func getInitialNodeCountGen2(deploymentRef string, meta interface{}) (int, error) {
 	globalClient, err := meta.(conns.ClientSession).GlobalCatalogV1API()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get global catalog client: %w", err)
+	}
+
+	deploymentID, err := extractDeploymentIDFromCRN(deploymentRef)
+	if err != nil {
+		return 0, fmt.Errorf("failed to normalize deployment reference: %w", err)
 	}
 
 	options := &globalcatalogv1.GetCatalogEntryOptions{
@@ -418,7 +431,8 @@ func getInitialNodeCountGen2(deploymentID string, meta interface{}) (int, error)
 
 	deployment, _, err := globalClient.GetCatalogEntry(options)
 	if err != nil {
-		return 0, fmt.Errorf("error retrieving deployment catalog entry: %w", err)
+		log.Printf("[WARN] Unable to retrieve Gen2 deployment catalog entry %q, using default member count %d: %v", deploymentID, defaultMemberCount, err)
+		return defaultMemberCount, nil
 	}
 
 	// Extract member count from deployment metadata

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -34,7 +34,9 @@ const (
 	defaultMemberCount = 3
 
 	// Instance states - shared across Classic and Gen2
-	instanceStateRemoved               = "removed"
+	instanceStateRemoved = "removed"
+
+	// Database instance status constants
 	databaseInstanceSuccessStatus      = "active"
 	databaseInstanceProvisioningStatus = "provisioning"
 	databaseInstanceProgressStatus     = "in progress"
@@ -49,7 +51,9 @@ const (
 	resourcesKey       = "resources"
 	platformOptionsKey = "platform_options"
 	adminUserKey       = "adminuser"
+	autoScalingKey     = "auto_scaling"
 	allowlistKey       = "allowlist"
+	databaseUserType   = "database"
 )
 
 type TimeoutHelper struct {
@@ -153,6 +157,33 @@ func extractLocationFromCRN(crn *string) (string, error) {
 		return "", fmt.Errorf("invalid CRN format: expected at least 6 parts, got %d", len(parts))
 	}
 	return parts[5], nil
+}
+
+// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
+// Catalog CRN format: crn:v1:bluemix:public:globalcatalog::::deployment:deployment-id
+// Returns the deployment ID or an error if the CRN format is invalid.
+func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
+	if catalogCRN == "" {
+		return "", fmt.Errorf("invalid catalog CRN format: empty CRN")
+	}
+
+	// Split by "deployment:" to extract the deployment ID
+	parts := strings.Split(catalogCRN, "deployment:")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid catalog CRN format: expected exactly one 'deployment:' prefix")
+	}
+
+	deploymentID := parts[1]
+	if deploymentID == "" {
+		return "", fmt.Errorf("empty deployment ID in catalog CRN")
+	}
+
+	// Check for multiple deployment prefixes (invalid format)
+	if strings.Contains(deploymentID, "deployment:") {
+		return "", fmt.Errorf("invalid catalog CRN format: multiple 'deployment:' prefixes found")
+	}
+
+	return deploymentID, nil
 }
 
 // wrapAPIError wraps an API error with operation context and response details.
@@ -373,31 +404,12 @@ func buildHostFlavorConfig(hostFlavorID string) []map[string]interface{} {
 	return []map[string]interface{}{hostflavor}
 }
 
-// extractDeploymentIDFromCRN extracts the deployment ID from a catalog CRN.
-func extractDeploymentIDFromCRN(catalogCRN string) (string, error) {
-	// Split by "deployment:" to get the deployment ID
-	parts := strings.Split(catalogCRN, "deployment:")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid catalog CRN format: %s", catalogCRN)
-	}
-	deploymentID := strings.TrimSpace(parts[1])
-	if deploymentID == "" {
-		return "", fmt.Errorf("empty deployment ID in catalog CRN: %s", catalogCRN)
-	}
-	return deploymentID, nil
-}
-
 // getInitialNodeCountGen2 retrieves the default member count for Gen2 plans from Global Catalog.
 // Returns the member count from the catalog metadata, or a default value of 3 if not found.
-func getInitialNodeCountGen2(catalogCRN string, meta interface{}) (int, error) {
+func getInitialNodeCountGen2(deploymentID string, meta interface{}) (int, error) {
 	globalClient, err := meta.(conns.ClientSession).GlobalCatalogV1API()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get global catalog client: %w", err)
-	}
-
-	deploymentID, err := extractDeploymentIDFromCRN(catalogCRN)
-	if err != nil {
-		return 0, fmt.Errorf("failed to extract deployment ID from catalog CRN: %w", err)
 	}
 
 	options := &globalcatalogv1.GetCatalogEntryOptions{
@@ -532,6 +544,42 @@ func getResourceManagerClient(meta interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("failed to get resource manager client: %w", err)
 	}
 	return client, nil
+}
+
+// setTagsWithLogging retrieves and sets tags for a resource, logging errors instead of failing.
+// Returns error only for critical failures, logs warnings for non-critical issues.
+func setTagsWithLogging(d *schema.ResourceData, crn string, meta interface{}) error {
+	tags, err := flex.GetTagsUsingCRN(meta, crn)
+	if err != nil {
+		log.Printf("[WARN] Failed to retrieve tags for resource %s: %v", crn, err)
+	}
+	return d.Set("tags", tags)
+}
+
+// buildResourceControllerURL constructs the resource controller URL for a given CRN.
+// Standardizes URL building across resources and data sources.
+func buildResourceControllerURL(meta interface{}, crn string) (string, error) {
+	rcontroller, err := flex.GetBaseController(meta)
+	if err != nil {
+		return "", fmt.Errorf("failed to get base controller: %w", err)
+	}
+	return rcontroller + "/services/" + url.QueryEscape(crn), nil
+}
+
+// setResourceControllerAttributes sets common flex resource controller attributes.
+// Reduces duplication of setting name, CRN, status, and controller URL.
+func setResourceControllerAttributes(d *schema.ResourceData, name, crn, state string, meta interface{}) error {
+	d.Set(flex.ResourceName, name)
+	d.Set(flex.ResourceCRN, crn)
+	d.Set(flex.ResourceStatus, state)
+
+	controllerURL, err := buildResourceControllerURL(meta, crn)
+	if err != nil {
+		return err
+	}
+	d.Set(flex.ResourceControllerURL, controllerURL)
+
+	return nil
 }
 
 // setGen2BasicAttributes sets basic instance attributes including tags, name, status, location, and resource controller attributes.
@@ -715,12 +763,25 @@ func setGen2GroupsInfo(d *schema.ResourceData, instance *rc.ResourceInstance, me
 // to avoid drift detection when users have these in their configuration.
 // This function is shared between data source and resource implementations.
 func clearGen2UnsupportedAttributes(d *schema.ResourceData) {
+	// Admin user is not supported in Gen2 (no default admin user)
+	d.Set("adminuser", nil)
+
+	// Admin password is not supported in Gen2
+	d.Set("adminpassword", nil)
+
 	// Allowlist is not supported in Gen2
 	d.Set(allowlistKey, nil)
 
 	// Users management is not supported in Gen2 (use ibm_resource_key instead)
 	d.Set("users", nil)
 
+	// Auto scaling is not supported in Gen2
+	d.Set("auto_scaling", nil)
+
 	// Configuration schema is not supported in Gen2
 	d.Set("configuration_schema", nil)
+
+	// Note: backup_encryption_key_crn within platform_options is also not supported in Gen2,
+	// but platform_options is handled by the data source implementation which only sets
+	// disk_encryption_key_crn for Gen2 instances
 }

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -292,6 +292,15 @@ func TestIsGen2Plan(t *testing.T) {
 // TestClearGen2UnsupportedAttributes tests the clearGen2UnsupportedAttributes function
 func TestClearGen2UnsupportedAttributes(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"adminuser": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"adminpassword": {
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+		},
 		"auto_scaling": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -333,6 +342,8 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 			Optional: true,
 		},
 	}, map[string]interface{}{
+		"adminuser":            "admin",
+		"adminpassword":        "password123",
 		"auto_scaling":         []interface{}{map[string]interface{}{"enabled": true}},
 		"allowlist":            []interface{}{map[string]interface{}{"address": "1.2.3.4"}},
 		"users":                []interface{}{map[string]interface{}{"name": "user1"}},
@@ -341,12 +352,18 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	clearGen2UnsupportedAttributes(d)
 
-	// auto_scaling is NOT cleared by clearGen2UnsupportedAttributes to avoid drift detection
-	// It should retain its original value
-	autoScaling := d.Get("auto_scaling")
-	require.NotEmpty(t, autoScaling, "auto_scaling should NOT be cleared (kept to avoid drift)")
+	// Verify all Gen2 unsupported attributes are cleared (d.Set(key, nil) results in empty values, not nil)
 
-	// Verify attributes that ARE cleared (d.Set(key, nil) results in empty values, not nil)
+	adminuser := d.Get("adminuser")
+	require.Equal(t, "", adminuser, "adminuser should be empty string after clearing")
+
+	adminpassword := d.Get("adminpassword")
+	require.Equal(t, "", adminpassword, "adminpassword should be empty string after clearing")
+
+	autoScaling := d.Get("auto_scaling")
+	require.NotNil(t, autoScaling, "auto_scaling should be set to empty value")
+	require.Empty(t, autoScaling, "auto_scaling should be empty after clearing")
+
 	allowlist := d.Get("allowlist")
 	require.NotNil(t, allowlist, "allowlist should be set to empty value")
 	require.Empty(t, allowlist, "allowlist should be empty after clearing")
@@ -357,6 +374,9 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 
 	configSchema := d.Get("configuration_schema")
 	require.Equal(t, "", configSchema, "configuration_schema should be empty string after clearing")
+
+	// Note: platform_options.backup_encryption_key_crn is also not supported in Gen2,
+	// but it's handled by the data source implementation which only sets disk_encryption_key_crn
 }
 
 func TestExtractDeploymentIDFromCRN(t *testing.T) {

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -75,7 +75,38 @@ In addition to all argument references list, you can access the following attrib
     - `rate_period_seconds`- (Integer) Auto scaling rate period in seconds.
     - `rate_units` - (String) Auto scaling rate in units.
 - `allowlist`  - (List) A list of allowed IP addresses or ranges.
+- `users` - (List) A list of users configured for the database.
 
 
 **Note**
-The provider only exports the admin user ID and associated connection string. It does not export any user IDs that are configured for the instance in addition. 
+The provider only exports the admin user ID and associated connection string. It does not export any user IDs that are configured for the instance in addition.
+
+
+## Gen2 Support
+This data source supports both Classic and Gen2 database instances. The backend is automatically selected based on the database plan.
+
+### Gen2 Limitations
+The following attributes are not supported for Gen2 databases:
+- `adminuser` - Gen2 databases do not create a default admin user. Use `ibm_resource_key` to manage credentials.
+- `adminpassword` - Not available for Gen2 databases. Use `ibm_resource_key` to manage credentials.
+- `users` - User management is not supported. Use `ibm_resource_key` to manage credentials.
+- `allowlist` - IP allowlisting is not supported for Gen2 databases. Use Context-Based Restrictions (`ibm_cbr_rule`) for IP allowlisting in Gen2.
+- `auto_scaling` - Auto-scaling configuration is not currently supported for Gen2 databases.
+- `configuration_schema` - Configuration schema is not available for Gen2 databases.
+- `platform_options.backup_encryption_key_crn` - Backup encryption key is not supported for Gen2 databases (only `disk_encryption_key_crn` is supported).
+
+### Gen2 Example
+```terraform
+data "ibm_database" "postgres_gen2" {
+  name     = "my-postgres-gen2"
+  location = "us-south"
+  service  = "databases-for-postgresql"
+}
+
+# Use ibm_resource_key to manage credentials for Gen2 databases
+resource "ibm_resource_key" "db_credentials" {
+  name                 = "my-db-credentials"
+  resource_instance_id = data.ibm_database.postgres_gen2.id
+  role                 = "Administrator"
+}
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Ticket : https://github.ibm.com/compose/App/issues/2857


## Overview

This documentation covers the enhancement to the IBM Cloud Terraform Provider that adds support for **Generation 2 (Gen2) database instances** in the `ibm_database` data source. This update enables users to seamlessly query both Classic and Gen2 database deployments using the same data source with automatic detection and appropriate handling of generation-specific features.

---
## What's New

### Gen2 Database Support in Data Source

The `ibm_database` data source now **automatically detects** whether a database instance is Classic or Gen2 and retrieves the appropriate information. This provides a unified interface for querying database instances regardless of their generation.

### Key Features

✅ **Automatic Detection**: The provider automatically identifies whether a database is Classic or Gen2 based on the plan type  
✅ **Unified Interface**: Use the same `ibm_database` data source for both Classic and Gen2 instances  
✅ **Backward Compatible**: Existing Terraform configurations continue to work without modification  
✅ **Proper State Management**: Gen2-specific behavior ensures clean state management when switching between instance types  
✅ **Comprehensive Testing**: Full test coverage for Gen2 scenarios including edge cases  

---

## Understanding Classic vs Gen2 Databases

### Classic Databases (Standard Plans)

- **Deployment Model**: Traditional IBM Cloud Databases architecture
- **Plan Names**: `standard`, `enterprise`, `platinum`
- **Features**: Full feature set including:
  - Default admin user management
  - IP allowlists for network access control
  - Auto-scaling configuration
  - Direct user management through API
  - Configuration schema access

### Gen2 Databases (Standard-Gen2 Plans)

- **Deployment Model**: Next-generation architecture with enhanced capabilities
- **Plan Names**: `standard-gen2`, `enterprise-gen2`
- **Benefits**:
  - Enhanced performance and scalability
  - Improved resource isolation
  - Modern infrastructure
  - Better integration with IBM Cloud platform services
- **Management Model**: Different approach to credentials and access control

---

## Architecture Overview

### Backend Selection Pattern

The data source uses a **strategy pattern** to handle different database generations:

```
User Query → findInstance() → Detect Plan Type → Select Backend
                                                      ↓
                                    ┌─────────────────┴─────────────────┐
                                    ↓                                   ↓
                          Classic Backend                        Gen2 Backend
                          (Full API Access)                (Metadata-based Access)
```

### Implementation Components

1. **`data_source_ibm_database.go`**: Main data source with backend selection logic
2. **`data_source_ibm_database_classic.go`**: Classic database backend implementation
3. **`data_source_ibm_database_gen2.go`**: Gen2 database backend implementation
4. **`helpers.go`**: Shared utility functions for both backends
5. **Test Files**: Comprehensive test coverage for both generations

---

## Important Differences for Gen2

### Attributes Not Available in Gen2

The following attributes are **not supported** for Gen2 database instances and will return empty/zero values:

| Attribute | Classic Behavior | Gen2 Behavior | Reason |
|-----------|------------------|---------------|--------|
| `adminuser` | Returns default admin username | Returns empty string | No default admin user in Gen2 |
| `adminpassword` | Returns admin password | Returns empty string | Credentials managed via service keys |
| `users` | Returns list of database users | Returns empty list `[]` | User management through service keys |
| `allowlist` | Returns IP allowlist entries | Returns empty list `[]` | Network access via VPC/CBR |
| `auto_scaling` | Returns auto-scaling config | Returns empty list `[]` | Not currently supported |
| `configuration_schema` | Returns JSON schema | Returns empty string | Not available in Gen2 |
| `backup_encryption_key_crn` | Returns backup encryption key | Not set | Different encryption model |

### Attributes Available in Gen2

These attributes work identically in both Classic and Gen2:

✅ `name` - Database instance name  
✅ `service` - Database service type (e.g., `databases-for-postgresql`)  
✅ `plan` - Service plan (e.g., `standard-gen2`)  
✅ `status` - Instance status  
✅ `version` - Database version  
✅ `location` - Region/location  
✅ `resource_group_id` - Resource group identifier  
✅ `guid` - Unique instance identifier  
✅ `groups` - Scaling group configurations (memory, disk, CPU)  
✅ `platform_options.disk_encryption_key_crn` - Disk encryption key  
✅ `tags` - Instance tags  

---

## Usage Examples

### Example 1: Basic Data Source Query

Works for both Classic and Gen2 databases:

```hcl
# Query any database instance
data "ibm_database" "database" {
  name = "my-database-instance"
}

# Access common attributes
output "database_info" {
  value = {
    version  = data.ibm_database.database.version
    location = data.ibm_database.database.location
    plan     = data.ibm_database.database.plan
    status   = data.ibm_database.database.status
  }
}
```

### Example 2: Gen2 Database with Credential Management

For Gen2 databases, use `ibm_resource_key` for credentials:

```hcl
# Query Gen2 database instance
data "ibm_database" "my_gen2_db" {
  name = "my-postgres-gen2"
}

# Create service credentials for Gen2 database
resource "ibm_resource_key" "db_credentials" {
  name                 = "my-db-credentials"
  resource_instance_id = data.ibm_database.my_gen2_db.id
  role                 = "Administrator"
}

# Access connection details
output "database_connection" {
  value = {
    host     = ibm_resource_key.db_credentials.credentials["connection.postgres.hosts.0.hostname"]
    port     = ibm_resource_key.db_credentials.credentials["connection.postgres.hosts.0.port"]
    database = ibm_resource_key.db_credentials.credentials["connection.postgres.database"]
    username = ibm_resource_key.db_credentials.credentials["connection.postgres.authentication.username"]
    password = ibm_resource_key.db_credentials.credentials["connection.postgres.authentication.password"]
  }
  sensitive = true
}
```

### Example 3: Querying with Resource Group Filter

```hcl
data "ibm_resource_group" "group" {
  name = "production"
}

data "ibm_database" "database" {
  name              = "my-database"
  resource_group_id = data.ibm_resource_group.group.id
}
```

### Example 4: Querying with Location Filter

```hcl
data "ibm_database" "database" {
  name     = "my-database"
  location = "ca-mon"
}

# Useful when multiple databases share the same name in different regions
```

### Example 5: Accessing Scaling Groups Information

```hcl
data "ibm_database" "database" {
  name = "my-database"
}

# Memory allocation
output "memory_allocation_mb" {
  value = data.ibm_database.database.groups[0].memory[0].allocation_mb
}

# Disk allocation
output "disk_allocation_mb" {
  value = data.ibm_database.database.groups[0].disk[0].allocation_mb
}

# CPU allocation (if available)
output "cpu_allocation_count" {
  value = data.ibm_database.database.groups[0].cpu[0].allocation_count
}

# Check if resources are adjustable
output "can_scale_memory" {
  value = data.ibm_database.database.groups[0].memory[0].is_adjustable
}
```

### Example 6: Conditional Logic Based on Plan Type

```hcl
data "ibm_database" "database" {
  name = "my-database"
}

locals {
  is_gen2 = can(regex("gen2", data.ibm_database.database.plan))
}

# Use different credential management based on generation
resource "ibm_resource_key" "credentials" {
  count = local.is_gen2 ? 1 : 0
  
  name                 = "gen2-credentials"
  resource_instance_id = data.ibm_database.database.id
  role                 = "Administrator"
}

output "credential_source" {
  value = local.is_gen2 ? "Using ibm_resource_key for Gen2" : "Using adminuser for Classic"
}
```

### Example 7: Platform Options and Encryption

```hcl
data "ibm_database" "database" {
  name = "my-encrypted-database"
}

# Access disk encryption key
output "disk_encryption_key" {
  value = try(
    data.ibm_database.database.platform_options[0].disk_encryption_key_crn,
    "No encryption key configured"
  )
}
```

## Supported Attributes

### Input Parameters

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `name` | String | Yes | Database instance name |
| `resource_group_id` | String | No | Filter by resource group ID |
| `location` | String | No | Filter by region/location |
| `service` | String | No | Filter by service type |

### Output Attributes - Common (Both Generations)

| Attribute | Type | Description |
|-----------|------|-------------|
| `id` | String | Resource instance ID |
| `name` | String | Database instance name |
| `service` | String | Database service type |
| `plan` | String | Service plan (includes `-gen2` suffix for Gen2) |
| `status` | String | Instance status (active, provisioning, etc.) |
| `version` | String | Database version |
| `location` | String | Region/location |
| `resource_group_id` | String | Resource group ID |
| `guid` | String | Unique instance identifier |
| `resource_name` | String | Resource name |
| `resource_crn` | String | Cloud Resource Name |
| `resource_status` | String | Resource status |
| `resource_group_name` | String | Resource group name |
| `resource_controller_url` | String | Dashboard URL |
| `tags` | Set(String) | Instance tags |

### Output Attributes - Groups (Both Generations)

| Attribute | Type | Description |
|-----------|------|-------------|
| `groups` | List | Scaling group configurations |
| `groups[].group_id` | String | Group identifier (e.g., "member") |
| `groups[].count` | Integer | Number of members in group |
| `groups[].memory` | List | Memory configuration |
| `groups[].memory[].allocation_mb` | Integer | Current memory allocation in MB |
| `groups[].memory[].minimum_mb` | Integer | Minimum allowed memory |
| `groups[].memory[].step_size_mb` | Integer | Memory scaling increment |
| `groups[].memory[].is_adjustable` | Boolean | Whether memory can be adjusted |
| `groups[].memory[].can_scale_down` | Boolean | Whether memory can scale down |
| `groups[].disk` | List | Disk configuration |
| `groups[].disk[].allocation_mb` | Integer | Current disk allocation in MB |
| `groups[].disk[].minimum_mb` | Integer | Minimum allowed disk |
| `groups[].disk[].step_size_mb` | Integer | Disk scaling increment |
| `groups[].disk[].is_adjustable` | Boolean | Whether disk can be adjusted |
| `groups[].disk[].can_scale_down` | Boolean | Whether disk can scale down |
| `groups[].cpu` | List | CPU configuration |
| `groups[].cpu[].allocation_count` | Integer | Current CPU allocation |
| `groups[].cpu[].minimum_count` | Integer | Minimum allowed CPUs |
| `groups[].cpu[].step_size_count` | Integer | CPU scaling increment |
| `groups[].cpu[].is_adjustable` | Boolean | Whether CPU can be adjusted |
| `groups[].cpu[].can_scale_down` | Boolean | Whether CPU can scale down |

### Output Attributes - Platform Options (Both Generations)

| Attribute | Type | Gen2 Support | Description |
|-----------|------|--------------|-------------|
| `platform_options` | Set | Yes | Platform-specific options |
| `platform_options[].disk_encryption_key_crn` | String | Yes | Disk encryption key CRN |
| `platform_options[].backup_encryption_key_crn` | String | No | Backup encryption key (Classic only) |

### Output Attributes - Classic Only

| Attribute | Type | Gen2 Behavior | Description |
|-----------|------|---------------|-------------|
| `adminuser` | String | Empty string | Default admin username (Classic only) |
| `adminpassword` | String | Empty string | Default admin password (Classic only) |
| `users` | Set | Empty list | Database users (Classic only) |
| `allowlist` | Set | Empty list | IP allowlist (Classic only) |
| `auto_scaling` | List | Empty list | Auto-scaling configuration (Classic only) |
| `configuration_schema` | String | Empty string | Configuration schema JSON (Classic only) |

---

## Testing

### Test Coverage

The implementation includes comprehensive test coverage for Gen2 scenarios:

#### Test Cases

1. **TestAccIBMDatabaseDataSourceGen2Basic**
   - Validates successful data retrieval for Gen2 instances
   - Verifies common attributes (name, service, plan, location)
   - Confirms Gen2-specific behavior (empty adminuser, users, allowlist)
   - Checks groups information (memory, disk allocations)

2. **TestAccIBMDatabaseDataSourceGen2WithResourceGroupID**
   - Tests filtering by resource group
   - Validates resource group ID is properly set
   - Ensures correct instance is retrieved when multiple exist

3. **TestAccIBMDatabaseDataSourceGen2InvalidInput**
   - Tests error handling for non-existent databases
   - Validates appropriate error messages
   - Ensures graceful failure

4. **TestAccIBMDatabaseDataSourceGen2InvalidID**
   - Tests error handling for malformed identifiers
   - Validates input validation
   - Ensures proper error reporting


</br>
</br>

**`ibm_database` TF Tests for Gen2**

**TF INPUT CONFIG**
```
# Data Source to Read the Gen2 Database
data "ibm_database" "pushpa_tf_gen2-postgres" {
  name              = "my-postgres-gen2-Test"
  location          = "ca-mon"
  service           = "databases-for-postgresql"
}

# Output the Data Source Information
output "database_info" {
  value = {
    # Basic Information
    name    = data.ibm_database.pushpa_tf_gen2-postgres.name
    id      = data.ibm_database.pushpa_tf_gen2-postgres.id
    status  = data.ibm_database.pushpa_tf_gen2-postgres.status
    version = data.ibm_database.pushpa_tf_gen2-postgres.version
    tags    = data.ibm_database.pushpa_tf_gen2-postgres.tags

    # Platform Options (Gen2 specific)
    platform_options = data.ibm_database.pushpa_tf_gen2-postgres.platform_options

    # Configuration
    plan     = data.ibm_database.pushpa_tf_gen2-postgres.plan
    location = data.ibm_database.pushpa_tf_gen2-postgres.location
    service  = data.ibm_database.pushpa_tf_gen2-postgres.service

    # Resource Scaling
    groups = data.ibm_database.pushpa_tf_gen2-postgres.groups
  }
}
```

**TF OUTPUT**
```
ibm-database git:(2857/gen2-datasource-ibm_database-1) ✗ terraform apply
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

database_info = {
  "groups" = tolist([
    {
      "count" = 2
      "cpu" = tolist([
        {
          "allocation_count" = 4
          "can_scale_down" = true
          "is_adjustable" = true
          "minimum_count" = 6
          "step_size_count" = 2
          "units" = "count"
        },
      ])
      "disk" = tolist([
        {
          "allocation_mb" = 10240
          "can_scale_down" = false
          "is_adjustable" = true
          "minimum_mb" = 20480
          "step_size_mb" = 2048
          "units" = "gb"
        },
      ])
      "group_id" = "member"
      "host_flavor" = tolist([
        {
          "hosting_size" = ""
          "id" = "bx3d.4x20"
          "name" = "bx3d.4x20"
        },
      ])
      "memory" = tolist([
        {
          "allocation_mb" = 20480
          "can_scale_down" = true
          "is_adjustable" = true
          "minimum_mb" = 2048
          "step_size_mb" = 256
          "units" = "gb"
        },
      ])
    },
  ])
  "id" = "crn:v1:bluemix:public:databases-for-postgresql:ca-mon:a/40ddc34a953a8c02f10987b59085b60e:7b231067-9ddd-4de9-964a-d7bf84cfdc3f::"
  "location" = "ca-mon"
  "name" = "my-postgres-gen2-Test"
  "plan" = "standard-gen2"
  "platform_options" = toset([
    {
      "backup_encryption_key_crn" = ""
      "disk_encryption_key_crn" = ""
    },
  ])
  "service" = "databases-for-postgresql"
  "status" = "active"
  "tags" = toset([
    "app:myapp",
    "do-not-delete",
    "env:production",
    "gen2-test",
  ])
  "version" = "18"
}
```



</br>
</br>

**`ibm_database` TF Tests for Classic**

**TF INPUT CONFIG**

```
# Data Source to Read the Classic Database
data "ibm_database" "pushpa_tf_classic-postgres" {
  name              = "Databases for PostgreSQL-tn"
  location          = "us-east"
  service           = "databases-for-postgresql"
}

# Output the Data Source Information
output "database_info" {
  value = {
    # Basic Information
    name    = data.ibm_database.pushpa_tf_classic-postgres.name
    id      = data.ibm_database.pushpa_tf_classic-postgres.id
    status  = data.ibm_database.pushpa_tf_classic-postgres.status
    version = data.ibm_database.pushpa_tf_classic-postgres.version
    tags    = data.ibm_database.pushpa_tf_classic-postgres.tags

    # Platform Options (Gen2 specific)
    platform_options = data.ibm_database.pushpa_tf_classic-postgres.platform_options

    # Configuration
    plan     = data.ibm_database.pushpa_tf_classic-postgres.plan
    location = data.ibm_database.pushpa_tf_classic-postgres.location
    service  = data.ibm_database.pushpa_tf_classic-postgres.service

    # Resource Scaling
    groups = data.ibm_database.pushpa_tf_classic-postgres.groups
  }
}
```


**TF OUTPUT**
```
ibm-database git:(2857/gen2-datasource-ibm_database-1) ✗ terraform apply
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

database_info = {
  "groups" = tolist([
    {
      "count" = 2
      "cpu" = tolist([
        {
          "allocation_count" = 4
          "can_scale_down" = true
          "is_adjustable" = true
          "minimum_count" = 0
          "step_size_count" = 2
          "units" = "count"
        },
      ])
      "disk" = tolist([
        {
          "allocation_mb" = 10240
          "can_scale_down" = false
          "is_adjustable" = true
          "minimum_mb" = 10240
          "step_size_mb" = 2048
          "units" = "mb"
        },
      ])
      "group_id" = "member"
      "host_flavor" = tolist([
        {
          "hosting_size" = ""
          "id" = "multitenant"
          "name" = ""
        },
      ])
      "memory" = tolist([
        {
          "allocation_mb" = 8192
          "can_scale_down" = true
          "is_adjustable" = true
          "minimum_mb" = 8192
          "step_size_mb" = 256
          "units" = "mb"
        },
      ])
    },
  ])
  "id" = "crn:v1:bluemix:public:databases-for-postgresql:us-east:a/40ddc34a953a8c02f10987b59085b60e:92d35483-3205-4324-adcb-2e2e5b740673::"
  "location" = "us-east"
  "name" = "Databases for PostgreSQL-tn"
  "plan" = "standard"
  "platform_options" = toset([
    {
      "backup_encryption_key_crn" = ""
      "disk_encryption_key_crn" = ""
    },
  ])
  "service" = "databases-for-postgresql"
  "status" = "active"
  "tags" = toset([
    "claasic-test",
    "classic-test-tasks",
    "isl",
  ])
  "version" = "18"
}
```


### Running Tests

#### Prerequisites

```bash
# Set required environment variables
export IC_API_KEY="your-ibm-cloud-api-key"

```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -v -run "TestAccIBMDatabaseDataSourceGen2Basic" -timeout 120m
=== RUN   TestAccIBMDatabaseDataSourceGen2Basic
=== PAUSE TestAccIBMDatabaseDataSourceGen2Basic
=== CONT  TestAccIBMDatabaseDataSourceGen2Basic
--- PASS: TestAccIBMDatabaseDataSourceGen2Basic (281.23s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        282.779s


$ go test -v -run "TestAccIBMDatabaseDataSourceGen2InvalidInput" -timeout 120m
=== RUN   TestAccIBMDatabaseDataSourceGen2InvalidInput
--- PASS: TestAccIBMDatabaseDataSourceGen2InvalidInput (4.35s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        6.390s


$ go test -v -run "TestAccIBMDatabaseDataSourceGen2InvalidInput" -timeout 120m
=== RUN   TestAccIBMDatabaseDataSourceGen2InvalidID
--- PASS: TestAccIBMDatabaseDataSourceGen2InvalidID (2.64s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        4.577s

```
