### PR TITLE
fix: handle UPDATE_PENDING state in security group target deletion

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group_target.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target.go
@@ -272,9 +272,31 @@ func resourceIBMISSecurityGroupTargetDelete(context context.Context, d *schema.R
 	deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(securityGroupID, securityGroupTargetID)
 	response, err = sess.DeleteSecurityGroupTargetBindingWithContext(context, deleteSecurityGroupTargetBindingOptions)
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteSecurityGroupTargetBindingWithContext failed: %s", err.Error()), "ibm_is_security_group_target", "delete")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		// Check if error is due to load balancer being in UPDATE_PENDING or CREATE_PENDING state
+		if strings.Contains(strings.ToLower(err.Error()), "load balancer") && ((strings.Contains(strings.ToUpper(err.Error()), "UPDATE_PENDING")) || (strings.Contains(strings.ToUpper(err.Error()), "CREATE_PENDING"))) {
+			log.Printf("[INFO] Load balancer with ID '%s' is in UPDATE_PENDING state. Waiting for it to become available before retrying deletion...", securityGroupTargetID)
+
+			// Wait for the load balancer to become available
+			_, waitErr := isWaitForSGTargetLBAvailable(sess, securityGroupTargetID, d.Timeout(schema.TimeoutDelete))
+			if waitErr != nil {
+				err = fmt.Errorf("isWaitForSGTargetLBAvailable failed: waiting for load balancer to become available while deleting Security Group Target Binding: %s", waitErr)
+				tfErr := flex.TerraformErrorf(waitErr, fmt.Sprintf("isWaitForSGTargetLBAvailable failed: %s", waitErr.Error()), "ibm_is_security_group_target", "delete")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+
+			// Retry the deletion after load balancer becomes available
+			response, err = sess.DeleteSecurityGroupTargetBindingWithContext(context, deleteSecurityGroupTargetBindingOptions)
+			if err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteSecurityGroupTargetBindingWithContext failed after retry: %s", err.Error()), "ibm_is_security_group_target", "delete")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+		} else {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteSecurityGroupTargetBindingWithContext failed: %s", err.Error()), "ibm_is_security_group_target", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
 	}
 	securityGroupTargetReference := sgt.(*vpcv1.SecurityGroupTargetReference)
 	crn := securityGroupTargetReference.CRN

--- a/ibm/service/vpc/resource_ibm_is_security_group_target_test.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_target_test.go
@@ -199,6 +199,45 @@ func TestAccIBMISSecurityGroupTarget_UpdatePendingRetry(t *testing.T) {
 	})
 }
 
+func TestAccIBMISSecurityGroupTarget_DeletionWithUpdatePending(t *testing.T) {
+	var securityGroup1, securityGroup2 string
+
+	vpcname := fmt.Sprintf("tfsg-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfsg-subnet-%d", acctest.RandIntRange(10, 100))
+	lbname := fmt.Sprintf("tfsg-lb-%d", acctest.RandIntRange(10, 100))
+	sg1name := fmt.Sprintf("tfsg-one-%d", acctest.RandIntRange(10, 100))
+	sg2name := fmt.Sprintf("tfsg-two-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISSecurityGroupTargetDestroy,
+		Steps: []resource.TestStep{
+			// Create two security group targets for the same load balancer
+			{
+				Config: testAccCheckIBMISsecurityGroupTargetDualConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, sg1name, sg2name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSecurityGroupTargetExists("ibm_is_security_group_target.testacc_security_group_target", &securityGroup1),
+					testAccCheckIBMISSecurityGroupTargetExists("ibm_is_security_group_target.testacc_security_group_target2", &securityGroup2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_security_group_target.testacc_security_group_target", "name", lbname),
+					resource.TestCheckResourceAttr(
+						"ibm_is_security_group_target.testacc_security_group_target2", "name", lbname),
+				),
+			},
+			// Remove one security group target - this should trigger UPDATE_PENDING handling during deletion
+			{
+				Config: testAccCheckIBMISsecurityGroupTargetConfig(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, sg1name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISSecurityGroupTargetExists("ibm_is_security_group_target.testacc_security_group_target", &securityGroup1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_security_group_target.testacc_security_group_target", "name", lbname),
+				),
+			},
+		},
+	})
+}
+
 // Config for dual security groups attached to the same load balancer
 func testAccCheckIBMISsecurityGroupTargetDualConfig(vpcname, subnetname, zoneName, cidr, lbname, sg1name, sg2name string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
When deleting a security group target binding for a load balancer that is in UPDATE_PENDING or CREATE_PENDING state, the deletion now waits for the load balancer to become available before retrying the operation.

This fix implements the same retry logic pattern already used in the create operation, ensuring consistent behavior across both operations.

Fixes issue where DeleteSecurityGroupTargetBindingWithContext fails with: 'The load balancer cannot be updated because its status is UPDATE_PENDING'

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISSecurityGroupTarget_DeletionWithUpdatePending
--- PASS: TestAccIBMISSecurityGroupTarget_DeletionWithUpdatePending (746.87s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     748.627s
```
