### PR TITLE
fix(flow-log): Added resource group name and documentation of auto-delete

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_flow_log.go
+++ b/ibm/service/vpc/resource_ibm_is_flow_log.go
@@ -348,6 +348,11 @@ func resourceIBMISFlowLogRead(context context.Context, d *schema.ResourceData, m
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_flow_log", "read", "set-lifecycle_state").GetDiag()
 	}
 
+	if err = d.Set(isFlowLogAutoDelete, flowLogCollector.AutoDelete); err != nil {
+		err = fmt.Errorf("Error setting auto_delete: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_ibm_is_flow_log", "read", "set-auto_delete").GetDiag()
+	}
+
 	if flowLogCollector.VPC != nil {
 		if err = d.Set(isFlowLogVpc, *flowLogCollector.VPC.ID); err != nil {
 			err = fmt.Errorf("Error setting vpc: %s", err)
@@ -418,7 +423,7 @@ func resourceIBMISFlowLogRead(context context.Context, d *schema.ResourceData, m
 			err = fmt.Errorf("Error setting resource_group: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_flow_log", "read", "set-resource_group").GetDiag()
 		}
-		if err = d.Set(flex.ResourceGroupName, *flowLogCollector.ResourceGroup.ID); err != nil {
+		if err = d.Set(flex.ResourceGroupName, *flowLogCollector.ResourceGroup.Name); err != nil {
 			err = fmt.Errorf("Error setting resource_group_name: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_flow_log", "read", "set-flex_resource_group_name").GetDiag()
 		}

--- a/ibm/service/vpc/resource_ibm_is_flow_log_test.go
+++ b/ibm/service/vpc/resource_ibm_is_flow_log_test.go
@@ -49,6 +49,9 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISFlowLogExists("ibm_is_flow_log.test_flow_log", instance),
 					resource.TestCheckResourceAttr("ibm_is_flow_log.test_flow_log", "name", flowlogname),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "auto_delete"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group_name"),
 				),
 			},
 			//update
@@ -58,6 +61,9 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					testAccCheckIBMISFlowLogExists("ibm_is_flow_log.test_flow_log", instance),
 					resource.TestCheckResourceAttr("ibm_is_flow_log.test_flow_log", "name", newflowlogname),
 					resource.TestCheckResourceAttr("ibm_is_flow_log.test_flow_log", "active", "false"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "auto_delete"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group_name"),
 				),
 			},
 		},
@@ -274,6 +280,9 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMISFlowLogExists("ibm_is_flow_log.test_flow_log", instance),
 					resource.TestCheckResourceAttr("ibm_is_flow_log.test_flow_log", "name", flowlogname),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "auto_delete"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group"),
+					resource.TestCheckResourceAttrSet("ibm_is_flow_log.test_flow_log", "resource_group_name"),
 				),
 			},
 			{

--- a/website/docs/r/is_flow_log.html.markdown
+++ b/website/docs/r/is_flow_log.html.markdown
@@ -100,6 +100,7 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
+- `auto_delete` - (Boolean) Indicates whether this flow log collector will be automatically deleted when target is deleted. At present, this is always true, but may be modifiable in the future.
 - `created_at`-  (String) The date and time that the flow log collector created.
 - `crn` - (String) The CRN of the flow log collector.
 - `href` - (String) The URL of the flow log collector.


### PR DESCRIPTION
Added auto-delete documentation
in flow-logs
auto-delete will only return true or false
resource group name resolution

Output from acceptance testing:
```
--- PASS: TestAccIBMISFlowLog_basic (190.55s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     191.779s

--- PASS: TestAccIBMISFlowLogImport (162.80s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     164.079s
```