### PR TITLE
docs: update Continuous Delivery (CD) region discontinuation warnings

### DIFF
--- a/ibm/service/cdtoolchain/toolchain_utils.go
+++ b/ibm/service/cdtoolchain/toolchain_utils.go
@@ -71,9 +71,7 @@ func IsRegionDeprecated(region string) bool {
 		"au-syd",
 		"ca-mon",
 		"ca-tor",
-		"eu-es",
 		"eu-fr2",
-		"jp-osa",
 		"us-east",
 	}
 	return slices.Contains(deprecatedRegions, region)
@@ -83,6 +81,6 @@ func GetRegionDeprecationWarning() diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Warning,
 		Summary:  "Region availability update",
-		Detail:   "This toolchain is located in a region where Continuous Delivery (CD) will be discontinued on 12 February 2027. The following regions are being discontinued: `au-syd`, `ca-mon`, `ca-tor`, `eu-es`, `jp-osa`, `us-east`. Learn more: https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-faq_region_feature_consolidation",
+		Detail:   "This toolchain is located in a region where Continuous Delivery (CD) will be discontinued on 12 February 2027. The following regions are being discontinued: `au-syd`, `ca-mon`, `ca-tor`, `us-east`. Learn more: https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-faq_region_feature_consolidation",
 	}
 }

--- a/website/docs/d/cd_toolchain.html.markdown
+++ b/website/docs/d/cd_toolchain.html.markdown
@@ -10,7 +10,7 @@ subcategory: "Continuous Delivery"
 
 Provides a read-only data source to retrieve information about a cd_toolchain. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `eu-es`, `jp-osa`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
+~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
 
 ## Example Usage
 

--- a/website/docs/d/cd_toolchains.html.markdown
+++ b/website/docs/d/cd_toolchains.html.markdown
@@ -10,7 +10,7 @@ subcategory: "Continuous Delivery"
 
 Provides a read-only data source to retrieve information about cd_toolchains. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
-~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `eu-es`, `jp-osa`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
+~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
 
 ## Example Usage
 

--- a/website/docs/r/cd_toolchain.html.markdown
+++ b/website/docs/r/cd_toolchain.html.markdown
@@ -10,7 +10,7 @@ subcategory: "Continuous Delivery"
 
 Create, update, and delete cd_toolchains with this resource.
 
-~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `eu-es`, `jp-osa`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
+~> **Warning:** Continuous Delivery (CD) will be discontinued in these regions on 12 February 2027: `au-syd`, `ca-mon`, `ca-tor`, `us-east`. Follow the [migration guide](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region) to avoid disruption. [Learn more](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-cd-migrate-region)
 
 ## Example Usage
 


### PR DESCRIPTION
### Description
Relates https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6687

Continuous Delivery was discontinued early in the following regions:
* Madrid (eu-es)
* Osaka (jp-osa)

In this PR:
* Update docs by removing already discontinued regions `eu-es` and `jp-osa`
* Update warning message string by removing already discontinued regions `eu-es` and `jp-osa`

See [FAQ](https://cloud.ibm.com/docs/ContinuousDelivery?topic=ContinuousDelivery-faq_region_feature_consolidation) for more information.

---

Output from acceptance testing:
`N/A. Only string changes, no code logic updates.`