### PR TITLE
Expose validation.target info in ibm_cm_validation resource and ibm_cm_version datasource

### DIFF
--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version.go
@@ -2252,8 +2252,9 @@ func dataSourceIBMCmVersionValidationToMap(model *catalogmanagementv1.Validation
 	}
 	if model.Target != nil {
 		targetMap := make(map[string]interface{}, len(model.Target))
-		// for k, v := range model.Target {
-		// }
+		for k, v := range model.Target {
+			targetMap[k] = v
+		}
 		modelMap["target"] = flex.Flatten(targetMap)
 	}
 	if model.Message != nil {

--- a/ibm/service/catalogmanagement/resource_ibm_cm_validation.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_validation.go
@@ -133,12 +133,12 @@ func ResourceIBMCmValidation() *schema.Resource {
 				Computed:    true,
 				Description: "Last operation (e.g. submit_deployment, generate_installer, install_offering.",
 			},
-			// "target": &schema.Schema{
-			// 	Type:        schema.TypeMap,
-			// 	Computed:    true,
-			// 	Description: "Validation target information (e.g. cluster_id, region, namespace, etc).  Values will vary by Content type.",
-			// 	Elem:        &schema.Schema{Type: schema.TypeString},
-			// },
+			"target": &schema.Schema{
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Validation target information (e.g. cluster_id, region, namespace, etc).  Values will vary by Content type.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"message": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -382,11 +382,17 @@ func resourceIBMCmValidationRead(context context.Context, d *schema.ResourceData
 			return tfErr.GetDiag()
 		}
 	}
-	// if version.Validation != nil && version.Validation.Target != nil {
-	// 	if err = d.Set("target", version.Validation.Target); err != nil {
-	// 		return diag.FromErr(fmt.Errorf("Error setting target: %s", err))
-	// 	}
-	// }
+	if version.Validation != nil && version.Validation.Target != nil {
+		targetMap := make(map[string]string, len(version.Validation.Target))
+		for k, v := range version.Validation.Target {
+			targetMap[k] = fmt.Sprintf("%v", v)
+		}
+		if err = d.Set("target", targetMap); err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting target: %s", err), "ibm_cm_validation", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Description

Expose the `validation.target` attribute from the Catalog Management Offering REST API in the `ibm_cm_validation` resource and `ibm_cm_version` data source.

This provides access to the Schematics workspace ID created during offering version validation.

Closes #6824

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [X] Run `go mod tidy` (if you modified `go.mod`)
- [X] Run `go fmt ./...` to format all code
- [X] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
