### PR TITLE
fix(iam-identity): update error format for a number of cases

### DIFF
--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2025 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -222,7 +222,9 @@ func dataSourceIBMIamAccountSettingsRead(context context.Context, d *schema.Reso
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMIamAccountSettingsRead failed: %s", err.Error()), "ibm_iam_account_settings", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsOptions.SetAccountID(userDetails.UserAccount)

--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template.go
@@ -270,15 +270,14 @@ func dataSourceIBMAccountSettingsTemplateRead(context context.Context, d *schema
 
 	getAccountSettingsTemplateVersionOptions := &iamidentityv1.GetAccountSettingsTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Get("template_id").(string))
+	templateId, version, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) resourceIBMAccountSettingsTemplateRead", "read", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template", "read", "parse-resource-id").GetDiag()
 	}
 	if version == "" {
 		version = d.Get("version").(string)
 	}
-
-	getAccountSettingsTemplateVersionOptions.SetTemplateID(id)
+	getAccountSettingsTemplateVersionOptions.SetTemplateID(templateId)
 	getAccountSettingsTemplateVersionOptions.SetVersion(version)
 
 	if _, ok := d.GetOk("include_history"); ok {

--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
@@ -14,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
@@ -258,15 +263,16 @@ func DataSourceIBMAccountSettingsTemplate() *schema.Resource {
 func dataSourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsTemplateVersionOptions := &iamidentityv1.GetAccountSettingsTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) resourceIBMAccountSettingsTemplateRead", "read", "sep-id-parts").GetDiag()
 	}
 	if version == "" {
 		version = d.Get("version").(string)
@@ -279,51 +285,54 @@ func dataSourceIBMAccountSettingsTemplateRead(context context.Context, d *schema
 		getAccountSettingsTemplateVersionOptions.SetIncludeHistory(d.Get("include_history").(bool))
 	}
 
-	accountSettingsTemplateResponse, response, err := iamIdentityClient.GetAccountSettingsTemplateVersionWithContext(context, getAccountSettingsTemplateVersionOptions)
+	accountSettingsTemplateResponse, _, err := iamIdentityClient.GetAccountSettingsTemplateVersionWithContext(context, getAccountSettingsTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsTemplateVersionWithContext failed: %s", err.Error()), "(Data) ibm_iam_account_settings_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*accountSettingsTemplateResponse.ID, *accountSettingsTemplateResponse.Version))
 
 	if err = d.Set("id", accountSettingsTemplateResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting id: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-id").GetDiag()
 	}
 
 	if !core.IsNil(accountSettingsTemplateResponse.Version) {
 		versionStr := strconv.Itoa(int(*accountSettingsTemplateResponse.Version))
 		if err = d.Set("version", versionStr); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting version: %s", err))
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting version: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-version").GetDiag()
 		}
 	}
 
 	if err = d.Set("account_id", accountSettingsTemplateResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("name", accountSettingsTemplateResponse.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-name").GetDiag()
 	}
 
-	if err = d.Set("description", accountSettingsTemplateResponse.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+	if !core.IsNil(accountSettingsTemplateResponse.Description) {
+		if err = d.Set("description", accountSettingsTemplateResponse.Description); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-description").GetDiag()
+		}
 	}
 
 	if err = d.Set("committed", accountSettingsTemplateResponse.Committed); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting committed: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting committed: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-committed").GetDiag()
 	}
 
 	var accountSettings []map[string]interface{}
 	if accountSettingsTemplateResponse.AccountSettings != nil {
 		modelMap, err := dataSourceIBMAccountSettingsTemplateAccountSettingsComponentToMap(accountSettingsTemplateResponse.AccountSettings)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template", "read", "account_settings-to-map").GetDiag()
 		}
 		accountSettings = append(accountSettings, modelMap)
 	}
 	if err = d.Set("account_settings", accountSettings); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_settings %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_settings: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-account_settings").GetDiag()
 	}
 
 	var history []map[string]interface{}
@@ -331,37 +340,45 @@ func dataSourceIBMAccountSettingsTemplateRead(context context.Context, d *schema
 		for _, modelItem := range accountSettingsTemplateResponse.History {
 			modelMap, err := EnityHistoryRecordToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, modelMap)
 		}
 	}
 	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting history %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting history: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-history").GetDiag()
 	}
 
 	if err = d.Set("entity_tag", accountSettingsTemplateResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-entity_tag").GetDiag()
 	}
 
 	if err = d.Set("crn", accountSettingsTemplateResponse.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-crn").GetDiag()
 	}
 
-	if err = d.Set("created_at", accountSettingsTemplateResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	if !core.IsNil(accountSettingsTemplateResponse.CreatedAt) {
+		if err = d.Set("created_at", accountSettingsTemplateResponse.CreatedAt); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-created_at").GetDiag()
+		}
 	}
 
-	if err = d.Set("created_by_id", accountSettingsTemplateResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+	if !core.IsNil(accountSettingsTemplateResponse.CreatedByID) {
+		if err = d.Set("created_by_id", accountSettingsTemplateResponse.CreatedByID); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by_id: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-created_by_id").GetDiag()
+		}
 	}
 
-	if err = d.Set("last_modified_at", accountSettingsTemplateResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+	if !core.IsNil(accountSettingsTemplateResponse.LastModifiedAt) {
+		if err = d.Set("last_modified_at", accountSettingsTemplateResponse.LastModifiedAt); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_at: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-last_modified_at").GetDiag()
+		}
 	}
 
-	if err = d.Set("last_modified_by_id", accountSettingsTemplateResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+	if !core.IsNil(accountSettingsTemplateResponse.LastModifiedByID) {
+		if err = d.Set("last_modified_by_id", accountSettingsTemplateResponse.LastModifiedByID); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_by_id: %s", err), "(Data) ibm_iam_account_settings_template", "read", "set-last_modified_by_id").GetDiag()
+		}
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_account_settings_template_assignment.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
@@ -290,7 +294,9 @@ func DataSourceIBMAccountSettingsTemplateAssignment() *schema.Resource {
 func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsAssignmentOptions := &iamidentityv1.GetAccountSettingsAssignmentOptions{}
@@ -300,10 +306,11 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		getAccountSettingsAssignmentOptions.SetIncludeHistory(d.Get("include_history").(bool))
 	}
 
-	templateAssignmentResponse, response, err := iamIdentityClient.GetAccountSettingsAssignmentWithContext(context, getAccountSettingsAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.GetAccountSettingsAssignmentWithContext(context, getAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTrustedProfileAssignmentWithContext failed: %s", err.Error()), "(Data) ibm_iam_account_settings_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s", *getAccountSettingsAssignmentOptions.AssignmentID))
@@ -312,40 +319,40 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 	if templateAssignmentResponse.Context != nil {
 		modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "context-to-map").GetDiag()
 		}
 		respContext = append(respContext, modelMap)
 	}
 	if err = d.Set("context", respContext); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting context %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting context: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-context").GetDiag()
 	}
 
 	if err = d.Set("id", templateAssignmentResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-id").GetDiag()
 	}
 
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
 
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_version: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-template_version").GetDiag()
 	}
 
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target_type: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-target_type").GetDiag()
 	}
 
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-target").GetDiag()
 	}
 
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-status").GetDiag()
 	}
 
 	var resources []map[string]interface{}
@@ -353,13 +360,13 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		for _, modelItem := range templateAssignmentResponse.Resources {
 			modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, modelMap)
 		}
 	}
 	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting resources %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resources: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-resources").GetDiag()
 	}
 
 	var history []map[string]interface{}
@@ -367,37 +374,37 @@ func dataSourceIBMAccountSettingsTemplateAssignmentRead(context context.Context,
 		for _, modelItem := range templateAssignmentResponse.History {
 			modelMap, err := EnityHistoryRecordToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_account_settings_template_assignment", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, modelMap)
 		}
 	}
 	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting history %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting history: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-history").GetDiag()
 	}
 
 	if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-href").GetDiag()
 	}
 
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_at: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_by_id: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_account_settings_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identity.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identity.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
- */
+*/
 
 package iamidentity
 
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
@@ -74,7 +76,9 @@ func DataSourceIBMIamTrustedProfileIdentity() *schema.Resource {
 func dataSourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_identity", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProfileIdentityOptions := &iamidentityv1.GetProfileIdentityOptions{}
@@ -83,32 +87,35 @@ func dataSourceIBMIamTrustedProfileIdentityRead(context context.Context, d *sche
 	getProfileIdentityOptions.SetIdentityType(d.Get("identity_type").(string))
 	getProfileIdentityOptions.SetIdentifierID(d.Get("identifier_id").(string))
 
-	profileIdentityResponse, response, err := iamIdentityClient.GetProfileIdentityWithContext(context, getProfileIdentityOptions)
+	profileIdentityResponse, _, err := iamIdentityClient.GetProfileIdentityWithContext(context, getProfileIdentityOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetProfileIdentityWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProfileIdentityWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileIdentityWithContext failed: %s", err.Error()), "(Data) ibm_iam_trusted_profile_identity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s|%s", *getProfileIdentityOptions.ProfileID, *getProfileIdentityOptions.IdentityType, *getProfileIdentityOptions.IdentifierID))
 
 	if err = d.Set("iam_id", profileIdentityResponse.IamID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting iam_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting iam_id: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-iam_id").GetDiag()
 	}
 
 	if err = d.Set("identifier", profileIdentityResponse.Identifier); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting identifier: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting identifier: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-identifier").GetDiag()
 	}
 
 	if err = d.Set("type", profileIdentityResponse.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting type: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-type").GetDiag()
 	}
 
-	if err = d.Set("description", profileIdentityResponse.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+	if !core.IsNil(profileIdentityResponse.Description) {
+		if err = d.Set("description", profileIdentityResponse.Description); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-description").GetDiag()
+		}
 	}
 
 	if err = d.Set("accounts", profileIdentityResponse.Accounts); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting accounts: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting accounts: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-accounts").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identity.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_identity.go
@@ -3,7 +3,7 @@
 
 /*
  * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
-*/
+ */
 
 package iamidentity
 
@@ -106,6 +106,12 @@ func dataSourceIBMIamTrustedProfileIdentityRead(context context.Context, d *sche
 
 	if err = d.Set("type", profileIdentityResponse.Type); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting type: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-type").GetDiag()
+	}
+
+	if !core.IsNil(profileIdentityResponse.Accounts) {
+		if err = d.Set("accounts", profileIdentityResponse.Accounts); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting accounts: %s", err), "(Data) ibm_iam_trusted_profile_identity", "read", "set-accounts").GetDiag()
+		}
 	}
 
 	if !core.IsNil(profileIdentityResponse.Description) {

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template.go
@@ -279,15 +279,14 @@ func dataSourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.
 
 	getProfileTemplateVersionOptions := &iamidentityv1.GetProfileTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Get("template_id").(string))
+	templateId, version, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "parse-resource-id").GetDiag()
 	}
 	if version == "" {
 		version = d.Get("version").(string)
 	}
-
-	getProfileTemplateVersionOptions.SetTemplateID(id)
+	getProfileTemplateVersionOptions.SetTemplateID(templateId)
 	getProfileTemplateVersionOptions.SetVersion(version)
 
 	if _, ok := d.GetOk("include_history"); ok {

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -272,15 +272,16 @@ func DataSourceIBMTrustedProfileTemplate() *schema.Resource {
 func dataSourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProfileTemplateVersionOptions := &iamidentityv1.GetProfileTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "sep-id-parts").GetDiag()
 	}
 	if version == "" {
 		version = d.Get("version").(string)
@@ -293,51 +294,53 @@ func dataSourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.
 		getProfileTemplateVersionOptions.SetIncludeHistory(d.Get("include_history").(bool))
 	}
 
-	trustedProfileTemplateResponse, response, err := iamIdentityClient.GetProfileTemplateVersionWithContext(context, getProfileTemplateVersionOptions)
+	trustedProfileTemplateResponse, _, err := iamIdentityClient.GetProfileTemplateVersionWithContext(context, getProfileTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetProfileTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProfileTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileTemplateVersionWithContext failed: %s", err.Error()), "(Data) ibm_iam_trusted_profile_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*trustedProfileTemplateResponse.ID, *trustedProfileTemplateResponse.Version))
 
 	if err = d.Set("id", trustedProfileTemplateResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting id: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-id").GetDiag()
 	}
 
 	if !core.IsNil(trustedProfileTemplateResponse.Version) {
 		versionStr := strconv.Itoa(int(*trustedProfileTemplateResponse.Version))
 		if err = d.Set("version", versionStr); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting version: %s", err))
+			err = fmt.Errorf("Error setting version: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "set-version").GetDiag()
 		}
 	}
 
 	if err = d.Set("account_id", trustedProfileTemplateResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("name", trustedProfileTemplateResponse.Name); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-name").GetDiag()
 	}
 
 	if err = d.Set("description", trustedProfileTemplateResponse.Description); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting description: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-description").GetDiag()
 	}
 
 	if err = d.Set("committed", trustedProfileTemplateResponse.Committed); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting committed: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting committed: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-committed").GetDiag()
 	}
 
 	var profile []map[string]interface{}
 	if trustedProfileTemplateResponse.Profile != nil {
 		modelMap, err := dataSourceIBMTrustedProfileTemplateTemplateProfileComponentResponseToMap(trustedProfileTemplateResponse.Profile)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "profile-to-map").GetDiag()
 		}
 		profile = append(profile, modelMap)
 	}
 	if err = d.Set("profile", profile); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting profile %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting profile: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-profile").GetDiag()
 	}
 
 	var policyTemplateReferences []map[string]interface{}
@@ -345,13 +348,13 @@ func dataSourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.
 		for _, modelItem := range trustedProfileTemplateResponse.PolicyTemplateReferences {
 			modelMap, err := dataSourceIBMTrustedProfileTemplatePolicyTemplateReferenceToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "policy_template_references-to-map").GetDiag()
 			}
 			policyTemplateReferences = append(policyTemplateReferences, modelMap)
 		}
 	}
 	if err = d.Set("policy_template_references", policyTemplateReferences); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting policy_template_references %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting policy_template_references: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-policy_template_references").GetDiag()
 	}
 
 	var history []map[string]interface{}
@@ -359,37 +362,37 @@ func dataSourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.
 		for _, modelItem := range trustedProfileTemplateResponse.History {
 			modelMap, err := EnityHistoryRecordToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, modelMap)
 		}
 	}
 	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting history %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting history: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-history").GetDiag()
 	}
 
 	if err = d.Set("entity_tag", trustedProfileTemplateResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting entity_tag: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-entity_tag").GetDiag()
 	}
 
 	if err = d.Set("crn", trustedProfileTemplateResponse.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting crn: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting crn: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-crn").GetDiag()
 	}
 
 	if err = d.Set("created_at", trustedProfileTemplateResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("created_by_id", trustedProfileTemplateResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting created_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by_id: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-created_by_id").GetDiag()
 	}
 
 	if err = d.Set("last_modified_at", trustedProfileTemplateResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_at: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-last_modified_at").GetDiag()
 	}
 
 	if err = d.Set("last_modified_by_id", trustedProfileTemplateResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting last_modified_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_by_id: %s", err), "(Data) ibm_iam_trusted_profile_template", "read", "set-last_modified_by_id").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
@@ -433,7 +433,7 @@ func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, 
 		}
 	}
 	if err = d.Set("resources", resources); err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-status").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting resources: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-resources").GetDiag()
 	}
 
 	var history []map[string]interface{}

--- a/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_trusted_profile_template_assignment.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.98.0-8be2046a-20241205-162752
+ */
 
 package iamidentity
 
@@ -357,7 +361,9 @@ func DataSourceIBMTrustedProfileTemplateAssignment() *schema.Resource {
 func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getTrustedProfileAssignmentOptions := &iamidentityv1.GetTrustedProfileAssignmentOptions{}
@@ -367,10 +373,11 @@ func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, 
 		getTrustedProfileAssignmentOptions.SetIncludeHistory(d.Get("include_history").(bool))
 	}
 
-	templateAssignmentResponse, response, err := iamIdentityClient.GetTrustedProfileAssignmentWithContext(context, getTrustedProfileAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.GetTrustedProfileAssignmentWithContext(context, getTrustedProfileAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetTrustedProfileAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetTrustedProfileAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTrustedProfileAssignmentWithContext failed: %s", err.Error()), "(Data) ibm_iam_trusted_profile_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s", *getTrustedProfileAssignmentOptions.AssignmentID))
@@ -379,40 +386,40 @@ func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, 
 	if templateAssignmentResponse.Context != nil {
 		modelMap, err := dataSourceIBMAccountSettingsTemplateAssignmentResponseContextToMap(templateAssignmentResponse.Context)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "context-to-map").GetDiag()
 		}
 		respContext = append(respContext, modelMap)
 	}
 	if err = d.Set("context", respContext); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting context %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting context: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-context").GetDiag()
 	}
 
 	if err = d.Set("id", templateAssignmentResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting id: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-id").GetDiag()
 	}
 
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting account_id: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-account_id").GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_id: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-template_id").GetDiag()
 	}
 
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting template_version: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-template_version").GetDiag()
 	}
 
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target_type: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-target_type").GetDiag()
 	}
 
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting target: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-target").GetDiag()
 	}
 
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-status").GetDiag()
 	}
 
 	var resources []map[string]interface{}
@@ -420,13 +427,13 @@ func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, 
 		for _, modelItem := range templateAssignmentResponse.Resources {
 			modelMap, err := dataSourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, modelMap)
 		}
 	}
 	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting resources %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-status").GetDiag()
 	}
 
 	var history []map[string]interface{}
@@ -434,37 +441,37 @@ func dataSourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, 
 		for _, modelItem := range templateAssignmentResponse.History {
 			modelMap, err := EnityHistoryRecordToMap(&modelItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "history-to-map").GetDiag()
 			}
 			history = append(history, modelMap)
 		}
 	}
 	if err = d.Set("history", history); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting history %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting history: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-history").GetDiag()
 	}
 
 	if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting href: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-href").GetDiag()
 	}
 
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_at: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-created_at").GetDiag()
 	}
 
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting created_by_id: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_at: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting last_modified_by_id: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting entity_tag: %s", err), "(Data) ibm_iam_trusted_profile_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/data_source_ibm_iam_user_mfa_enrollments.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_user_mfa_enrollments.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
@@ -138,7 +139,9 @@ func DataSourceIBMIamUserMfaEnrollments() *schema.Resource {
 func dataSourceIBMIamUserMfaEnrollmentsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getMfaStatusOptions := &iamidentityv1.GetMfaStatusOptions{}
@@ -148,38 +151,39 @@ func dataSourceIBMIamUserMfaEnrollmentsRead(context context.Context, d *schema.R
 
 	userMfaEnrollments, response, err := iamIdentityClient.GetMfaStatusWithContext(context, getMfaStatusOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetMfaStatusWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetMfaStatusWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetMfaStatusWithContext failed: %s", err.Error()), "ibm_iam_user_mfa_enrollments", "read")
+		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), response)
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(dataSourceIBMIamUserMfaEnrollmentsID(d))
 
 	if err = d.Set("effective_mfa_type", userMfaEnrollments.EffectiveMfaType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting effective_mfa_type: %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "set-effective_mfa_type").GetDiag()
 	}
 
 	idBasedMfa := []map[string]interface{}{}
 	if userMfaEnrollments.IDBasedMfa != nil {
 		modelMap, err := dataSourceIBMIamUserMfaEnrollmentsIDBasedMfaEnrollmentToMap(userMfaEnrollments.IDBasedMfa)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "mfa-enrollment-to-map").GetDiag()
 		}
 		idBasedMfa = append(idBasedMfa, modelMap)
 	}
 	if err = d.Set("id_based_mfa", idBasedMfa); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting id_based_mfa %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "set-id_based_mfa").GetDiag()
 	}
 
 	accountBasedMfa := []map[string]interface{}{}
 	if userMfaEnrollments.AccountBasedMfa != nil {
 		modelMap, err := dataSourceIBMIamUserMfaEnrollmentsAccountBasedMfaEnrollmentToMap(userMfaEnrollments.AccountBasedMfa)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "mfa-enrollment-to-map").GetDiag()
 		}
 		accountBasedMfa = append(accountBasedMfa, modelMap)
 	}
 	if err = d.Set("account_based_mfa", accountBasedMfa); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting account_based_mfa %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_user_mfa_enrollments", "read", "set-account_based_mfa").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2025 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -288,14 +288,18 @@ func ResourceIBMIAMAccountSettingsValidator() *validate.ResourceValidator {
 func resourceIBMIamAccountSettingsCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsOptions := &iamidentityv1.GetAccountSettingsOptions{}
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMIamAccountSettingsCreate failed: %s", err.Error()), "ibm_iam_account_settings", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	getAccountSettingsOptions.SetAccountID(userDetails.UserAccount)
 	if _, ok := d.GetOk("include_history"); ok {
@@ -304,8 +308,9 @@ func resourceIBMIamAccountSettingsCreate(context context.Context, d *schema.Reso
 
 	accountSettingsResponse, response, err := iamIdentityClient.GetAccountSettings(getAccountSettingsOptions)
 	if err != nil {
-		log.Printf("[DEBUG] GetAccountSettings failed %s\n%s", err, response)
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMIamAccountSettingsCreate failed: %s", err.Error()), "ibm_iam_account_settings", "create")
+		log.Printf("[DEBUG]\nGetAccountSettings failed: %s\n%s", tfErr.GetDebugMessage(), response)
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*accountSettingsResponse.AccountID)

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
@@ -15,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
@@ -221,7 +226,9 @@ func ResourceIBMAccountSettingsTemplate() *schema.Resource {
 func resourceIBMAccountSettingsTemplateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if _, ok := d.GetOk("template_id"); ok { // if template_id is present then we need to create a new version of this template instead
@@ -245,15 +252,16 @@ func resourceIBMAccountSettingsTemplateCreate(context context.Context, d *schema
 	if _, ok := d.GetOk("account_settings"); ok {
 		accountSettingsModel, err := resourceIBMAccountSettingsTemplateMapToAccountSettingsComponent(d.Get("account_settings.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "create", "parse-account_settings").GetDiag()
 		}
 		createAccountSettingsTemplateOptions.SetAccountSettings(accountSettingsModel)
 	}
 
-	accountSettingsTemplateResponse, response, err := iamIdentityClient.CreateAccountSettingsTemplateWithContext(context, createAccountSettingsTemplateOptions)
+	accountSettingsTemplateResponse, _, err := iamIdentityClient.CreateAccountSettingsTemplateWithContext(context, createAccountSettingsTemplateOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateAccountSettingsTemplateWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateAccountSettingsTemplateWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateAccountSettingsTemplateWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*accountSettingsTemplateResponse.ID, *accountSettingsTemplateResponse.Version))
@@ -261,8 +269,9 @@ func resourceIBMAccountSettingsTemplateCreate(context context.Context, d *schema
 	if d.Get("committed").(bool) {
 		err := resourceIBMAccountSettingsTemplateCommit(context, d, meta)
 		if err != nil {
-			log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateCommit failed %s", err)
-			return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateCommit failed %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCommit failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -279,8 +288,9 @@ func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d 
 
 	id, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_account_settings_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsTemplateVersionOptions.SetTemplateID(id)
@@ -301,15 +311,16 @@ func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d 
 	if _, ok := d.GetOk("account_settings"); ok {
 		accountSettingsModel, err := resourceIBMAccountSettingsTemplateMapToAccountSettingsComponent(d.Get("account_settings.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "create", "parse-account_settings").GetDiag()
 		}
 		createAccountSettingsTemplateVersionOptions.SetAccountSettings(accountSettingsModel)
 	}
 
-	accountSettingsTemplateResponse, response, err := iamIdentityClient.CreateAccountSettingsTemplateVersionWithContext(context, createAccountSettingsTemplateVersionOptions)
+	accountSettingsTemplateResponse, _, err := iamIdentityClient.CreateAccountSettingsTemplateVersionWithContext(context, createAccountSettingsTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateAccountSettingsTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*accountSettingsTemplateResponse.ID, *accountSettingsTemplateResponse.Version))
@@ -317,8 +328,9 @@ func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d 
 	if d.Get("committed").(bool) {
 		err := resourceIBMAccountSettingsTemplateCommit(context, d, meta)
 		if err != nil {
-			log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateCommit failed %s", err)
-			return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateCommit failed %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCommit failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -328,15 +340,16 @@ func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d 
 func resourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsTemplateVersionOptions := &iamidentityv1.GetAccountSettingsTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "sep-id-parts").GetDiag()
 	}
 
 	getAccountSettingsTemplateVersionOptions.SetTemplateID(id)
@@ -348,69 +361,83 @@ func resourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.R
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if !core.IsNil(accountSettingsTemplateResponse.Version) {
 		if err = d.Set("version", accountSettingsTemplateResponse.Version); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting version: %s", err))
+			err = fmt.Errorf("Error setting version: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-version").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.AccountID) {
 		if err = d.Set("account_id", accountSettingsTemplateResponse.AccountID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+			err = fmt.Errorf("Error setting account_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-account_id").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.Name) {
 		if err = d.Set("name", accountSettingsTemplateResponse.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-name").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.Description) {
 		if err = d.Set("description", accountSettingsTemplateResponse.Description); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting description: %s", err))
+			err = fmt.Errorf("Error setting description: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-description").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.AccountSettings) {
 		accountSettingsMap, err := resourceIBMAccountSettingsTemplateAccountSettingsComponentToMap(accountSettingsTemplateResponse.AccountSettings)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "account_settings-to-map").GetDiag()
 		}
 		if err = d.Set("account_settings", []map[string]interface{}{accountSettingsMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting account_settings: %s", err))
+			err = fmt.Errorf("Error setting account_settings: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-account_settings").GetDiag()
 		}
 	}
 	if err = d.Set("id", accountSettingsTemplateResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		err = fmt.Errorf("Error setting id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-id").GetDiag()
 	}
 	if err = d.Set("committed", accountSettingsTemplateResponse.Committed); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting committed: %s", err))
+		err = fmt.Errorf("Error setting committed: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-committed").GetDiag()
 	}
 	if err = d.Set("entity_tag", accountSettingsTemplateResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		err = fmt.Errorf("Error setting entity_tag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-entity_tag").GetDiag()
 	}
 	if err = d.Set("crn", accountSettingsTemplateResponse.CRN); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting crn: %s", err))
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-crn").GetDiag()
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.CreatedAt) {
 		if err = d.Set("created_at", accountSettingsTemplateResponse.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-created_at").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.CreatedByID) {
 		if err = d.Set("created_by_id", accountSettingsTemplateResponse.CreatedByID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+			err = fmt.Errorf("Error setting created_by_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-created_by_id").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.LastModifiedAt) {
 		if err = d.Set("last_modified_at", accountSettingsTemplateResponse.LastModifiedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+			err = fmt.Errorf("Error setting last_modified_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-last_modified_at").GetDiag()
 		}
 	}
 	if !core.IsNil(accountSettingsTemplateResponse.LastModifiedByID) {
 		if err = d.Set("last_modified_by_id", accountSettingsTemplateResponse.LastModifiedByID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+			err = fmt.Errorf("Error setting last_modified_by_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "set-last_modified_by_id").GetDiag()
 		}
 	}
 
@@ -420,15 +447,16 @@ func resourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.R
 func resourceIBMAccountSettingsTemplateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAccountSettingsTemplateVersionOptions := &iamidentityv1.UpdateAccountSettingsTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateUpdate failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateUpdate failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateAccountSettingsTemplateVersionOptions.SetTemplateID(id)
@@ -448,17 +476,18 @@ func resourceIBMAccountSettingsTemplateUpdate(context context.Context, d *schema
 	if d.HasChange("account_settings") {
 		accountSettings, err := resourceIBMAccountSettingsTemplateMapToAccountSettingsComponent(d.Get("account_settings.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "update", "parse-account_settings").GetDiag()
 		}
 		updateAccountSettingsTemplateVersionOptions.SetAccountSettings(accountSettings)
 		hasChange = true
 	}
 
 	if hasChange {
-		_, response, err := iamIdentityClient.UpdateAccountSettingsTemplateVersionWithContext(context, updateAccountSettingsTemplateVersionOptions)
+		_, _, err := iamIdentityClient.UpdateAccountSettingsTemplateVersionWithContext(context, updateAccountSettingsTemplateVersionOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAccountSettingsTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -466,11 +495,14 @@ func resourceIBMAccountSettingsTemplateUpdate(context context.Context, d *schema
 		if d.Get("committed").(bool) {
 			err := resourceIBMAccountSettingsTemplateCommit(context, d, meta)
 			if err != nil {
-				log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateCommit failed %s", err)
-				return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateCommit failed %s", err))
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCommit failed: %s", err.Error()), "ibm_iam_account_settings_template", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 		} else {
-			return diag.FromErr(fmt.Errorf("A committed template cannot be uncommitted"))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("A committed template cannot be uncommitted: %s", err.Error()), "ibm_iam_account_settings_template", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -480,24 +512,26 @@ func resourceIBMAccountSettingsTemplateUpdate(context context.Context, d *schema
 func resourceIBMAccountSettingsTemplateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteAccountSettingsTemplateVersionOptions := &iamidentityv1.DeleteAccountSettingsTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateDelete failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateDelete failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteAccountSettingsTemplateVersionOptions.SetTemplateID(id)
 	deleteAccountSettingsTemplateVersionOptions.SetVersion(version)
 
-	response, err := iamIdentityClient.DeleteAccountSettingsTemplateVersionWithContext(context, deleteAccountSettingsTemplateVersionOptions)
+	_, err = iamIdentityClient.DeleteAccountSettingsTemplateVersionWithContext(context, deleteAccountSettingsTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteAccountSettingsTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAccountSettingsTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
@@ -288,14 +288,12 @@ func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d 
 
 	createAccountSettingsTemplateVersionOptions := &iamidentityv1.CreateAccountSettingsTemplateVersionOptions{}
 
-	id, _, err := parseResourceId(d.Get("template_id").(string))
+	templateId, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCreateVersion failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "create", "parse-resource-id").GetDiag()
 	}
 
-	createAccountSettingsTemplateVersionOptions.SetTemplateID(id)
+	createAccountSettingsTemplateVersionOptions.SetTemplateID(templateId)
 
 	if _, ok := d.GetOk("account_id"); ok {
 		createAccountSettingsTemplateVersionOptions.SetAccountID(d.Get("account_id").(string))
@@ -349,12 +347,12 @@ func resourceIBMAccountSettingsTemplateRead(context context.Context, d *schema.R
 
 	getAccountSettingsTemplateVersionOptions := &iamidentityv1.GetAccountSettingsTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "read", "parse-resource-id").GetDiag()
 	}
 
-	getAccountSettingsTemplateVersionOptions.SetTemplateID(id)
+	getAccountSettingsTemplateVersionOptions.SetTemplateID(templateId)
 	getAccountSettingsTemplateVersionOptions.SetVersion(version)
 
 	accountSettingsTemplateResponse, response, err := iamIdentityClient.GetAccountSettingsTemplateVersionWithContext(context, getAccountSettingsTemplateVersionOptions)
@@ -456,12 +454,12 @@ func resourceIBMAccountSettingsTemplateUpdate(context context.Context, d *schema
 
 	updateAccountSettingsTemplateVersionOptions := &iamidentityv1.UpdateAccountSettingsTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "update", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "update", "parse-resource-id").GetDiag()
 	}
 
-	updateAccountSettingsTemplateVersionOptions.SetTemplateID(id)
+	updateAccountSettingsTemplateVersionOptions.SetTemplateID(templateId)
 	updateAccountSettingsTemplateVersionOptions.SetVersion(version)
 	updateAccountSettingsTemplateVersionOptions.SetIfMatch(d.Get("entity_tag").(string))
 
@@ -521,12 +519,12 @@ func resourceIBMAccountSettingsTemplateDelete(context context.Context, d *schema
 
 	deleteAccountSettingsTemplateVersionOptions := &iamidentityv1.DeleteAccountSettingsTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "delete", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "delete", "parse-resource-id").GetDiag()
 	}
 
-	deleteAccountSettingsTemplateVersionOptions.SetTemplateID(id)
+	deleteAccountSettingsTemplateVersionOptions.SetTemplateID(templateId)
 	deleteAccountSettingsTemplateVersionOptions.SetVersion(version)
 
 	_, err = iamIdentityClient.DeleteAccountSettingsTemplateVersionWithContext(context, deleteAccountSettingsTemplateVersionOptions)
@@ -547,12 +545,12 @@ func resourceIBMAccountSettingsTemplateCommit(context context.Context, d *schema
 		return err
 	}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
 		return err
 	}
 
-	commitAccountSettingsTemplateVersionOptions := iamIdentityClient.NewCommitAccountSettingsTemplateOptions(id, version)
+	commitAccountSettingsTemplateVersionOptions := iamIdentityClient.NewCommitAccountSettingsTemplateOptions(templateId, version)
 	_, err = iamIdentityClient.CommitAccountSettingsTemplateWithContext(context, commitAccountSettingsTemplateVersionOptions)
 	if err != nil {
 		return err

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template.go
@@ -281,14 +281,16 @@ func resourceIBMAccountSettingsTemplateCreate(context context.Context, d *schema
 func resourceIBMAccountSettingsTemplateCreateVersion(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsTemplateVersionOptions := &iamidentityv1.CreateAccountSettingsTemplateVersionOptions{}
 
 	id, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_account_settings_template", "read")
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCreateVersion failed: %s", err.Error()), "ibm_iam_account_settings_template", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -224,7 +224,7 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutCreate), meta, d, isAccountSettingsTemplateAssigned)
 	if err != nil {
-		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "create", "wait-for-assignment").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
 	return resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
@@ -343,13 +343,14 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 	if hasChange || d.Get("status") == "failed" { // allow the same version to retry failed assignments
 		_, response, err := iamIdentityClient.UpdateAccountSettingsAssignmentWithContext(context, updateAccountSettingsAssignmentOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "update")
+			log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), response)
+			return tfErr.GetDiag()
 		}
 
 		_, err = waitForAssignment(d.Timeout(schema.TimeoutUpdate), meta, d, isAccountSettingsTemplateAssigned)
 		if err != nil {
-			flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "update", "wait-for-assignment").GetDiag()
 		}
 	}
 
@@ -377,7 +378,7 @@ func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context,
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isAccountSettingsAssignmentRemoved)
 	if err != nil {
-		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "delete", "wait-for-assignment").GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
@@ -190,15 +194,18 @@ func ResourceIBMAccountSettingsTemplateAssignmentValidator() *validate.ResourceV
 func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsAssignmentOptions := &iamidentityv1.CreateAccountSettingsAssignmentOptions{}
 
 	templateId, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createAccountSettingsAssignmentOptions.SetTemplateID(templateId)
@@ -206,17 +213,18 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 	createAccountSettingsAssignmentOptions.SetTargetType(d.Get("target_type").(string))
 	createAccountSettingsAssignmentOptions.SetTarget(d.Get("target").(string))
 
-	templateAssignmentResponse, response, err := iamIdentityClient.CreateAccountSettingsAssignmentWithContext(context, createAccountSettingsAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.CreateAccountSettingsAssignmentWithContext(context, createAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*templateAssignmentResponse.ID)
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutCreate), meta, d, isAccountSettingsTemplateAssigned)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error assigning %s", err))
+		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "create", "wait-for-assignment").GetDiag()
 	}
 
 	return resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
@@ -225,7 +233,9 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getAccountSettingsAssignmentOptions := &iamidentityv1.GetAccountSettingsAssignmentOptions{}
@@ -238,60 +248,74 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		err = fmt.Errorf("Error setting template_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		err = fmt.Errorf("Error setting template_version: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_version").GetDiag()
 	}
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		err = fmt.Errorf("Error setting target_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-target_type").GetDiag()
 	}
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		err = fmt.Errorf("Error setting target: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-target").GetDiag()
 	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-account_id").GetDiag()
 	}
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-status").GetDiag()
 	}
 	var resources []map[string]interface{}
 	if !core.IsNil(templateAssignmentResponse.Resources) {
 		for _, resourcesItem := range templateAssignmentResponse.Resources {
 			resourcesItemMap, err := resourceIBMAccountSettingsTemplateAssignmentTemplateAssignmentResponseResourceToMap(&resourcesItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, resourcesItemMap)
 		}
 	}
 	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
+		err = fmt.Errorf("Error setting resources: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-resources").GetDiag()
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+			err = fmt.Errorf("Error setting href: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-href").GetDiag()
 		}
 	}
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		err = fmt.Errorf("Error setting created_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		err = fmt.Errorf("Error setting last_modified_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		err = fmt.Errorf("Error setting last_modified_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		err = fmt.Errorf("Error setting entity_tag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil
@@ -300,7 +324,9 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateAccountSettingsAssignmentOptions := &iamidentityv1.UpdateAccountSettingsAssignmentOptions{}
@@ -323,7 +349,7 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 
 		_, err = waitForAssignment(d.Timeout(schema.TimeoutUpdate), meta, d, isAccountSettingsTemplateAssigned)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error assigning %s", err))
+			flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
 		}
 	}
 
@@ -333,22 +359,25 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteAccountSettingsAssignmentOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{}
 
 	deleteAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
 
-	_, response, err := iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
+	_, _, err = iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteAccountSettingsAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteAccountSettingsAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isAccountSettingsAssignmentRemoved)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error removing assignment %s", err))
+		flex.DiscriminatedTerraformErrorf(err, err.Error(), "error assigning", "update", "wait-for-assignment").GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -203,9 +203,7 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 
 	templateId, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "create")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "parse-resource-id").GetDiag()
 	}
 
 	createAccountSettingsAssignmentOptions.SetTemplateID(templateId)

--- a/ibm/service/iamidentity/resource_ibm_iam_service_id.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_id.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,14 +71,18 @@ func ResourceIBMIAMServiceID() *schema.Resource {
 func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	name := d.Get("name").(string)
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMIAMServiceIDCreate failed: %s", err.Error()), "ibm_iam_service_id", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createServiceIDOptions := iamidentityv1.CreateServiceIDOptions{
@@ -92,8 +97,9 @@ func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceDa
 
 	serviceID, resp, err := iamIdentityClient.CreateServiceID(&createServiceIDOptions)
 	if err != nil || serviceID == nil {
-		log.Printf("Error creating serviceID: %s, %s", err, resp)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error creating serviceID: %s %s", err, resp))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateServiceID failed: %s", err.Error()), "ibm_iam_service_id", "create")
+		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+		return tfErr.GetDiag()
 	}
 	d.SetId(*serviceID.ID)
 
@@ -103,7 +109,9 @@ func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceDa
 func resourceIBMIAMServiceIDRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	serviceIDUUID := d.Id()
 	getServiceIDOptions := iamidentityv1.GetServiceIDOptions{
@@ -115,8 +123,9 @@ func resourceIBMIAMServiceIDRead(context context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		log.Printf("Error retrieving serviceID: %s %s", err, resp)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error retrieving serviceID: %s %s", err, resp))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetServiceID failed: %s", err.Error()), "ibm_iam_service_id", "read")
+		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+		return tfErr.GetDiag()
 	}
 	if serviceID.Name != nil {
 		d.Set("name", *serviceID.Name)
@@ -140,10 +149,11 @@ func resourceIBMIAMServiceIDRead(context context.Context, d *schema.ResourceData
 }
 
 func resourceIBMIAMServiceIDUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	serviceIDUUID := d.Id()
 
@@ -169,8 +179,9 @@ func resourceIBMIAMServiceIDUpdate(context context.Context, d *schema.ResourceDa
 	if hasChange {
 		_, resp, err := iamIdentityClient.UpdateServiceID(&updateServiceIDOptions)
 		if err != nil {
-			log.Printf("Error updating serviceID: %s, %s", err, resp)
-			return diag.FromErr(fmt.Errorf("[ERROR] Error updating serviceID: %s %s", err, resp))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateServiceID failed: %s", err.Error()), "ibm_iam_service_id", "update")
+			log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -181,7 +192,9 @@ func resourceIBMIAMServiceIDUpdate(context context.Context, d *schema.ResourceDa
 func resourceIBMIAMServiceIDDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	serviceIDUUID := d.Id()
@@ -190,8 +203,9 @@ func resourceIBMIAMServiceIDDelete(context context.Context, d *schema.ResourceDa
 	}
 	resp, err := iamIdentityClient.DeleteServiceID(&deleteServiceIDOptions)
 	if err != nil {
-		log.Printf("Error deleting serviceID: %s %s", err, resp)
-		return diag.FromErr(fmt.Errorf("[ERROR] Error deleting serviceID: %s %s", err, resp))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteServiceID failed: %s", err.Error()), "ibm_iam_service_id", "delete")
+		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile.go
@@ -176,7 +176,9 @@ func resourceIBMIamTrustedProfileCreate(context context.Context, d *schema.Resou
 
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMIamTrustedProfileCreate failed: %s", err.Error()), "ibm_iam_trusted_profile", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	accountID := userDetails.UserAccount

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identities.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2025 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
@@ -140,7 +140,8 @@ func resourceIBMIamTrustedProfileIdentitiesRead(context context.Context, d *sche
 		return tfErr.GetDiag()
 	}
 	if err := d.Set("profile_id", d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting profile_id: %s", err))
+		err = fmt.Errorf("Error setting profile_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "set-profile_id").GetDiag()
 	}
 	if !core.IsNil(profileIdentitiesResponse.Identities) {
 		identities := []map[string]interface{}{}
@@ -164,7 +165,8 @@ func resourceIBMIamTrustedProfileIdentitiesRead(context context.Context, d *sche
 		}
 	}
 	if err = d.Set("if_match", response.Headers.Get("ETag")); err != nil {
-		return diag.FromErr(flex.FmtErrorf("Error setting etag: %s", err))
+		err = flex.FmtErrorf("Error setting if_match: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identities", "read", "set-if_match").GetDiag()
 	}
 
 	return nil

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
@@ -223,7 +223,7 @@ func resourceIBMIamTrustedProfileIdentityDelete(context context.Context, d *sche
 	deleteProfileIdentityOptions.SetIdentityType(parts_to_use[1])
 	deleteProfileIdentityOptions.SetIdentifierID(parts_to_use[2])
 
-	response, err := iamIdentityClient.DeleteProfileIdentityWithContext(context, deleteProfileIdentityOptions)
+	_, err = iamIdentityClient.DeleteProfileIdentityWithContext(context, deleteProfileIdentityOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteProfileIdentityWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identity", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
@@ -95,7 +99,9 @@ func ResourceIBMIamTrustedProfileIdentityValidator() *validate.ResourceValidator
 func resourceIBMIamTrustedProfileIdentityCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	setProfileIdentityOptions := &iamidentityv1.SetProfileIdentityOptions{}
@@ -116,10 +122,11 @@ func resourceIBMIamTrustedProfileIdentityCreate(context context.Context, d *sche
 		setProfileIdentityOptions.SetDescription(d.Get("description").(string))
 	}
 
-	profileIdentityResponse, response, err := iamIdentityClient.SetProfileIdentityWithContext(context, setProfileIdentityOptions)
+	profileIdentityResponse, _, err := iamIdentityClient.SetProfileIdentityWithContext(context, setProfileIdentityOptions)
 	if err != nil {
-		log.Printf("[DEBUG] SetProfileIdentityWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("SetProfileIdentityWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("SetProfileIdentityWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identity", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s|%s", *setProfileIdentityOptions.ProfileID, *setProfileIdentityOptions.IdentityType, *profileIdentityResponse.Identifier))
@@ -130,7 +137,9 @@ func resourceIBMIamTrustedProfileIdentityCreate(context context.Context, d *sche
 func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProfileIdentityOptions := &iamidentityv1.GetProfileIdentityOptions{}
@@ -139,7 +148,7 @@ func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema
 	if original_err != nil {
 		parts, err := flex.SepIdParts(d.Id(), "/") // compatability - can be removed in future release
 		if err != nil {
-			return diag.FromErr(original_err)
+			return flex.DiscriminatedTerraformErrorf(original_err, original_err.Error(), "ibm_iam_trusted_profile_identity", "read", "sep-id-parts").GetDiag()
 		}
 		parts_to_use = parts
 	}
@@ -154,8 +163,9 @@ func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetProfileIdentityWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProfileIdentityWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileIdentityWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identity", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s|%s", *getProfileIdentityOptions.ProfileID, *getProfileIdentityOptions.IdentityType, *getProfileIdentityOptions.IdentifierID))
@@ -167,19 +177,23 @@ func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema
 		return diag.FromErr(fmt.Errorf("Error setting identity_type: %s", err))
 	}
 	if err = d.Set("identifier", profileIdentityResponse.Identifier); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting identifier: %s", err))
+		err = fmt.Errorf("Error setting identifier: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-identifier").GetDiag()
 	}
 	if err = d.Set("type", profileIdentityResponse.Type); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+		err = fmt.Errorf("Error setting type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-type").GetDiag()
 	}
 	if !core.IsNil(profileIdentityResponse.Accounts) {
 		if err = d.Set("accounts", profileIdentityResponse.Accounts); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting accounts: %s", err))
+			err = fmt.Errorf("Error setting accounts: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-accounts").GetDiag()
 		}
 	}
 	if !core.IsNil(profileIdentityResponse.Description) {
 		if err = d.Set("description", profileIdentityResponse.Description); err != nil {
-			return diag.FromErr(fmt.Errorf("Error setting description: %s", err))
+			err = fmt.Errorf("Error setting description: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-description").GetDiag()
 		}
 	}
 
@@ -189,7 +203,9 @@ func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema
 func resourceIBMIamTrustedProfileIdentityDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteProfileIdentityOptions := &iamidentityv1.DeleteProfileIdentityOptions{}
@@ -198,7 +214,7 @@ func resourceIBMIamTrustedProfileIdentityDelete(context context.Context, d *sche
 	if original_err != nil {
 		parts, err := flex.SepIdParts(d.Id(), "/") // compatability - remove in future release
 		if err != nil {
-			return diag.FromErr(original_err)
+			return flex.DiscriminatedTerraformErrorf(original_err, original_err.Error(), "ibm_iam_trusted_profile_identity", "delete", "sep-id-parts").GetDiag()
 		}
 		parts_to_use = parts
 	}
@@ -209,8 +225,9 @@ func resourceIBMIamTrustedProfileIdentityDelete(context context.Context, d *sche
 
 	response, err := iamIdentityClient.DeleteProfileIdentityWithContext(context, deleteProfileIdentityOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteProfileIdentityWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteProfileIdentityWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteProfileIdentityWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_identity", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity.go
@@ -171,10 +171,12 @@ func resourceIBMIamTrustedProfileIdentityRead(context context.Context, d *schema
 	d.SetId(fmt.Sprintf("%s|%s|%s", *getProfileIdentityOptions.ProfileID, *getProfileIdentityOptions.IdentityType, *getProfileIdentityOptions.IdentifierID))
 
 	if err = d.Set("profile_id", getProfileIdentityOptions.ProfileID); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting profile_id: %s", err))
+		err = fmt.Errorf("Error setting profile_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-profile_id").GetDiag()
 	}
 	if err = d.Set("identity_type", getProfileIdentityOptions.IdentityType); err != nil {
-		return diag.FromErr(fmt.Errorf("Error setting identity_type: %s", err))
+		err = fmt.Errorf("Error setting identity_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_identity", "read", "set-identity_type").GetDiag()
 	}
 	if err = d.Set("identifier", profileIdentityResponse.Identifier); err != nil {
 		err = fmt.Errorf("Error setting identifier: %s", err)

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_identity_test.go
@@ -27,7 +27,7 @@ func TestAccIBMIamTrustedProfileIdentityBasic(t *testing.T) {
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIBMIamTrustedProfileIdentityDestroy,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIBMIamTrustedProfileIdentityConfigBasic(profileID, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIamTrustedProfileIdentityExists("ibm_iam_trusted_profile_identity.iam_trusted_profile_identity", conf),
@@ -54,7 +54,7 @@ func TestAccIBMIamTrustedProfileIdentityAllArgs(t *testing.T) {
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIBMIamTrustedProfileIdentityDestroy,
 		Steps: []resource.TestStep{
-			{
+			resource.TestStep{
 				Config: testAccCheckIBMIamTrustedProfileIdentityConfig(profileID, identityType, identifier, typeVar, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMIamTrustedProfileIdentityExists("ibm_iam_trusted_profile_identity.iam_trusted_profile_identity", conf),

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
@@ -303,6 +303,7 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 	}
 
 	createProfileTemplateVersionOptions := &iamidentityv1.CreateProfileTemplateVersionOptions{}
+
 	if _, ok := d.GetOk("account_id"); ok {
 		createProfileTemplateVersionOptions.SetAccountID(d.Get("account_id").(string))
 	} else {
@@ -310,14 +311,12 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 		accountID := userDetails.UserAccount
 		createProfileTemplateVersionOptions.SetAccountID(accountID)
 	}
-	id, _, err := parseResourceId(d.Get("template_id").(string))
+	templateId, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "parse-resource-id").GetDiag()
 	}
 
-	createProfileTemplateVersionOptions.SetTemplateID(id)
+	createProfileTemplateVersionOptions.SetTemplateID(templateId)
 
 	if _, ok := d.GetOk("name"); ok {
 		createProfileTemplateVersionOptions.SetName(d.Get("name").(string))
@@ -376,12 +375,12 @@ func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.Re
 
 	getProfileTemplateVersionOptions := &iamidentityv1.GetProfileTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "parse-resource-id").GetDiag()
 	}
 
-	getProfileTemplateVersionOptions.SetTemplateID(id)
+	getProfileTemplateVersionOptions.SetTemplateID(templateId)
 	getProfileTemplateVersionOptions.SetVersion(version)
 
 	trustedProfileTemplateResponse, response, err := iamIdentityClient.GetProfileTemplateVersionWithContext(context, getProfileTemplateVersionOptions)
@@ -503,12 +502,12 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 
 	updateProfileTemplateVersionOptions := &iamidentityv1.UpdateProfileTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "parse-resource-id").GetDiag()
 	}
 
-	updateProfileTemplateVersionOptions.SetTemplateID(id)
+	updateProfileTemplateVersionOptions.SetTemplateID(templateId)
 	updateProfileTemplateVersionOptions.SetVersion(version)
 	updateProfileTemplateVersionOptions.SetIfMatch(d.Get("entity_tag").(string))
 
@@ -580,12 +579,12 @@ func resourceIBMTrustedProfileTemplateDelete(context context.Context, d *schema.
 
 	deleteProfileTemplateVersionOptions := &iamidentityv1.DeleteProfileTemplateVersionOptions{}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "delete", "sep-id-parts").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "delete", "parse-resource-id").GetDiag()
 	}
 
-	deleteProfileTemplateVersionOptions.SetTemplateID(id)
+	deleteProfileTemplateVersionOptions.SetTemplateID(templateId)
 	deleteProfileTemplateVersionOptions.SetVersion(version)
 
 	_, err = iamIdentityClient.DeleteProfileTemplateVersionWithContext(context, deleteProfileTemplateVersionOptions)
@@ -606,12 +605,12 @@ func resourceIBMTrustedProfileTemplateCommit(context context.Context, d *schema.
 		return err
 	}
 
-	id, version, err := parseResourceId(d.Id())
+	templateId, version, err := parseResourceId(d.Id())
 	if err != nil {
 		return err
 	}
 
-	commitTrustedProfileTemplateVersionOptions := iamIdentityClient.NewCommitProfileTemplateOptions(id, version)
+	commitTrustedProfileTemplateVersionOptions := iamIdentityClient.NewCommitProfileTemplateOptions(templateId, version)
 	_, err = iamIdentityClient.CommitProfileTemplateWithContext(context, commitTrustedProfileTemplateVersionOptions)
 	if err != nil {
 		return err

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
@@ -562,7 +562,8 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 				return tfErr.GetDiag()
 			}
 		} else {
-			return diag.FromErr(fmt.Errorf("A committed template cannot be uncommitted"))
+			err := fmt.Errorf("A committed template cannot be uncommitted")
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("resourceIBMTrustedProfileTemplateUpdate failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "update", "set-committed").GetDiag()
 		}
 	}
 

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -229,7 +229,9 @@ func ResourceIBMTrustedProfileTemplate() *schema.Resource {
 func resourceIBMTrustedProfileTemplateCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if _, ok := d.GetOk("template_id"); ok { // if template_id is present then we need to create a new version of this template instead
@@ -254,7 +256,7 @@ func resourceIBMTrustedProfileTemplateCreate(context context.Context, d *schema.
 	if _, ok := d.GetOk("profile"); ok {
 		profileModel, err := resourceIBMTrustedProfileTemplateMapToTemplateProfileComponentRequest(d.Get("profile.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "parse-profile").GetDiag()
 		}
 		createProfileTemplateOptions.SetProfile(profileModel)
 	}
@@ -264,17 +266,18 @@ func resourceIBMTrustedProfileTemplateCreate(context context.Context, d *schema.
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMTrustedProfileTemplateMapToPolicyTemplateReference(value)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "parse-policy_template_references").GetDiag()
 			}
 			policyTemplateReferences = append(policyTemplateReferences, *policyTemplateReferencesItem)
 		}
 		createProfileTemplateOptions.SetPolicyTemplateReferences(policyTemplateReferences)
 	}
 
-	trustedProfileTemplateResponse, response, err := iamIdentityClient.CreateProfileTemplateWithContext(context, createProfileTemplateOptions)
+	trustedProfileTemplateResponse, _, err := iamIdentityClient.CreateProfileTemplateWithContext(context, createProfileTemplateOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateProfileTemplateWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateProfileTemplateWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateProfileTemplateWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*trustedProfileTemplateResponse.ID, *trustedProfileTemplateResponse.Version))
@@ -282,8 +285,9 @@ func resourceIBMTrustedProfileTemplateCreate(context context.Context, d *schema.
 	if d.Get("committed").(bool) {
 		err := resourceIBMTrustedProfileTemplateCommit(context, d, meta)
 		if err != nil {
-			log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateCommit failed %s", err)
-			return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateCommit failed %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCommit failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -293,7 +297,9 @@ func resourceIBMTrustedProfileTemplateCreate(context context.Context, d *schema.
 func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createProfileTemplateVersionOptions := &iamidentityv1.CreateProfileTemplateVersionOptions{}
@@ -306,8 +312,9 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 	}
 	id, _, err := parseResourceId(d.Get("template_id").(string))
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateRead failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createProfileTemplateVersionOptions.SetTemplateID(id)
@@ -321,7 +328,7 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 	if _, ok := d.GetOk("profile"); ok {
 		profileModel, err := resourceIBMTrustedProfileTemplateMapToTemplateProfileComponentRequest(d.Get("profile.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "parse-profile").GetDiag()
 		}
 		createProfileTemplateVersionOptions.SetProfile(profileModel)
 	}
@@ -331,17 +338,18 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMTrustedProfileTemplateMapToPolicyTemplateReference(value)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "create", "parse-policy_template_references").GetDiag()
 			}
 			policyTemplateReferences = append(policyTemplateReferences, *policyTemplateReferencesItem)
 		}
 		createProfileTemplateVersionOptions.SetPolicyTemplateReferences(policyTemplateReferences)
 	}
 
-	trustedProfileTemplateVersionResponse, response, err := iamIdentityClient.CreateProfileTemplateVersionWithContext(context, createProfileTemplateVersionOptions)
+	trustedProfileTemplateVersionResponse, _, err := iamIdentityClient.CreateProfileTemplateVersionWithContext(context, createProfileTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateProfileTemplateWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateProfileTemplateWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateProfileTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(buildResourceIdFromTemplateVersion(*trustedProfileTemplateVersionResponse.ID, *trustedProfileTemplateVersionResponse.Version))
@@ -349,8 +357,9 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 	if d.Get("committed").(bool) {
 		err := resourceIBMTrustedProfileTemplateCommit(context, d, meta)
 		if err != nil {
-			log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateCommit failed %s", err)
-			return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateCommit failed %s", err))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMAccountSettingsTemplateCommit failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "create")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -360,15 +369,16 @@ func resourceIBMTrustedProfileTemplateCreateVersion(context context.Context, d *
 func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getProfileTemplateVersionOptions := &iamidentityv1.GetProfileTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateRead failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateRead failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "sep-id-parts").GetDiag()
 	}
 
 	getProfileTemplateVersionOptions.SetTemplateID(id)
@@ -380,37 +390,43 @@ func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetProfileTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetProfileTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetProfileTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if !core.IsNil(trustedProfileTemplateResponse.Version) {
 		if err = d.Set("version", trustedProfileTemplateResponse.Version); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting version: %s", err))
+			err = fmt.Errorf("Error setting version: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-version").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.AccountID) {
 		if err = d.Set("account_id", trustedProfileTemplateResponse.AccountID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+			err = fmt.Errorf("Error setting account_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-account_id").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.Name) {
 		if err = d.Set("name", trustedProfileTemplateResponse.Name); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting name: %s", err))
+			err = fmt.Errorf("Error setting name: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-name").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.Description) {
 		if err = d.Set("description", trustedProfileTemplateResponse.Description); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting description: %s", err))
+			err = fmt.Errorf("Error setting description: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-description").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.Profile) {
 		profileMap, err := resourceIBMTrustedProfileTemplateTemplateProfileComponentResponseToMap(trustedProfileTemplateResponse.Profile)
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "profile-to-map").GetDiag()
 		}
 		if err = d.Set("profile", []map[string]interface{}{profileMap}); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting profile: %s", err))
+			err = fmt.Errorf("Error setting profile: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-profile").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.PolicyTemplateReferences) {
@@ -418,50 +434,59 @@ func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.Re
 		for _, policyTemplateReferencesItem := range trustedProfileTemplateResponse.PolicyTemplateReferences {
 			policyTemplateReferencesItemMap, err := resourceIBMTrustedProfileTemplatePolicyTemplateReferenceToMap(&policyTemplateReferencesItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "policy_template_references-to-map").GetDiag()
 			}
 			policyTemplateReferences = append(policyTemplateReferences, policyTemplateReferencesItemMap)
 		}
 		if err = d.Set("policy_template_references", policyTemplateReferences); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting policy_template_references: %s", err))
+			err = fmt.Errorf("Error setting policy_template_references: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-policy_template_references").GetDiag()
 		}
 	}
 	if err = d.Set("id", trustedProfileTemplateResponse.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting id: %s", err))
+		err = fmt.Errorf("Error setting id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-id").GetDiag()
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.Committed) {
 		if err = d.Set("committed", trustedProfileTemplateResponse.Committed); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting committed: %s", err))
+			err = fmt.Errorf("Error setting committed: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-committed").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.EntityTag) {
 		if err = d.Set("entity_tag", trustedProfileTemplateResponse.EntityTag); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+			err = fmt.Errorf("Error setting entity_tag: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-entity_tag").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.CRN) {
 		if err = d.Set("crn", trustedProfileTemplateResponse.CRN); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting crn: %s", err))
+			err = fmt.Errorf("Error setting crn: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-crn").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.CreatedAt) {
 		if err = d.Set("created_at", trustedProfileTemplateResponse.CreatedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+			err = fmt.Errorf("Error setting created_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-created_at").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.CreatedByID) {
 		if err = d.Set("created_by_id", trustedProfileTemplateResponse.CreatedByID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+			err = fmt.Errorf("Error setting created_by_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-created_by_id").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.LastModifiedAt) {
 		if err = d.Set("last_modified_at", trustedProfileTemplateResponse.LastModifiedAt); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+			err = fmt.Errorf("Error setting last_modified_at: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-last_modified_at").GetDiag()
 		}
 	}
 	if !core.IsNil(trustedProfileTemplateResponse.LastModifiedByID) {
 		if err = d.Set("last_modified_by_id", trustedProfileTemplateResponse.LastModifiedByID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+			err = fmt.Errorf("Error setting last_modified_by_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "read", "set-last_modified_by_id").GetDiag()
 		}
 	}
 
@@ -471,15 +496,16 @@ func resourceIBMTrustedProfileTemplateRead(context context.Context, d *schema.Re
 func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateProfileTemplateVersionOptions := &iamidentityv1.UpdateProfileTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateUpdate failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateUpdate failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "sep-id-parts").GetDiag()
 	}
 
 	updateProfileTemplateVersionOptions.SetTemplateID(id)
@@ -499,7 +525,7 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 	if d.HasChange("profile") {
 		profile, err := resourceIBMTrustedProfileTemplateMapToTemplateProfileComponentRequest(d.Get("profile.0").(map[string]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "parse-profile").GetDiag()
 		}
 		updateProfileTemplateVersionOptions.SetProfile(profile)
 		hasChange = true
@@ -510,7 +536,7 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 			value := v.(map[string]interface{})
 			policyTemplateReferencesItem, err := resourceIBMTrustedProfileTemplateMapToPolicyTemplateReference(value)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "update", "parse-policy_template_references").GetDiag()
 			}
 			policyTemplateReferences = append(policyTemplateReferences, *policyTemplateReferencesItem)
 		}
@@ -519,10 +545,11 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 	}
 
 	if hasChange {
-		_, response, err := iamIdentityClient.UpdateProfileTemplateVersionWithContext(context, updateProfileTemplateVersionOptions)
+		_, _, err := iamIdentityClient.UpdateProfileTemplateVersionWithContext(context, updateProfileTemplateVersionOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateProfileTemplateVersionWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateProfileTemplateVersionWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateProfileTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 	}
 
@@ -530,8 +557,9 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 		if d.Get("committed").(bool) {
 			err := resourceIBMTrustedProfileTemplateCommit(context, d, meta)
 			if err != nil {
-				log.Printf("[DEBUG] resourceIBMTrustedProfileTemplateCommit failed %s", err)
-				return diag.FromErr(fmt.Errorf("resourceIBMTrustedProfileTemplateCommit failed %s", err))
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMTrustedProfileTemplateCommit failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
 			}
 		} else {
 			return diag.FromErr(fmt.Errorf("A committed template cannot be uncommitted"))
@@ -544,24 +572,26 @@ func resourceIBMTrustedProfileTemplateUpdate(context context.Context, d *schema.
 func resourceIBMTrustedProfileTemplateDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteProfileTemplateVersionOptions := &iamidentityv1.DeleteProfileTemplateVersionOptions{}
 
 	id, version, err := parseResourceId(d.Id())
 	if err != nil {
-		log.Printf("[DEBUG] resourceIBMAccountSettingsTemplateDelete failed %s", err)
-		return diag.FromErr(fmt.Errorf("resourceIBMAccountSettingsTemplateDelete failed %s", err))
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template", "delete", "sep-id-parts").GetDiag()
 	}
 
 	deleteProfileTemplateVersionOptions.SetTemplateID(id)
 	deleteProfileTemplateVersionOptions.SetVersion(version)
 
-	response, err := iamIdentityClient.DeleteProfileTemplateVersionWithContext(context, deleteProfileTemplateVersionOptions)
+	_, err = iamIdentityClient.DeleteProfileTemplateVersionWithContext(context, deleteProfileTemplateVersionOptions)
 	if err != nil {
-		log.Printf("[DEBUG] DeleteProfileTemplateVersionWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("DeleteProfileTemplateVersionWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteProfileTemplateVersionWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2023 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity
@@ -273,7 +273,9 @@ func ResourceIBMTrustedProfileTemplateAssignmentValidator() *validate.ResourceVa
 func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	createTrustedProfileAssignmentOptions := &iamidentityv1.CreateTrustedProfileAssignmentOptions{}
@@ -283,17 +285,19 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 	createTrustedProfileAssignmentOptions.SetTargetType(d.Get("target_type").(string))
 	createTrustedProfileAssignmentOptions.SetTarget(d.Get("target").(string))
 
-	templateAssignmentResponse, response, err := iamIdentityClient.CreateTrustedProfileAssignmentWithContext(context, createTrustedProfileAssignmentOptions)
+	templateAssignmentResponse, _, err := iamIdentityClient.CreateTrustedProfileAssignmentWithContext(context, createTrustedProfileAssignmentOptions)
 	if err != nil {
-		log.Printf("[DEBUG] CreateTrustedProfileAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("CreateTrustedProfileAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*templateAssignmentResponse.ID)
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutCreate), meta, d, isTrustedProfileTemplateAssigned)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error assigning %s", err))
+		err = fmt.Errorf("error assigning %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "wait-assignment").GetDiag()
 	}
 
 	return resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
@@ -302,7 +306,9 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	getTrustedProfileAssignmentOptions := &iamidentityv1.GetTrustedProfileAssignmentOptions{}
@@ -315,60 +321,74 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 			d.SetId("")
 			return nil
 		}
-		log.Printf("[DEBUG] GetTrustedProfileAssignmentWithContext failed %s\n%s", err, response)
-		return diag.FromErr(fmt.Errorf("GetTrustedProfileAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	if err = d.Set("template_id", templateAssignmentResponse.TemplateID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_id: %s", err))
+		err = fmt.Errorf("Error setting template_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-template_id").GetDiag()
 	}
 	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting template_version: %s", err))
+		err = fmt.Errorf("Error setting template_version: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-template_version").GetDiag()
 	}
 	if err = d.Set("target_type", templateAssignmentResponse.TargetType); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target_type: %s", err))
+		err = fmt.Errorf("Error setting target_type: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-target_type").GetDiag()
 	}
 	if err = d.Set("target", templateAssignmentResponse.Target); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting target: %s", err))
+		err = fmt.Errorf("Error setting target: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-target").GetDiag()
 	}
 	if err = d.Set("account_id", templateAssignmentResponse.AccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting account_id: %s", err))
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-account_id").GetDiag()
 	}
 	if err = d.Set("status", templateAssignmentResponse.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting status: %s", err))
+		err = fmt.Errorf("Error setting status: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-status").GetDiag()
 	}
 	resources := []map[string]interface{}{}
 	if !core.IsNil(templateAssignmentResponse.Resources) {
 		for _, resourcesItem := range templateAssignmentResponse.Resources {
 			resourcesItemMap, err := resourceIBMTrustedProfileTemplateAssignmentTemplateAssignmentResponseResourceToMap(&resourcesItem)
 			if err != nil {
-				return diag.FromErr(err)
+				return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "resources-to-map").GetDiag()
 			}
 			resources = append(resources, resourcesItemMap)
 		}
-	}
-	if err = d.Set("resources", resources); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting resources: %s", err))
+		if err = d.Set("resources", resources); err != nil {
+			err = fmt.Errorf("Error setting resources: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-resources").GetDiag()
+		}
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting href: %s", err))
+			err = fmt.Errorf("Error setting href: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-href").GetDiag()
 		}
 	}
 	if err = d.Set("created_at", templateAssignmentResponse.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_at: %s", err))
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-created_at").GetDiag()
 	}
 	if err = d.Set("created_by_id", templateAssignmentResponse.CreatedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting created_by_id: %s", err))
+		err = fmt.Errorf("Error setting created_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-created_by_id").GetDiag()
 	}
 	if err = d.Set("last_modified_at", templateAssignmentResponse.LastModifiedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_at: %s", err))
+		err = fmt.Errorf("Error setting last_modified_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-last_modified_at").GetDiag()
 	}
 	if err = d.Set("last_modified_by_id", templateAssignmentResponse.LastModifiedByID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting last_modified_by_id: %s", err))
+		err = fmt.Errorf("Error setting last_modified_by_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-last_modified_by_id").GetDiag()
 	}
 	if err = d.Set("entity_tag", templateAssignmentResponse.EntityTag); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting entity_tag: %s", err))
+		err = fmt.Errorf("Error setting entity_tag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
 
 	return nil
@@ -377,7 +397,9 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "update", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	updateTrustedProfileAssignmentOptions := &iamidentityv1.UpdateTrustedProfileAssignmentOptions{}
@@ -392,15 +414,17 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 	}
 
 	if hasChange || d.Get("status") == "failed" { // allow the same version to retry failed assignments
-		_, response, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(context, updateTrustedProfileAssignmentOptions)
+		_, _, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(context, updateTrustedProfileAssignmentOptions)
 		if err != nil {
-			log.Printf("[DEBUG] UpdateTrustedProfileAssignmentWithContext failed %s\n%s", err, response)
-			return diag.FromErr(fmt.Errorf("UpdateTrustedProfileAssignmentWithContext failed %s\n%s", err, response))
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
 		}
 
 		_, err = waitForAssignment(d.Timeout(schema.TimeoutUpdate), meta, d, isTrustedProfileTemplateAssigned)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("error assigning %s", err))
+			err = fmt.Errorf("error assigning %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "update", "wait-assignment").GetDiag()
 		}
 	}
 
@@ -410,21 +434,26 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 func resourceIBMTrustedProfileTemplateAssignmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	deleteTrustedProfileAssignmentOptions := &iamidentityv1.DeleteTrustedProfileAssignmentOptions{}
 
 	deleteTrustedProfileAssignmentOptions.SetAssignmentID(d.Id())
 
-	_, response, err := iamIdentityClient.DeleteTrustedProfileAssignmentWithContext(context, deleteTrustedProfileAssignmentOptions)
+	_, _, err = iamIdentityClient.DeleteTrustedProfileAssignmentWithContext(context, deleteTrustedProfileAssignmentOptions)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("[DEBUG] DeleteTrustedProfileAssignmentWithContext failed %s\n%s", err, response))
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "delete")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isTrustedProfileAssignmentRemoved)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error removing assignment %s", err))
+		err = fmt.Errorf("error removing assignment %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "remove-assignment").GetDiag()
 	}
 
 	d.SetId("")

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -359,10 +359,10 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 			}
 			resources = append(resources, resourcesItemMap)
 		}
-		if err = d.Set("resources", resources); err != nil {
-			err = fmt.Errorf("Error setting resources: %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-resources").GetDiag()
-		}
+	}
+	if err = d.Set("resources", resources); err != nil {
+		err = fmt.Errorf("Error setting resources: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-resources").GetDiag()
 	}
 	if !core.IsNil(templateAssignmentResponse.Href) {
 		if err = d.Set("href", templateAssignmentResponse.Href); err != nil {

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -280,7 +280,11 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 
 	createTrustedProfileAssignmentOptions := &iamidentityv1.CreateTrustedProfileAssignmentOptions{}
 
-	createTrustedProfileAssignmentOptions.SetTemplateID(d.Get("template_id").(string))
+	templateId, _, err := parseResourceId(d.Get("template_id").(string))
+	if err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "parse-resource-id").GetDiag()
+	}
+	createTrustedProfileAssignmentOptions.SetTemplateID(templateId)
 	createTrustedProfileAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
 	createTrustedProfileAssignmentOptions.SetTargetType(d.Get("target_type").(string))
 	createTrustedProfileAssignmentOptions.SetTarget(d.Get("target").(string))

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -296,8 +296,7 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutCreate), meta, d, isTrustedProfileTemplateAssigned)
 	if err != nil {
-		err = fmt.Errorf("error assigning %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "wait-assignment").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
 	return resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
@@ -423,8 +422,7 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 
 		_, err = waitForAssignment(d.Timeout(schema.TimeoutUpdate), meta, d, isTrustedProfileTemplateAssigned)
 		if err != nil {
-			err = fmt.Errorf("error assigning %s", err)
-			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "update", "wait-assignment").GetDiag()
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "update", "wait-for-assignment").GetDiag()
 		}
 	}
 
@@ -452,8 +450,7 @@ func resourceIBMTrustedProfileTemplateAssignmentDelete(context context.Context, 
 
 	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isTrustedProfileAssignmentRemoved)
 	if err != nil {
-		err = fmt.Errorf("error removing assignment %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "remove-assignment").GetDiag()
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "wait-for-assignment").GetDiag()
 	}
 
 	d.SetId("")

--- a/website/docs/d/iam_trusted_profile_identity.html.markdown
+++ b/website/docs/d/iam_trusted_profile_identity.html.markdown
@@ -8,7 +8,7 @@ subcategory: "IAM Identity Services"
 
 # ibm_iam_trusted_profile_identity
 
-Provides a read-only data source for iam_trusted_profile_identity. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source to retrieve information about an iam_trusted_profile_identity. You can then reference the fields of the data source in other resources within the same configuration by using interpolation syntax.
 
 ## Example Usage
 
@@ -26,27 +26,22 @@ data "ibm_iam_trusted_profile_identity" "iam_trusted_profile_identity" {
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your data source.
+You can specify the following arguments for this data source.
 
-* `identifier_id` - (Required, String) Identifier of the identity that can assume the trusted profiles.
-* `identity_type` - (Required, String) Type of the identity.
+* `identifier_id` - (Required, Forces new resource, String) Identifier of the identity that can assume the trusted profiles.
+* `identity_type` - (Required, Forces new resource, String) Type of the identity.
   * Constraints: Allowable values are: `user`, `serviceid`, `crn`.
-* `profile_id` - (Required, String) ID of the trusted profile.
+* `profile_id` - (Required, Forces new resource, String) ID of the trusted profile.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your data source is created.
+After your data source is created, you can read values from the following attributes.
 
 * `id` - The unique identifier of the iam_trusted_profile_identity.
-
 * `accounts` - (List) Only valid for the type user. Accounts from which a user can assume the trusted profile.
-
 * `description` - (String) Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
-
 * `iam_id` - (String) IAM ID of the identity.
-
 * `identifier` - (String) Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn' it uses account id contained in the CRN.
-
 * `type` - (String) Type of the identity.
   * Constraints: Allowable values are: `user`, `serviceid`, `crn`.
 

--- a/website/docs/r/iam_trusted_profile_identity.html.markdown
+++ b/website/docs/r/iam_trusted_profile_identity.html.markdown
@@ -8,7 +8,7 @@ subcategory: "IAM Identity Services"
 
 # ibm_iam_trusted_profile_identity
 
-Provides a resource for iam_trusted_profile_identity. This allows iam_trusted_profile_identity to be created, updated and deleted.
+Create, update, and delete iam_trusted_profile_identitys with this resource.
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ resource "ibm_iam_trusted_profile_identity" "iam_trusted_profile_identity_instan
 
 ## Argument Reference
 
-Review the argument reference that you can specify for your resource.
+You can specify the following arguments for this resource.
 
 * `accounts` - (Optional, Forces new resource, List) Only valid for the type user. Accounts from which a user can assume the trusted profile.
 * `description` - (Optional, Forces new resource, String) Description of the identity that can assume the trusted profile. This is optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
@@ -36,24 +36,24 @@ Review the argument reference that you can specify for your resource.
 
 ## Attribute Reference
 
-In addition to all argument references listed, you can access the following attribute references after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
 * `id` - The unique identifier of the iam_trusted_profile_identity. Id is a combination of `profile_id`|`identity-type`|`identifier-id`.
 
 
 ## Import
 
-You can import the `ibm_iam_trusted_profile_identity` resource by using `iam_id`.
-The `iam_id` property can be formed from `profile-id`, `identity-type`, and `identifier-id` in the following format:
+You can import the `ibm_iam_trusted_profile_identity` resource by using `identifier`.
+The `identifier` property can be formed from `profile_id`, and `identifier` in the following format:
 
-```
-<profile-id>|<identity-type>|<identifier-id>
-```
+<pre>
+&lt;profile_id&gt;|&lt;identity-type&gt;|&lt;identifier&gt;
+</pre>
 * `profile-id`: A string. ID of the trusted profile.
 * `identity-type`: A string. Type of the identity.
 * `identifier-id`: A string. Identifier of the identity that can assume the trusted profiles.
 
 # Syntax
-```
-$ terraform import ibm_iam_trusted_profile_identity.iam_trusted_profile_identity &lt;profile-id&gt;&vert;&lt;identity-type&gt;&vert;&lt;identifier-id&gt;
-```
+<pre>
+$ terraform import ibm_iam_trusted_profile_identity.iam_trusted_profile_identity &lt;profile_id&gt;|&lt;identity-type&gt;|&lt;identifier&gt;
+</pre>

--- a/website/docs/r/iam_trusted_profile_identity.html.markdown
+++ b/website/docs/r/iam_trusted_profile_identity.html.markdown
@@ -8,7 +8,7 @@ subcategory: "IAM Identity Services"
 
 # ibm_iam_trusted_profile_identity
 
-Create, update, and delete iam_trusted_profile_identitys with this resource.
+Create, update, and delete iam_trusted_profile_identity with this resource.
 
 ## Example Usage
 
@@ -43,8 +43,8 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Import
 
-You can import the `ibm_iam_trusted_profile_identity` resource by using `identifier`.
-The `identifier` property can be formed from `profile_id`, and `identifier` in the following format:
+You can import the `ibm_iam_trusted_profile_identity` resource by using `id`.
+The `id` property can be formed from `profile_id`, `identity-type`, and `identifier` in the following format:
 
 <pre>
 &lt;profile_id&gt;|&lt;identity-type&gt;|&lt;identifier&gt;


### PR DESCRIPTION
### Description

Update the error format across a number of IAM Idenity resources and data sources. This PR combines a set of previously opened PRs that were never merged, as well as further updates to the error format in other areas of IAM Identity resources.

List of old PRs whose changes are included here:
- https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5971
- https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6053
- https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6069
- https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6073
- https://github.com/IBM-Cloud/terraform-provider-ibm/pull/6074

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iamidentity TESTARGS='-run=TestAcc\(IBM\|Ibm\)\(Iam\|IAM\)'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity -v -run=TestAcc\(IBM\|Ibm\)\(Iam\|IAM\) -timeout 700m 2>&1 | grep -v "^\[.*\]\ Set"
=== RUN   TestAccIBMIAMAccountSettingsDataSourceBasic
--- PASS: TestAccIBMIAMAccountSettingsDataSourceBasic (20.60s)
=== RUN   TestAccIbmIamApiKeyDataSourceBasic
--- PASS: TestAccIbmIamApiKeyDataSourceBasic (20.00s)
=== RUN   TestAccIbmIamApiKeyDataSourceAllArgs
--- PASS: TestAccIbmIamApiKeyDataSourceAllArgs (19.05s)
=== RUN   TestAccIBMIamEffectiveAccountSettingsDataSourceBasic
--- PASS: TestAccIBMIamEffectiveAccountSettingsDataSourceBasic (20.64s)
=== RUN   TestAccIBMIAMServiceIDDataSource_basic
--- PASS: TestAccIBMIAMServiceIDDataSource_basic (23.32s)
=== RUN   TestAccIBMIAMServiceIDDataSource_same_name
--- PASS: TestAccIBMIAMServiceIDDataSource_same_name (34.94s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleDataSourceBasic (26.29s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleDataSourceAllArgs
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleDataSourceAllArgs (34.43s)
=== RUN   TestAccIBMIamTrustedProfileIdentitiesDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfileIdentitiesDataSourceBasic (27.31s)
=== RUN   TestAccIBMIamTrustedProfileIdentityDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfileIdentityDataSourceBasic (19.74s)
=== RUN   TestAccIBMIAMTrustedProfileLinkDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileLinkDataSourceBasic (26.01s)
=== RUN   TestAccIBMIAMTrustedProfileLinkDataSourceAllArgs
--- PASS: TestAccIBMIAMTrustedProfileLinkDataSourceAllArgs (26.90s)
=== RUN   TestAccIBMIamTrustedProfileLinksDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfileLinksDataSourceBasic (21.18s)
=== RUN   TestAccIBMIAMTrustedProfileDataSourceBasic
--- PASS: TestAccIBMIAMTrustedProfileDataSourceBasic (17.76s)
=== RUN   TestAccIBMIamTrustedProfilesClaimRulesDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfilesClaimRulesDataSourceBasic (17.83s)
=== RUN   TestAccIBMIamTrustedProfilesDataSourceBasic
--- PASS: TestAccIBMIamTrustedProfilesDataSourceBasic (16.60s)
=== RUN   TestAccIBMIamUserMfaEnrollmentsDataSourceBasic
--- PASS: TestAccIBMIamUserMfaEnrollmentsDataSourceBasic (18.50s)
=== RUN   TestAccIBMIAMUserProfileDataSource_Basic
    data_source_ibm_iam_user_profile_test.go:16:
--- SKIP: TestAccIBMIAMUserProfileDataSource_Basic (0.00s)
=== RUN   TestAccIBMIAMUsersDataSource_Basic
--- PASS: TestAccIBMIAMUsersDataSource_Basic (16.28s)
=== RUN   TestAccIBMIAMAccountSettingsDataSourceBasic
--- PASS: TestAccIBMIAMAccountSettingsDataSourceBasic (27.38s)
=== RUN   TestAccIBMIAMAccountSettingsBasic
--- PASS: TestAccIBMIAMAccountSettingsBasic (30.77s)
=== RUN   TestAccIBMIAMAccountSettingsAllArgs
--- PASS: TestAccIBMIAMAccountSettingsAllArgs (35.27s)
=== RUN   TestAccIbmIamApiKeyBasic
--- PASS: TestAccIbmIamApiKeyBasic (32.73s)
=== RUN   TestAccIbmIamApiKeyAllArgs
--- PASS: TestAccIbmIamApiKeyAllArgs (35.33s)
=== RUN   TestAccIBMIAMServiceAPIKey_Basic
--- PASS: TestAccIBMIAMServiceAPIKey_Basic (52.26s)
=== RUN   TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue
--- PASS: TestAccIBMIAMServiceAPIKey_doNotStoreApikeyValue (20.26s)
=== RUN   TestAccIBMIAMServiceAPIKey_import
--- PASS: TestAccIBMIAMServiceAPIKey_import (25.42s)
=== RUN   TestAccIBMIAMServiceID_Basic
--- PASS: TestAccIBMIAMServiceID_Basic (45.87s)
=== RUN   TestAccIBMIAMServiceID_import
--- PASS: TestAccIBMIAMServiceID_import (21.38s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleBasic
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleBasic (22.55s)
=== RUN   TestAccIBMIAMTrustedProfileClaimRuleAllArgs
--- PASS: TestAccIBMIAMTrustedProfileClaimRuleAllArgs (28.61s)
=== RUN   TestAccIBMIamTrustedProfileIdentitiesBasic
--- PASS: TestAccIBMIamTrustedProfileIdentitiesBasic (40.64s)
=== RUN   TestAccIBMIamTrustedProfileIdentityBasic
--- PASS: TestAccIBMIamTrustedProfileIdentityBasic (20.73s)
=== RUN   TestAccIBMIamTrustedProfileIdentityAllArgs
--- PASS: TestAccIBMIamTrustedProfileIdentityAllArgs (24.62s)
=== RUN   TestAccIBMIAMTrustedProfileLinkBasic
--- PASS: TestAccIBMIAMTrustedProfileLinkBasic (25.35s)
=== RUN   TestAccIBMIAMTrustedProfileLinkAllArgs
--- PASS: TestAccIBMIAMTrustedProfileLinkAllArgs (28.80s)
=== RUN   TestAccIBMIamTrustedProfileBasic
--- PASS: TestAccIBMIamTrustedProfileBasic (42.24s)
=== RUN   TestAccIBMIamTrustedProfileAllArgs
--- PASS: TestAccIBMIamTrustedProfileAllArgs (50.41s)
=== RUN   TestAccIBMIAMUserSettings_Basic
    resource_ibm_iam_user_settings_test.go:20:
--- SKIP: TestAccIBMIAMUserSettings_Basic (0.00s)
PASS
ok    github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity     952.507s
```
