### PR TITLE
fix(IAM Identity): Update error handling for ServiceId

### DIFF
--- a/examples/ibm-iam-identity-service-id/main.tf
+++ b/examples/ibm-iam-identity-service-id/main.tf
@@ -1,0 +1,16 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+}
+
+// Provision iam_service_id resource instance
+resource "ibm_iam_service_id" "iam_service_id_instance" {
+  name = var.iam_service_id_name
+  description = "serviceId description"
+}
+
+// iam_service_id data source
+data "ibm_iam_service_id" "iam_service_id_data" {
+  name = ibm_iam_service_id.iam_service_id_instance.name
+
+  depends_on = [ibm_iam_service_id.iam_service_id_instance]
+}

--- a/examples/ibm-iam-identity-service-id/outputs.tf
+++ b/examples/ibm-iam-identity-service-id/outputs.tf
@@ -1,0 +1,14 @@
+// This allows iam_service_id data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+
+// for ServiceID resource
+output "ibm_iam_service_id" {
+  value       = ibm_iam_service_id.iam_service_id_instance
+  description = "iam_service_id resource instance"
+}
+
+// for ServiceID data source
+output "ibm_iam_service_ids" {
+  value       = data.ibm_iam_service_id.iam_service_id_data
+  description = "iam_service_id data"
+}

--- a/examples/ibm-iam-identity-service-id/variables.tf
+++ b/examples/ibm-iam-identity-service-id/variables.tf
@@ -1,0 +1,11 @@
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key"
+  type        = string
+}
+
+// Resource arguments for iam_service_id
+variable "iam_service_id_name" {
+  description = "Name of the ServiceID. The name is not checked for uniqueness."
+  type        = string
+  default     = "name"
+}

--- a/examples/ibm-iam-identity-service-id/versions.tf
+++ b/examples/ibm-iam-identity-service-id/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = ">=1.33.0"
+    }
+  }
+}

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -433,7 +433,7 @@ func Provider() *schema.Provider {
 			"ibm_iam_user_policy":                           iampolicy.DataSourceIBMIAMUserPolicy(),
 			"ibm_iam_authorization_policies":                iampolicy.DataSourceIBMIAMAuthorizationPolicies(),
 			"ibm_iam_user_profile":                          iamidentity.DataSourceIBMIAMUserProfile(),
-			"ibm_iam_service_id":                            iamidentity.DataSourceIBMIAMServiceID(),
+			"ibm_iam_service_id":                            iamidentity.DataSourceIBMIamServiceID(),
 			"ibm_iam_serviceid_group":                       iamidentity.DataSourceIBMIamServiceidGroup(),
 			"ibm_iam_service_policy":                        iampolicy.DataSourceIBMIAMServicePolicy(),
 			"ibm_iam_api_key":                               iamidentity.DataSourceIBMIamApiKey(),
@@ -1361,7 +1361,7 @@ func Provider() *schema.Provider {
 			"ibm_iam_authorization_policy_detach":           iampolicy.ResourceIBMIAMAuthorizationPolicyDetach(),
 			"ibm_iam_user_policy":                           iampolicy.ResourceIBMIAMUserPolicy(),
 			"ibm_iam_user_settings":                         iamidentity.ResourceIBMIAMUserSettings(),
-			"ibm_iam_service_id":                            iamidentity.ResourceIBMIAMServiceID(),
+			"ibm_iam_service_id":                            iamidentity.ResourceIBMIamServiceID(),
 			"ibm_iam_serviceid_group":                       iamidentity.ResourceIBMIamServiceidGroup(),
 			"ibm_iam_service_api_key":                       iamidentity.ResourceIBMIAMServiceAPIKey(),
 			"ibm_iam_service_policy":                        iampolicy.ResourceIBMIAMServicePolicy(),
@@ -2505,7 +2505,7 @@ func Validator() validate.ValidatorDict {
 
 				"ibm_iam_access_group": iamaccessgroup.DataSourceIBMIAMAccessGroupValidator(),
 
-				"ibm_iam_service_id":                  iamidentity.DataSourceIBMIAMServiceIDValidator(),
+				"ibm_iam_service_id":                  iamidentity.DataSourceIBMIamServiceIDValidator(),
 				"ibm_iam_trusted_profile_claim_rule":  iamidentity.DataSourceIBMIamTrustedProfileClaimRuleValidator(),
 				"ibm_iam_trusted_profile_link":        iamidentity.DataSourceIBMIamTrustedProfileLinkValidator(),
 				"ibm_iam_trusted_profile_links":       iamidentity.DataSourceIBMIamTrustedProfileLinksValidator(),

--- a/ibm/service/iamidentity/data_source_ibm_iam_service_id.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_service_id.go
@@ -1,73 +1,74 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity
 
 import (
+	"context"
 	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceIBMIAMServiceID() *schema.Resource {
+func DataSourceIBMIamServiceID() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceIBMIAMServiceIDRead,
+		ReadContext: dataSourceIBMIamServiceIDRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"name": &schema.Schema{
 				Description: "Name of the serviceID",
 				Type:        schema.TypeString,
 				Required:    true,
 				ValidateFunc: validate.InvokeDataSourceValidator("ibm_iam_service_id",
 					"name"),
 			},
-
 			"service_ids": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"id": &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-
-						"bound_to": {
+						"bound_to": &schema.Schema{
 							Description: "bound to of the serviceID",
 							Type:        schema.TypeString,
 							Computed:    true,
 							Deprecated:  "bound_to attribute in service_ids list has been deprecated",
 						},
-
-						"crn": {
+						"crn": &schema.Schema{
 							Description: "CRN of the serviceID",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
-
-						"description": {
+						"description": &schema.Schema{
 							Description: "description of the serviceID",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
-
-						"version": {
+						"version": &schema.Schema{
 							Description: "Version of the serviceID",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
-
-						"locked": {
+						"locked": &schema.Schema{
 							Description: "lock state of the serviceID",
 							Type:        schema.TypeBool,
 							Computed:    true,
 						},
-
-						"iam_id": {
+						"iam_id": &schema.Schema{
 							Description: "The IAM ID of the serviceID",
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -78,7 +79,8 @@ func DataSourceIBMIAMServiceID() *schema.Resource {
 		},
 	}
 }
-func DataSourceIBMIAMServiceIDValidator() *validate.ResourceValidator {
+
+func DataSourceIBMIamServiceIDValidator() *validate.ResourceValidator {
 	validateSchema := make([]validate.ValidateSchema, 0)
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{
@@ -93,20 +95,21 @@ func DataSourceIBMIAMServiceIDValidator() *validate.ResourceValidator {
 	return &iBMIAMServiceIDValidator
 }
 
-func dataSourceIBMIAMServiceIDRead(d *schema.ResourceData, meta interface{}) error {
-
-	name := d.Get("name").(string)
-
+func dataSourceIBMIamServiceIDRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
+	if err != nil {
+		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "(Data) ibm_iam_service_id", "read", "initialize-client")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		return err
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	iamClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
-	if err != nil {
-		return err
-	}
-
+	name := d.Get("name").(string)
 	start := ""
 	allrecs := []iamidentityv1.ServiceID{}
 	var pg int64 = 100
@@ -120,9 +123,10 @@ func dataSourceIBMIAMServiceIDRead(d *schema.ResourceData, meta interface{}) err
 			listServiceIDOptions.Pagetoken = &start
 		}
 
-		serviceIDs, resp, err := iamClient.ListServiceIds(&listServiceIDOptions)
+		serviceIDs, _, err := iamIdentityClient.ListServiceIds(&listServiceIDOptions)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error listing Service Ids %s %s", err, resp)
+			err = fmt.Errorf("Error listing Service Ids: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "list-service_ids").GetDiag()
 		}
 		start = flex.GetNextIAM(serviceIDs.Next)
 		allrecs = append(allrecs, serviceIDs.Serviceids...)
@@ -131,20 +135,20 @@ func dataSourceIBMIAMServiceIDRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 	if len(allrecs) == 0 {
-		return fmt.Errorf("[ERROR] No serviceID found with name [%s]", name)
-
+		err = fmt.Errorf("No serviceID found with name [%s]", name)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-service_ids").GetDiag()
 	}
 
 	serviceIDListMap := make([]map[string]interface{}, 0, len(allrecs))
 	for _, serviceID := range allrecs {
 		l := map[string]interface{}{
-			"id": serviceID.ID,
-			// "bound_to":    serviceID.BoundTo,
+			"id":          serviceID.ID,
 			"version":     serviceID.EntityTag,
 			"description": serviceID.Description,
 			"crn":         serviceID.CRN,
 			"locked":      serviceID.Locked,
 			"iam_id":      serviceID.IamID,
+			// "bound_to":    serviceID.BoundTo,
 		}
 		serviceIDListMap = append(serviceIDListMap, l)
 	}

--- a/ibm/service/iamidentity/data_source_ibm_iam_service_id_test.go
+++ b/ibm/service/iamidentity/data_source_ibm_iam_service_id_test.go
@@ -1,5 +1,9 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
+
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
 
 package iamidentity_test
 
@@ -53,33 +57,30 @@ func TestAccIBMIAMServiceIDDataSource_same_name(t *testing.T) {
 
 func testAccCheckIBMIAMServiceIDDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
+		resource "ibm_iam_service_id" "serviceID" {
+			name        = "%s"
+			description = "ServiceID for test"
+		}
 
-resource "ibm_iam_service_id" "serviceID" {
-  name        = "%s"
-  description = "ServiceID for test"
-}
-
-data "ibm_iam_service_id" "testacc_ds_service_id" {
-  name = ibm_iam_service_id.serviceID.name
-}
-`, name)
-
+		data "ibm_iam_service_id" "testacc_ds_service_id" {
+			name = ibm_iam_service_id.serviceID.name
+		}
+	`, name)
 }
 
 func testAccCheckIBMIAMServiceIDDataSourceSameName(name string) string {
 	return fmt.Sprintf(`
+		resource "ibm_iam_service_id" "serviceID" {
+			name        = "%s"
+			description = "ServiceID for test"
+		}
 
-resource "ibm_iam_service_id" "serviceID" {
-  name        = "%s"
-  description = "ServiceID for test"
-}
+		resource "ibm_iam_service_id" "serviceID2" {
+			name = "%s"
+		}
 
-resource "ibm_iam_service_id" "serviceID2" {
-  name = "%s"
-}
-
-data "ibm_iam_service_id" "testacc_ds_service_id" {
-  name = ibm_iam_service_id.serviceID.name
-}`, name, name)
-
+		data "ibm_iam_service_id" "testacc_ds_service_id" {
+			name = ibm_iam_service_id.serviceID.name
+		}
+	`, name, name)
 }

--- a/ibm/service/iamidentity/resource_ibm_iam_service_id.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_id.go
@@ -55,7 +55,7 @@ func ResourceIBMIamServiceID() *schema.Resource {
 				Computed:    true,
 				Description: "Cloud Resource Name of the item. Example Cloud Resource Name: 'crn:v1:bluemix:public:iam-identity:us-south:a/myaccount::serviceid:1234-5678-9012'.",
 			},
-			"entity_tag": &schema.Schema{
+			"version": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Version of the ServiceID object.",
@@ -109,9 +109,15 @@ func resourceIBMIamServiceIDCreate(context context.Context, d *schema.ResourceDa
 	}
 
 	serviceID, _, err := iamIdentityClient.CreateServiceIDWithContext(context, createServiceIDOptions)
-	if err != nil || serviceID == nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateServiceID failed: %s", err.Error()), "ibm_iam_service_id", "create")
-		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateServiceIDWithContext failed: %s", err.Error()), "ibm_iam_service_id", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+	if serviceID == nil {
+		err = fmt.Errorf("Create ServiceID failed: %s", d.Get("name").(string))
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_iam_service_id", "create")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
 	d.SetId(*serviceID.ID)
@@ -164,9 +170,9 @@ func resourceIBMIamServiceIDRead(context context.Context, d *schema.ResourceData
 		err = fmt.Errorf("Error setting crn: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-crn").GetDiag()
 	}
-	if err = d.Set("entity_tag", serviceID.EntityTag); err != nil {
-		err = fmt.Errorf("Error setting entity_tag: %s", err)
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-entity_tag").GetDiag()
+	if err = d.Set("version", serviceID.EntityTag); err != nil {
+		err = fmt.Errorf("Error setting version: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-version").GetDiag()
 	}
 	if err = d.Set("locked", serviceID.Locked); err != nil {
 		err = fmt.Errorf("Error setting locked: %s", err)

--- a/ibm/service/iamidentity/resource_ibm_iam_service_id.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_id.go
@@ -1,6 +1,10 @@
 // Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
+/*
+ * IBM OpenAPI Terraform Generator Version: 3.113.1-d76630af-20260320-135953
+ */
+
 package iamidentity
 
 import (
@@ -8,67 +12,80 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
-	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
-func ResourceIBMIAMServiceID() *schema.Resource {
+func ResourceIBMIamServiceID() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIBMIAMServiceIDCreate,
-		ReadContext:   resourceIBMIAMServiceIDRead,
-		UpdateContext: resourceIBMIAMServiceIDUpdate,
-		DeleteContext: resourceIBMIAMServiceIDDelete,
+		CreateContext: resourceIBMIamServiceIDCreate,
+		ReadContext:   resourceIBMIamServiceIDRead,
+		UpdateContext: resourceIBMIamServiceIDUpdate,
+		DeleteContext: resourceIBMIamServiceIDDelete,
 		Importer:      &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Name of the serviceID",
+				Description: "Name of the Service Id. The name is not checked for uniqueness. Therefore multiple names with the same value can exist. Access is done via the UUID of the Service Id.",
 			},
-
-			"description": {
+			"description": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Description of the serviceID",
+				Description: "The optional description of the Service Id. The 'description' property is only available if a description was provided during a create of a Service Id.",
 			},
-
-			"version": {
+			"iam_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "version of the serviceID",
+				Description: "Cloud wide identifier for identities of this service ID.",
 			},
-
-			"crn": {
+			"account_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "crn of the serviceID",
+				Description: "ID of the account.",
 			},
-
-			"iam_id": {
+			"crn": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The IAM ID of the serviceID",
+				Description: "Cloud Resource Name of the item. Example Cloud Resource Name: 'crn:v1:bluemix:public:iam-identity:us-south:a/myaccount::serviceid:1234-5678-9012'.",
 			},
-
+			"entity_tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Version of the ServiceID object.",
+			},
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"locked": {
-				Type:     schema.TypeBool,
-				Computed: true,
+			"locked": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The service ID cannot be changed if set to true.",
+			},
+			"created_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "If set contains a date time string of the creation date in ISO format.",
+			},
+			"modified_at": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "If set contains a date time string of the last modification date in ISO format.",
 			},
 		},
 	}
 }
 
-func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMIamServiceIDCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "create", "initialize-client")
@@ -76,26 +93,22 @@ func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceDa
 		return tfErr.GetDiag()
 	}
 
-	name := d.Get("name").(string)
-
 	userDetails, err := meta.(conns.ClientSession).BluemixUserDetails()
 	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("resourceIBMIAMServiceIDCreate failed: %s", err.Error()), "ibm_iam_service_id", "create")
+		tfErr := flex.TerraformErrorf(err, err.Error(), "ibm_iam_service_id", "create")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
+	accountID := userDetails.UserAccount
 
-	createServiceIDOptions := iamidentityv1.CreateServiceIDOptions{
-		Name:      &name,
-		AccountID: &userDetails.UserAccount,
+	createServiceIDOptions := &iamidentityv1.CreateServiceIDOptions{}
+	createServiceIDOptions.SetAccountID(accountID)
+	createServiceIDOptions.SetName(d.Get("name").(string))
+	if _, ok := d.GetOk("description"); ok {
+		createServiceIDOptions.SetDescription(d.Get("description").(string))
 	}
 
-	if d, ok := d.GetOk("description"); ok {
-		des := d.(string)
-		createServiceIDOptions.Description = &des
-	}
-
-	serviceID, resp, err := iamIdentityClient.CreateServiceID(&createServiceIDOptions)
+	serviceID, _, err := iamIdentityClient.CreateServiceIDWithContext(context, createServiceIDOptions)
 	if err != nil || serviceID == nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("CreateServiceID failed: %s", err.Error()), "ibm_iam_service_id", "create")
 		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
@@ -103,93 +116,103 @@ func resourceIBMIAMServiceIDCreate(context context.Context, d *schema.ResourceDa
 	}
 	d.SetId(*serviceID.ID)
 
-	return resourceIBMIAMServiceIDRead(context, d, meta)
+	return resourceIBMIamServiceIDRead(context, d, meta)
 }
 
-func resourceIBMIAMServiceIDRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMIamServiceIDRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	serviceIDUUID := d.Id()
-	getServiceIDOptions := iamidentityv1.GetServiceIDOptions{
-		ID: &serviceIDUUID,
-	}
-	serviceID, resp, err := iamIdentityClient.GetServiceID(&getServiceIDOptions)
+
+	getServiceIDOptions := &iamidentityv1.GetServiceIDOptions{}
+
+	getServiceIDOptions.SetID(d.Id())
+
+	serviceID, response, err := iamIdentityClient.GetServiceIDWithContext(context, getServiceIDOptions)
 	if err != nil || serviceID == nil {
-		if resp != nil && resp.StatusCode == 404 {
+		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetServiceID failed: %s", err.Error()), "ibm_iam_service_id", "read")
-		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetServiceIDWithContext failed: %s", err.Error()), "ibm_iam_service_id", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	if serviceID.Name != nil {
-		d.Set("name", *serviceID.Name)
+
+	if err = d.Set("account_id", serviceID.AccountID); err != nil {
+		err = fmt.Errorf("Error setting account_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-account_id").GetDiag()
 	}
-	if serviceID.Description != nil {
-		d.Set("description", *serviceID.Description)
+	if err = d.Set("name", serviceID.Name); err != nil {
+		err = fmt.Errorf("Error setting name: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-name").GetDiag()
 	}
-	if serviceID.CRN != nil {
-		d.Set("crn", *serviceID.CRN)
+	if !core.IsNil(serviceID.Description) {
+		if err = d.Set("description", serviceID.Description); err != nil {
+			err = fmt.Errorf("Error setting description: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-description").GetDiag()
+		}
 	}
-	if serviceID.EntityTag != nil {
-		d.Set("version", serviceID.EntityTag)
+	if err = d.Set("iam_id", serviceID.IamID); err != nil {
+		err = fmt.Errorf("Error setting iam_id: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-iam_id").GetDiag()
 	}
-	if serviceID.IamID != nil {
-		d.Set("iam_id", serviceID.IamID)
+	if err = d.Set("crn", serviceID.CRN); err != nil {
+		err = fmt.Errorf("Error setting crn: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-crn").GetDiag()
 	}
-	if serviceID.Locked != nil {
-		d.Set("locked", serviceID.Locked)
+	if err = d.Set("entity_tag", serviceID.EntityTag); err != nil {
+		err = fmt.Errorf("Error setting entity_tag: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-entity_tag").GetDiag()
+	}
+	if err = d.Set("locked", serviceID.Locked); err != nil {
+		err = fmt.Errorf("Error setting locked: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-locked").GetDiag()
+	}
+	if err = d.Set("created_at", flex.DateTimeToString(serviceID.CreatedAt)); err != nil {
+		err = fmt.Errorf("Error setting created_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-created_at").GetDiag()
+	}
+	if err = d.Set("modified_at", flex.DateTimeToString(serviceID.ModifiedAt)); err != nil {
+		err = fmt.Errorf("Error setting modified_at: %s", err)
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "read", "set-modified_at").GetDiag()
 	}
 	return nil
 }
 
-func resourceIBMIAMServiceIDUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMIamServiceIDUpdate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "update", "initialize-client")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	serviceIDUUID := d.Id()
 
-	hasChange := false
-	ifMatch := "*"
-	updateServiceIDOptions := iamidentityv1.UpdateServiceIDOptions{
-		ID:      &serviceIDUUID,
-		IfMatch: &ifMatch,
+	updateServiceIDOptions := &iamidentityv1.UpdateServiceIDOptions{}
+
+	updateServiceIDOptions.SetID(d.Id())
+	updateServiceIDOptions.SetIfMatch("*")
+	if _, ok := d.GetOk("name"); ok {
+		updateServiceIDOptions.SetName(d.Get("name").(string))
+	}
+	if _, ok := d.GetOk("description"); ok {
+		updateServiceIDOptions.SetDescription(d.Get("description").(string))
 	}
 
-	if d.HasChange("name") {
-		name := d.Get("name").(string)
-		updateServiceIDOptions.Name = &name
-		hasChange = true
+	_, _, err = iamIdentityClient.UpdateServiceIDWithContext(context, updateServiceIDOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateServiceIDWithContext failed: %s", err.Error()), "ibm_iam_service_id", "update")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
-	if d.HasChange("description") {
-		description := d.Get("description").(string)
-		updateServiceIDOptions.Description = &description
-		hasChange = true
-	}
-
-	if hasChange {
-		_, resp, err := iamIdentityClient.UpdateServiceID(&updateServiceIDOptions)
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateServiceID failed: %s", err.Error()), "ibm_iam_service_id", "update")
-			log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
-			return tfErr.GetDiag()
-		}
-	}
-
-	return resourceIBMIAMServiceIDRead(context, d, meta)
-
+	return resourceIBMIamServiceIDRead(context, d, meta)
 }
 
-func resourceIBMIAMServiceIDDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIBMIamServiceIDDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamIdentityClient, err := meta.(conns.ClientSession).IAMIdentityV1API()
 	if err != nil {
 		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_service_id", "delete", "initialize-client")
@@ -197,14 +220,14 @@ func resourceIBMIAMServiceIDDelete(context context.Context, d *schema.ResourceDa
 		return tfErr.GetDiag()
 	}
 
-	serviceIDUUID := d.Id()
-	deleteServiceIDOptions := iamidentityv1.DeleteServiceIDOptions{
-		ID: &serviceIDUUID,
-	}
-	resp, err := iamIdentityClient.DeleteServiceID(&deleteServiceIDOptions)
+	deleteServiceIDOptions := &iamidentityv1.DeleteServiceIDOptions{}
+
+	deleteServiceIDOptions.SetID(d.Id())
+
+	_, err = iamIdentityClient.DeleteServiceIDWithContext(context, deleteServiceIDOptions)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteServiceID failed: %s", err.Error()), "ibm_iam_service_id", "delete")
-		log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), resp)
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
 

--- a/ibm/service/iamidentity/resource_ibm_iam_service_id_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_service_id_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package iamidentity_test
@@ -109,7 +109,6 @@ func testAccCheckIBMIAMServiceIDDestroy(s *terraform.State) error {
 }
 
 func testAccCheckIBMIAMServiceIDExists(n string, obj string) resource.TestCheckFunc {
-
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -136,7 +135,6 @@ func testAccCheckIBMIAMServiceIDExists(n string, obj string) resource.TestCheckF
 
 func testAccCheckIBMIAMServiceIDBasic(name string) string {
 	return fmt.Sprintf(`
-		
 		resource "ibm_iam_service_id" "serviceID" {
 			name = "%s"
 			tags = ["tag1", "tag2"]
@@ -146,7 +144,6 @@ func testAccCheckIBMIAMServiceIDBasic(name string) string {
 
 func testAccCheckIBMIAMServiceIDUpdateWithSameName(name string) string {
 	return fmt.Sprintf(`
-		
 		resource "ibm_iam_service_id" "serviceID" {
 			name        = "%s"
 			description = "ServiceID for test scenario1"
@@ -157,7 +154,6 @@ func testAccCheckIBMIAMServiceIDUpdateWithSameName(name string) string {
 
 func testAccCheckIBMIAMServiceIDUpdate(updateName string) string {
 	return fmt.Sprintf(`
-
 		resource "ibm_iam_service_id" "serviceID" {
 			name              = "%s"		
 			description       = "ServiceID for test scenario2"
@@ -168,7 +164,6 @@ func testAccCheckIBMIAMServiceIDUpdate(updateName string) string {
 
 func testAccCheckIBMIAMServiceIDTag(name string) string {
 	return fmt.Sprintf(`
-
 		resource "ibm_iam_service_id" "serviceID" {
 			name              = "%s"		
 			description       = "ServiceID for test scenario2"

--- a/website/docs/d/iam_service_id.html.markdown
+++ b/website/docs/d/iam_service_id.html.markdown
@@ -10,23 +10,23 @@ description: |-
 
 Retrieve information about an IAM service ID. For more information, about IAM role action, see [managing service ID API keys](https://cloud.ibm.com/docs/account?topic=account-serviceidapikeys).
 
-## Example usage
+## Example Usage
 
-```terraform
-data "ibm_iam_service_id" "ds_serviceID" {
+```hcl
+data "ibm_iam_service_id" "iam_service_id" {
   name = "sample"
 }
-
 ```
 
-## Argument reference
+## Argument Reference
 
-Review the argument references that you can specify for your data source.
+You can specify the following arguments for this data source.
 
 - `name` - (Required, String) The name of the service ID.
 
-## Attribute reference
-In addition to the argument reference list, you can access the following attribute references after your data source is created.
+## Attribute Reference
+
+After your data source is created, you can read values from the following attributes.
 
 - `service_ids` - (List of Objects)  A nested block list of IAM service IDs.
   - `bound_to`-  (String) The service the service ID is bound to. This attribute is Deprecated.
@@ -36,5 +36,3 @@ In addition to the argument reference list, you can access the following attribu
   - `id` - (String) The unique identifier of the service ID.
   - `locked`- (Bool) If set to **true**, the service ID is locked.
   - `version`-  (String) The version of the service ID.
-
-  

--- a/website/docs/r/iam_service_id.html.markdown
+++ b/website/docs/r/iam_service_id.html.markdown
@@ -9,31 +9,43 @@ description: |-
 
 # ibm_iam_service_id
 
-Create, update, or delete an IAM service ID by using resource group and resource type.  For more information, about IAM role action, see [managing service ID API keys](https://cloud.ibm.com/docs/account?topic=account-serviceidapikeys).
+Create, update, and delete an IAM service ID with this resource.  For more information, about IAM role action, see [managing service ID API keys](https://cloud.ibm.com/docs/account?topic=account-serviceidapikeys).
 
-## Example usage
+## Example Usage
 
-```terraform
-resource "ibm_iam_service_id" "serviceID" {
+```hcl
+resource "ibm_iam_service_id" "iam_service_id_instance" {
   name        = "test"
   description = "New ServiceID"
 }
 ```
 
-## Argument reference
+## Argument Reference
 
-Review the argument references that you can specify for your resource.
+You can specify the following arguments for this resource.
 
-- `name` - (Required, String) The name of the service ID.
-- `description`  (Optional, String) The description of the service ID.
-- `tags` (Optional, Array of Strings)  A list of tags that you want to add to the service ID. **Note** The tags are managed locally and not stored on the IBM Cloud Service Endpoint at this moment.
+* `name` - (Required, String) Name of the Service Id. The name is not checked for uniqueness. Therefore multiple names with the same value can exist. Access is done via the UUID of the Service Id.
+* `description` - (Optional, String) The optional description of the Service Id. The 'description' property is only available if a description was provided during a create of a Service Id.
+* `tags` (Optional, Array of Strings) A list of tags that you want to add to the service ID. **Note** The tags are managed locally and not stored on the IBM Cloud Service Endpoint at this moment.
 
-## Attribute reference
+## Attribute Reference
 
-In addition to all argument reference list, you can access the following attribute reference after your resource is created.
+After your resource is created, you can read values from the listed arguments and the following attributes.
 
-- `crn`  - (String) The CRN of the service ID.
-- `iam_id`-  (String) The IAM ID of the service ID.
-- `id` - (String) The unique identifier of the service ID.
-- `locked`- (Bool) The Service Id lock status
-- `version`  - (String) The version of the service ID.
+* `id` - The unique identifier of the iam_service_id.
+* `created_at` - (String) If set contains a date time string of the creation date in ISO format.
+* `crn` - (String) Cloud Resource Name of the item. Example Cloud Resource Name: 'crn:v1:bluemix:public:iam-identity:us-south:a/myaccount::serviceid:1234-5678-9012'.
+* `iam_id` - (String) Cloud wide identifier for identities of this service ID.
+* `locked` - (Boolean) The service ID cannot be changed if set to true.
+* `modified_at` - (String) If set contains a date time string of the last modification date in ISO format.
+* `entity_tag` - (String) The version of the ServiceID object.
+
+
+## Import
+
+You can import the `ibm_iam_service_id` resource by using `id`. Unique identifier of this Service Id.
+
+# Syntax
+<pre>
+$ terraform import ibm_iam_service_id.iam_service_id &lt;id&gt;
+</pre>

--- a/website/docs/r/iam_service_id.html.markdown
+++ b/website/docs/r/iam_service_id.html.markdown
@@ -38,7 +38,7 @@ After your resource is created, you can read values from the listed arguments an
 * `iam_id` - (String) Cloud wide identifier for identities of this service ID.
 * `locked` - (Boolean) The service ID cannot be changed if set to true.
 * `modified_at` - (String) If set contains a date time string of the last modification date in ISO format.
-* `entity_tag` - (String) The version of the ServiceID object.
+* `version` - (String) The version of the ServiceID object.
 
 
 ## Import


### PR DESCRIPTION
### Description

- Update ServiceID error handling format
- Regenerate code with latest generator
- Add some missing fields: `created_at` and `modified_at`
- Update html docs
- Add an example for ServiceID

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/iamidentity TESTARGS='-run=TestAccIBMIAMServiceID*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity -v -run=TestAccIBMIAMServiceID* -timeout 700m 2>&1 | grep -v "^\[.*\]\ Set"
=== RUN   TestAccIBMIAMServiceIDDataSource_basic
--- PASS: TestAccIBMIAMServiceIDDataSource_basic (22.32s)
=== RUN   TestAccIBMIAMServiceIDDataSource_same_name
--- PASS: TestAccIBMIAMServiceIDDataSource_same_name (21.71s)
=== RUN   TestAccIBMIAMServiceID_Basic
--- PASS: TestAccIBMIAMServiceID_Basic (52.57s)
=== RUN   TestAccIBMIAMServiceID_import
--- PASS: TestAccIBMIAMServiceID_import (23.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/iamidentity     130.219s
```
