### PR TITLE
fix(cis): handle deleted domain gracefully

### DIFF
--- a/ibm/service/cis/resource_ibm_cis_domain.go
+++ b/ibm/service/cis/resource_ibm_cis_domain.go
@@ -5,6 +5,7 @@ package cis
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -118,7 +119,7 @@ func resourceCISdomainRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	zoneID, crn, _ := flex.ConvertTftoCisTwoVar(d.Id())
+	zoneID, crn, err := flex.ConvertTftoCisTwoVar(d.Id())
 	if err != nil {
 		return err
 	}
@@ -126,6 +127,11 @@ func resourceCISdomainRead(d *schema.ResourceData, meta interface{}) error {
 	opt := cisClient.NewGetZoneOptions(zoneID)
 	result, resp, err := cisClient.GetZone(opt)
 	if err != nil {
+		if isCISDomainDeleted(resp) {
+			log.Printf("[WARN] Zone not found or already deleted, removing from state")
+			d.SetId("")
+			return nil
+		}
 		log.Printf("[WARN] Error getting zone %v\n", resp)
 		return err
 	}
@@ -151,7 +157,7 @@ func resourceCISdomainExists(d *schema.ResourceData, meta interface{}) (bool, er
 		return false, err
 	}
 
-	zoneID, crn, _ := flex.ConvertTftoCisTwoVar(d.Id())
+	zoneID, crn, err := flex.ConvertTftoCisTwoVar(d.Id())
 	log.Println("resource exist :", d.Id())
 	if err != nil {
 		return false, err
@@ -161,8 +167,8 @@ func resourceCISdomainExists(d *schema.ResourceData, meta interface{}) (bool, er
 	opt := cisClient.NewGetZoneOptions(zoneID)
 	_, resp, err := cisClient.GetZone(opt)
 	if err != nil {
-		if resp != nil && resp.StatusCode == 404 {
-			log.Printf("[WARN] zone is not found")
+		if isCISDomainDeleted(resp) {
+			log.Printf("[WARN] zone is not found or already deleted")
 			return false, nil
 		}
 		log.Printf("[WARN] Error getting zone %v\n", resp)
@@ -181,7 +187,7 @@ func resourceCISdomainDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	zoneID, crn, _ := flex.ConvertTftoCisTwoVar(d.Id())
+	zoneID, crn, err := flex.ConvertTftoCisTwoVar(d.Id())
 	log.Println("resource delete :", d.Id())
 
 	if err != nil {
@@ -191,16 +197,48 @@ func resourceCISdomainDelete(d *schema.ResourceData, meta interface{}) error {
 	opt := cisClient.NewGetZoneOptions(zoneID)
 	_, resp, err := cisClient.GetZone(opt)
 	if err != nil {
+		if isCISDomainDeleted(resp) {
+			log.Printf("[WARN] Zone already deleted, removing from state")
+			return nil
+		}
 		log.Printf("[WARN] Error getting zone %v\n", resp)
 		return err
 	}
 	delOpt := cisClient.NewDeleteZoneOptions(zoneID)
 	_, resp, err = cisClient.DeleteZone(delOpt)
 	if err != nil {
+		// Zone already gone or deletion already in progress - treat as success so
+		// Terraform removes it from state without blocking schematics workspace runs.
+		if isCISDomainDeleted(resp) {
+			log.Printf("[WARN] Zone already deleted or deletion in progress, removing from state")
+			return nil
+		}
 		log.Printf("[ERR] Error deleting zone %v\n", resp)
 		return err
 	}
 	return nil
+}
+
+func isCISDomainDeleted(resp *core.DetailedResponse) bool {
+	if resp == nil {
+		return false
+	}
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		return true
+	}
+	// CIS API returns 400 with error code 1001 ("Invalid zone identifier") when a zone no longer exists.
+	if resp.StatusCode == http.StatusBadRequest {
+		if m, ok := resp.GetResultAsMap(); ok {
+			if errs, ok := m["errors"].([]interface{}); ok && len(errs) > 0 {
+				if e, ok := errs[0].(map[string]interface{}); ok {
+					if code, ok := e["code"].(float64); ok && code == 1001 {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func ResourceIBMCISDomainValidator() *validate.ResourceValidator {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccIBMCisDomain_CreateAfterManualDestroy'

=== RUN   TestAccIBMCisDomain_CreateAfterManualDestroy
--- PASS: TestAccIBMCisDomain_CreateAfterManualDestroy (31.72s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cis   31.72s

...
```
