### PR TITLE
Adding new parameters for deployments iam_registration and onboarding offering

### DIFF
--- a/examples/ibm-partner-center-sell/README.md
+++ b/examples/ibm-partner-center-sell/README.md
@@ -301,6 +301,7 @@ resource "ibm_onboarding_product" "onboarding_product_instance" {
 | staging_global_catalog_offering_id | The ID of a global catalog object. |
 | approver_resource_id | The ID of the approval workflow of your product. |
 | iam_registration_id | IAM registration identifier. |
+| oss_id | The ID of the OSS record connected to the product. |
 
 ### Resource: ibm_onboarding_registration
 

--- a/examples/ibm-partner-center-sell/main.tf
+++ b/examples/ibm-partner-center-sell/main.tf
@@ -176,6 +176,9 @@ resource "ibm_onboarding_catalog_deployment" "onboarding_catalog_deployment_inst
       location_url = "location_url"
       target_crn = "target_crn"
     }
+    other {
+      location_proxied_by = "location_proxied_by"
+    }
   }
 }
 
@@ -702,6 +705,9 @@ resource "ibm_onboarding_iam_registration" "onboarding_iam_registration_instance
       api_types {
         name = "name"
         enforcement_method = [ "enforcement_method" ]
+        event_publishing {
+          state = "enabled"
+        }
         display_name {
           default = "default"
           en = "en"
@@ -727,6 +733,12 @@ resource "ibm_onboarding_iam_registration" "onboarding_iam_registration_instance
           pt_br = "pt_br"
           zh_tw = "zh_tw"
           zh_cn = "zh_cn"
+        }
+      }
+      defaults {
+        enforcement_method = [ "enforcement_method" ]
+        event_publishing {
+          state = "enabled"
         }
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM-Cloud/terraform-provider-ibm
 
-go 1.25.2
+go 1.25.8
 
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20260526083905-8316c06b6742
@@ -29,7 +29,7 @@ require (
 	github.com/IBM/logs-router-go-sdk v1.0.8
 	github.com/IBM/mqcloud-go-sdk v0.4.0
 	github.com/IBM/networking-go-sdk v0.53.4
-	github.com/IBM/platform-services-go-sdk v0.97.5
+	github.com/IBM/platform-services-go-sdk v0.99.0
 	github.com/IBM/project-go-sdk v0.4.0
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/sarama v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/IBM/mqcloud-go-sdk v0.4.0 h1:BuZNXA6iYEg5OEPr13CMGrhH0ew4rH/4L56b1nFt
 github.com/IBM/mqcloud-go-sdk v0.4.0/go.mod h1:7zigCUz6k3eRrNE8KOcDkY72oPppEmoQifF+SB0NPRM=
 github.com/IBM/networking-go-sdk v0.53.4 h1:XDGOhavZocjVfItgcaT7/SFqB8zT2kznYuJ9LXkz/ug=
 github.com/IBM/networking-go-sdk v0.53.4/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
-github.com/IBM/platform-services-go-sdk v0.97.5 h1:Q/4zkxDTzyrfBD8cFA1mfzmUGSU29VOkJ43ilRNvSEw=
-github.com/IBM/platform-services-go-sdk v0.97.5/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
+github.com/IBM/platform-services-go-sdk v0.99.0 h1:oaWxQ6hSzqzFF3E9WU2FpQi77FMPPHRW+pMzOO7r0PQ=
+github.com/IBM/platform-services-go-sdk v0.99.0/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
 github.com/IBM/project-go-sdk v0.4.0 h1:72pEtVHJn434+MYRawER7Hk/kblapdfotoLBBhjv/jo=
 github.com/IBM/project-go-sdk v0.4.0/go.mod h1:FOJM9ihQV3EEAY6YigcWiTNfVCThtdY8bLC/nhQHFvo=
 github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 h1:NPUhkoOCRuv3OFWt19PmwjXGGTKlvmbuPg9fUrBUNe4=

--- a/ibm/service/partnercentersell/resource_ibm_onboarding_catalog_deployment.go
+++ b/ibm/service/partnercentersell/resource_ibm_onboarding_catalog_deployment.go
@@ -2,7 +2,7 @@
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.112.0-f88e9264-20260220-115155
+ * IBM OpenAPI Terraform Generator Version: 3.114.2-b2884bfd-20260601-185447
  */
 
 package partnercentersell
@@ -830,6 +830,21 @@ func ResourceIbmOnboardingCatalogDeployment() *schema.Resource {
 								},
 							},
 						},
+						"other": &schema.Schema{
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: "Additional deployment metadata for \"other\" location type.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"location_proxied_by": &schema.Schema{
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The region that proxies this deployment location.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1301,6 +1316,13 @@ func ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogDeploymentMetadataP
 		}
 		model.Deployment = DeploymentModel
 	}
+	if modelMap["other"] != nil && len(modelMap["other"].([]interface{})) > 0 {
+		OtherModel, err := ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentOther(modelMap["other"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Other = OtherModel
+	}
 	return model, nil
 }
 
@@ -1619,6 +1641,14 @@ func ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentB
 	return model, nil
 }
 
+func ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentOther(modelMap map[string]interface{}) (*partnercentersellv1.GlobalCatalogMetadataDeploymentOther, error) {
+	model := &partnercentersellv1.GlobalCatalogMetadataDeploymentOther{}
+	if modelMap["location_proxied_by"] != nil && modelMap["location_proxied_by"].(string) != "" {
+		model.LocationProxiedBy = core.StringPtr(modelMap["location_proxied_by"].(string))
+	}
+	return model, nil
+}
+
 func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogOverviewUIToMap(model *partnercentersellv1.GlobalCatalogOverviewUI) (map[string]interface{}, error) {
 	modelMap := make(map[string]interface{})
 	if model.En != nil {
@@ -1674,6 +1704,13 @@ func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentMetadataToMap(
 			return modelMap, err
 		}
 		modelMap["deployment"] = []map[string]interface{}{deploymentMap}
+	}
+	if model.Other != nil {
+		otherMap, err := ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherToMap(model.Other)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["other"] = []map[string]interface{}{otherMap}
 	}
 	return modelMap, nil
 }
@@ -1983,6 +2020,14 @@ func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentBroker
 	return modelMap, nil
 }
 
+func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherToMap(model *partnercentersellv1.GlobalCatalogMetadataDeploymentOther) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.LocationProxiedBy != nil {
+		modelMap["location_proxied_by"] = *model.LocationProxiedBy
+	}
+	return modelMap, nil
+}
+
 func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentPatchAsPatch(patchVals *partnercentersellv1.GlobalCatalogDeploymentPatch, d *schema.ResourceData) map[string]interface{} {
 	patch, _ := patchVals.AsPatch()
 	var path string
@@ -2057,6 +2102,25 @@ func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentMetadataProtot
 		ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentAsPatch(patch["deployment"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
 	} else if !exists {
 		delete(patch, "deployment")
+	}
+	path = rootPath + ".other"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["other"] = nil
+	} else if exists && patch["other"] != nil {
+		ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherAsPatch(patch["other"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
+	} else if !exists {
+		delete(patch, "other")
+	}
+}
+
+func ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherAsPatch(patch map[string]interface{}, d *schema.ResourceData, rootPath string) {
+	var path string
+
+	path = rootPath + ".location_proxied_by"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["location_proxied_by"] = nil
+	} else if !exists {
+		delete(patch, "location_proxied_by")
 	}
 }
 

--- a/ibm/service/partnercentersell/resource_ibm_onboarding_catalog_deployment_test.go
+++ b/ibm/service/partnercentersell/resource_ibm_onboarding_catalog_deployment_test.go
@@ -187,6 +187,9 @@ func testAccCheckIbmOnboardingCatalogDeploymentConfig(productID string, catalogP
 				name = "name"
 			}
 			metadata {
+				other {
+					location_proxied_by = "dal"
+				}
                 rc_compatible =	"%s"
 				service {
 					plan_updateable = false
@@ -253,6 +256,9 @@ func testAccCheckIbmOnboardingCatalogDeploymentUpdateConfig(productID string, ca
 				name = "name"
 			}
 			metadata {
+				other {
+					location_proxied_by = "eu-de"
+				}
                 rc_compatible =	"%s"
 				service {
 					plan_updateable = true
@@ -517,10 +523,14 @@ func TestResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentMetadataTo
 		globalCatalogMetadataDeploymentModel["location_url"] = "testString"
 		globalCatalogMetadataDeploymentModel["target_crn"] = "testString"
 
+		globalCatalogMetadataDeploymentOtherModel := make(map[string]interface{})
+		globalCatalogMetadataDeploymentOtherModel["location_proxied_by"] = "testString"
+
 		model := make(map[string]interface{})
 		model["rc_compatible"] = true
 		model["service"] = []map[string]interface{}{globalCatalogDeploymentMetadataServiceModel}
 		model["deployment"] = []map[string]interface{}{globalCatalogMetadataDeploymentModel}
+		model["other"] = []map[string]interface{}{globalCatalogMetadataDeploymentOtherModel}
 
 		assert.Equal(t, result, model)
 	}
@@ -599,10 +609,14 @@ func TestResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentMetadataTo
 	globalCatalogMetadataDeploymentModel.LocationURL = core.StringPtr("testString")
 	globalCatalogMetadataDeploymentModel.TargetCrn = core.StringPtr("testString")
 
+	globalCatalogMetadataDeploymentOtherModel := new(partnercentersellv1.GlobalCatalogMetadataDeploymentOther)
+	globalCatalogMetadataDeploymentOtherModel.LocationProxiedBy = core.StringPtr("testString")
+
 	model := new(partnercentersellv1.GlobalCatalogDeploymentMetadata)
 	model.RcCompatible = core.BoolPtr(true)
 	model.Service = globalCatalogDeploymentMetadataServiceModel
 	model.Deployment = globalCatalogMetadataDeploymentModel
+	model.Other = globalCatalogMetadataDeploymentOtherModel
 
 	result, err := partnercentersell.ResourceIbmOnboardingCatalogDeploymentGlobalCatalogDeploymentMetadataToMap(model)
 	assert.Nil(t, err)
@@ -1133,6 +1147,22 @@ func TestResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentBr
 	checkResult(result)
 }
 
+func TestResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["location_proxied_by"] = "testString"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(partnercentersellv1.GlobalCatalogMetadataDeploymentOther)
+	model.LocationProxiedBy = core.StringPtr("testString")
+
+	result, err := partnercentersell.ResourceIbmOnboardingCatalogDeploymentGlobalCatalogMetadataDeploymentOtherToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
 func TestResourceIbmOnboardingCatalogDeploymentMapToCatalogProductProvider(t *testing.T) {
 	checkResult := func(result *partnercentersellv1.CatalogProductProvider) {
 		model := new(partnercentersellv1.CatalogProductProvider)
@@ -1273,10 +1303,14 @@ func TestResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogDeploymentMetad
 		globalCatalogMetadataDeploymentModel.LocationURL = core.StringPtr("testString")
 		globalCatalogMetadataDeploymentModel.TargetCrn = core.StringPtr("testString")
 
+		globalCatalogMetadataDeploymentOtherModel := new(partnercentersellv1.GlobalCatalogMetadataDeploymentOther)
+		globalCatalogMetadataDeploymentOtherModel.LocationProxiedBy = core.StringPtr("testString")
+
 		model := new(partnercentersellv1.GlobalCatalogDeploymentMetadataPrototypePatch)
 		model.RcCompatible = core.BoolPtr(true)
 		model.Service = globalCatalogDeploymentMetadataServicePrototypePatchModel
 		model.Deployment = globalCatalogMetadataDeploymentModel
+		model.Other = globalCatalogMetadataDeploymentOtherModel
 
 		assert.Equal(t, result, model)
 	}
@@ -1355,10 +1389,14 @@ func TestResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogDeploymentMetad
 	globalCatalogMetadataDeploymentModel["location_url"] = "testString"
 	globalCatalogMetadataDeploymentModel["target_crn"] = "testString"
 
+	globalCatalogMetadataDeploymentOtherModel := make(map[string]interface{})
+	globalCatalogMetadataDeploymentOtherModel["location_proxied_by"] = "testString"
+
 	model := make(map[string]interface{})
 	model["rc_compatible"] = true
 	model["service"] = []interface{}{globalCatalogDeploymentMetadataServicePrototypePatchModel}
 	model["deployment"] = []interface{}{globalCatalogMetadataDeploymentModel}
+	model["other"] = []interface{}{globalCatalogMetadataDeploymentOtherModel}
 
 	result, err := partnercentersell.ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogDeploymentMetadataPrototypePatch(model)
 	assert.Nil(t, err)
@@ -1881,6 +1919,22 @@ func TestResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploym
 	model["guid"] = "testString"
 
 	result, err := partnercentersell.ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentBroker(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentOther(t *testing.T) {
+	checkResult := func(result *partnercentersellv1.GlobalCatalogMetadataDeploymentOther) {
+		model := new(partnercentersellv1.GlobalCatalogMetadataDeploymentOther)
+		model.LocationProxiedBy = core.StringPtr("testString")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["location_proxied_by"] = "testString"
+
+	result, err := partnercentersell.ResourceIbmOnboardingCatalogDeploymentMapToGlobalCatalogMetadataDeploymentOther(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }

--- a/ibm/service/partnercentersell/resource_ibm_onboarding_iam_registration.go
+++ b/ibm/service/partnercentersell/resource_ibm_onboarding_iam_registration.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2025 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.107.1-41b0fbd0-20250825-080732
+ * IBM OpenAPI Terraform Generator Version: 3.114.2-b2884bfd-20260601-185447
  */
 
 package partnercentersell
@@ -1038,6 +1038,21 @@ func ResourceIbmOnboardingIamRegistration() *schema.Resource {
 													Description: "The enforcement method used for the API type.",
 													Elem:        &schema.Schema{Type: schema.TypeString},
 												},
+												"event_publishing": &schema.Schema{
+													Type:        schema.TypeList,
+													MaxItems:    1,
+													Optional:    true,
+													Description: "Specifies the event publishing state.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"state": &schema.Schema{
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: "The event publishing state.",
+															},
+														},
+													},
+												},
 												"display_name": &schema.Schema{
 													Type:        schema.TypeList,
 													MaxItems:    1,
@@ -1164,6 +1179,37 @@ func ResourceIbmOnboardingIamRegistration() *schema.Resource {
 																Type:        schema.TypeString,
 																Optional:    true,
 																Description: "Simplified Chinese.",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"defaults": &schema.Schema{
+										Type:        schema.TypeList,
+										MaxItems:    1,
+										Optional:    true,
+										Description: "Specifies default supported network operation behavior that applies when an API type does not explicitly set a value.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enforcement_method": &schema.Schema{
+													Type:        schema.TypeList,
+													Optional:    true,
+													Description: "The default enforcement method used for API types.",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+												"event_publishing": &schema.Schema{
+													Type:        schema.TypeList,
+													MaxItems:    1,
+													Optional:    true,
+													Description: "Specifies the event publishing state.",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"state": &schema.Schema{
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: "The event publishing state.",
 															},
 														},
 													},
@@ -2021,7 +2067,7 @@ func ResourceIbmOnboardingIamRegistrationMapToSupportedAttributesOptions(modelMa
 	if modelMap["key"] != nil && modelMap["key"].(string) != "" {
 		model.Key = core.StringPtr(modelMap["key"].(string))
 	}
-	if modelMap["resource_hierarchy"] != nil && len(modelMap["resource_hierarchy"].([]interface{})) > 0 && modelMap["resource_hierarchy"].([]interface{})[0] != nil {
+	if modelMap["resource_hierarchy"] != nil && len(modelMap["resource_hierarchy"].([]interface{})) > 0 {
 		ResourceHierarchyModel, err := ResourceIbmOnboardingIamRegistrationMapToSupportedAttributesOptionsResourceHierarchy(modelMap["resource_hierarchy"].([]interface{})[0].(map[string]interface{}))
 		if err != nil {
 			return model, err
@@ -2308,6 +2354,13 @@ func ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNet
 		}
 		model.ApiTypes = apiTypes
 	}
+	if modelMap["defaults"] != nil && len(modelMap["defaults"].([]interface{})) > 0 && modelMap["defaults"].([]interface{})[0] != nil {
+		DefaultsModel, err := ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsDefaults(modelMap["defaults"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.Defaults = DefaultsModel
+	}
 	return model, nil
 }
 
@@ -2323,6 +2376,13 @@ func ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNet
 		}
 		model.EnforcementMethod = enforcementMethod
 	}
+	if modelMap["event_publishing"] != nil && len(modelMap["event_publishing"].([]interface{})) > 0 {
+		EventPublishingModel, err := ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsEventPublishing(modelMap["event_publishing"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.EventPublishing = EventPublishingModel
+	}
 	if modelMap["display_name"] != nil && len(modelMap["display_name"].([]interface{})) > 0 {
 		DisplayNameModel, err := ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationDisplayNameObject(modelMap["display_name"].([]interface{})[0].(map[string]interface{}))
 		if err != nil {
@@ -2336,6 +2396,33 @@ func ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNet
 			return model, err
 		}
 		model.Description = DescriptionModel
+	}
+	return model, nil
+}
+
+func ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsEventPublishing(modelMap map[string]interface{}) (*partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing, error) {
+	model := &partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing{}
+	if modelMap["state"] != nil && modelMap["state"].(string) != "" {
+		model.State = core.StringPtr(modelMap["state"].(string))
+	}
+	return model, nil
+}
+
+func ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsDefaults(modelMap map[string]interface{}) (*partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults, error) {
+	model := &partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults{}
+	if modelMap["enforcement_method"] != nil {
+		enforcementMethod := []string{}
+		for _, enforcementMethodItem := range modelMap["enforcement_method"].([]interface{}) {
+			enforcementMethod = append(enforcementMethod, enforcementMethodItem.(string))
+		}
+		model.EnforcementMethod = enforcementMethod
+	}
+	if modelMap["event_publishing"] != nil && len(modelMap["event_publishing"].([]interface{})) > 0 {
+		EventPublishingModel, err := ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsEventPublishing(modelMap["event_publishing"].([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return model, err
+		}
+		model.EventPublishing = EventPublishingModel
 	}
 	return model, nil
 }
@@ -2855,6 +2942,13 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 		}
 		modelMap["api_types"] = apiTypes
 	}
+	if model.Defaults != nil {
+		defaultsMap, err := ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsToMap(model.Defaults)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["defaults"] = []map[string]interface{}{defaultsMap}
+	}
 	return modelMap, nil
 }
 
@@ -2865,6 +2959,13 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 	}
 	if model.EnforcementMethod != nil {
 		modelMap["enforcement_method"] = model.EnforcementMethod
+	}
+	if model.EventPublishing != nil {
+		eventPublishingMap, err := ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingToMap(model.EventPublishing)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["event_publishing"] = []map[string]interface{}{eventPublishingMap}
 	}
 	if model.DisplayName != nil {
 		displayNameMap, err := ResourceIbmOnboardingIamRegistrationIamServiceRegistrationDisplayNameObjectToMap(model.DisplayName)
@@ -2879,6 +2980,29 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 			return modelMap, err
 		}
 		modelMap["description"] = []map[string]interface{}{descriptionMap}
+	}
+	return modelMap, nil
+}
+
+func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingToMap(model *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.State != nil {
+		modelMap["state"] = *model.State
+	}
+	return modelMap, nil
+}
+
+func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsToMap(model *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.EnforcementMethod != nil {
+		modelMap["enforcement_method"] = model.EnforcementMethod
+	}
+	if model.EventPublishing != nil {
+		eventPublishingMap, err := ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingToMap(model.EventPublishing)
+		if err != nil {
+			return modelMap, err
+		}
+		modelMap["event_publishing"] = []map[string]interface{}{eventPublishingMap}
 	}
 	return modelMap, nil
 }
@@ -3088,6 +3212,33 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 	} else if !exists {
 		delete(patch, "api_types")
 	}
+	path = rootPath + ".defaults"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["defaults"] = nil
+	} else if exists && patch["defaults"] != nil {
+		ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsAsPatch(patch["defaults"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
+	} else if !exists {
+		delete(patch, "defaults")
+	}
+}
+
+func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsAsPatch(patch map[string]interface{}, d *schema.ResourceData, rootPath string) {
+	var path string
+
+	path = rootPath + ".enforcement_method"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["enforcement_method"] = nil
+	} else if !exists {
+		delete(patch, "enforcement_method")
+	}
+	path = rootPath + ".event_publishing"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["event_publishing"] = nil
+	} else if exists && patch["event_publishing"] != nil {
+		ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingAsPatch(patch["event_publishing"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
+	} else if !exists {
+		delete(patch, "event_publishing")
+	}
 }
 
 func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsApiTypeItemsAsPatch(patch map[string]interface{}, d *schema.ResourceData, rootPath string) {
@@ -3105,6 +3256,14 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 	} else if !exists {
 		delete(patch, "enforcement_method")
 	}
+	path = rootPath + ".event_publishing"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["event_publishing"] = nil
+	} else if exists && patch["event_publishing"] != nil {
+		ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingAsPatch(patch["event_publishing"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
+	} else if !exists {
+		delete(patch, "event_publishing")
+	}
 	path = rootPath + ".display_name"
 	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
 		patch["display_name"] = nil
@@ -3120,6 +3279,17 @@ func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkO
 		ResourceIbmOnboardingIamRegistrationIamServiceRegistrationDescriptionObjectAsPatch(patch["description"].(map[string]interface{}), d, fmt.Sprintf("%s.0", path))
 	} else if !exists {
 		delete(patch, "description")
+	}
+}
+
+func ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingAsPatch(patch map[string]interface{}, d *schema.ResourceData, rootPath string) {
+	var path string
+
+	path = rootPath + ".state"
+	if _, exists := d.GetOk(path); d.HasChange(path) && !exists {
+		patch["state"] = nil
+	} else if !exists {
+		delete(patch, "state")
 	}
 }
 

--- a/ibm/service/partnercentersell/resource_ibm_onboarding_iam_registration_test.go
+++ b/ibm/service/partnercentersell/resource_ibm_onboarding_iam_registration_test.go
@@ -147,6 +147,8 @@ func testAccCheckIbmOnboardingIamRegistrationConfigBasic(productID string, name 
 			display_name {
 				default = "%s"
 			}
+			service_type = "service"
+
 		}
 	`, productID, name, name)
 }
@@ -605,6 +607,12 @@ func testAccCheckIbmOnboardingIamRegistrationUpdateConfig(
 					}
 				}
 				operations {
+					defaults {
+						enforcement_method = [ "authz-full" ]
+						event_publishing {
+							state = "enabled"
+						}
+					}
 					api_types {
 						name = "crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"
 						enforcement_method = ["authz-network"]
@@ -1665,6 +1673,9 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 		environmentAttributeModel["values"] = []string{"testString"}
 		environmentAttributeModel["options"] = []map[string]interface{}{environmentAttributeOptionsModel}
 
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
+
 		iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 		iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
 		iamServiceRegistrationDisplayNameObjectModel["en"] = "testString"
@@ -1694,11 +1705,17 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := make(map[string]interface{})
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["name"] = "testString"
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["enforcement_method"] = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["display_name"] = []map[string]interface{}{iamServiceRegistrationDisplayNameObjectModel}
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["description"] = []map[string]interface{}{iamServiceRegistrationDescriptionObjectModel}
 
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["enforcement_method"] = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
 		iamServiceRegistrationSupportedNetworkOperationsModel := make(map[string]interface{})
 		iamServiceRegistrationSupportedNetworkOperationsModel["api_types"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+		iamServiceRegistrationSupportedNetworkOperationsModel["defaults"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsDefaultsModel}
 
 		iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel := make(map[string]interface{})
 		iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel["api_types"] = []string{"testString"}
@@ -1721,6 +1738,9 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 	environmentAttributeModel.Key = core.StringPtr("testString")
 	environmentAttributeModel.Values = []string{"testString"}
 	environmentAttributeModel.Options = environmentAttributeOptionsModel
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
 
 	iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 	iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
@@ -1751,11 +1771,17 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Name = core.StringPtr("testString")
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EnforcementMethod = []string{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Description = iamServiceRegistrationDescriptionObjectModel
 
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EnforcementMethod = []string{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
 	iamServiceRegistrationSupportedNetworkOperationsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperations)
 	iamServiceRegistrationSupportedNetworkOperationsModel.ApiTypes = []partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems{*iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+	iamServiceRegistrationSupportedNetworkOperationsModel.Defaults = iamServiceRegistrationSupportedNetworkOperationsDefaultsModel
 
 	iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishing)
 	iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel.ApiTypes = []string{"testString"}
@@ -1817,6 +1843,9 @@ func TestResourceIbmOnboardingIamRegistrationEnvironmentAttributeOptionsToMap(t 
 
 func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsToMap(t *testing.T) {
 	checkResult := func(result map[string]interface{}) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
+
 		iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 		iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
 		iamServiceRegistrationDisplayNameObjectModel["en"] = "testString"
@@ -1846,14 +1875,23 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := make(map[string]interface{})
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["name"] = "testString"
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["enforcement_method"] = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["display_name"] = []map[string]interface{}{iamServiceRegistrationDisplayNameObjectModel}
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["description"] = []map[string]interface{}{iamServiceRegistrationDescriptionObjectModel}
 
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["enforcement_method"] = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
 		model := make(map[string]interface{})
 		model["api_types"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+		model["defaults"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsDefaultsModel}
 
 		assert.Equal(t, result, model)
 	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
 
 	iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 	iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
@@ -1884,11 +1922,17 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Name = core.StringPtr("testString")
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EnforcementMethod = []string{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Description = iamServiceRegistrationDescriptionObjectModel
 
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EnforcementMethod = []string{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
 	model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperations)
 	model.ApiTypes = []partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems{*iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+	model.Defaults = iamServiceRegistrationSupportedNetworkOperationsDefaultsModel
 
 	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsToMap(model)
 	assert.Nil(t, err)
@@ -1897,6 +1941,9 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 
 func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsApiTypeItemsToMap(t *testing.T) {
 	checkResult := func(result map[string]interface{}) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
+
 		iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 		iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
 		iamServiceRegistrationDisplayNameObjectModel["en"] = "testString"
@@ -1926,11 +1973,15 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 		model := make(map[string]interface{})
 		model["name"] = "testString"
 		model["enforcement_method"] = []string{"testString"}
+		model["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 		model["display_name"] = []map[string]interface{}{iamServiceRegistrationDisplayNameObjectModel}
 		model["description"] = []map[string]interface{}{iamServiceRegistrationDescriptionObjectModel}
 
 		assert.Equal(t, result, model)
 	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
 
 	iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 	iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
@@ -1961,10 +2012,51 @@ func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetw
 	model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 	model.Name = core.StringPtr("testString")
 	model.EnforcementMethod = []string{"testString"}
+	model.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 	model.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 	model.Description = iamServiceRegistrationDescriptionObjectModel
 
 	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsApiTypeItemsToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		model := make(map[string]interface{})
+		model["state"] = "enabled"
+
+		assert.Equal(t, result, model)
+	}
+
+	model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+	model.State = core.StringPtr("enabled")
+
+	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsEventPublishingToMap(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsToMap(t *testing.T) {
+	checkResult := func(result map[string]interface{}) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
+
+		model := make(map[string]interface{})
+		model["enforcement_method"] = []string{"testString"}
+		model["event_publishing"] = []map[string]interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
+		assert.Equal(t, result, model)
+	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
+
+	model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+	model.EnforcementMethod = []string{"testString"}
+	model.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
+	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationIamServiceRegistrationSupportedNetworkOperationsDefaultsToMap(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }
@@ -2931,6 +3023,9 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 		environmentAttributeModel.Values = []string{"testString"}
 		environmentAttributeModel.Options = environmentAttributeOptionsModel
 
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
+
 		iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 		iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
 		iamServiceRegistrationDisplayNameObjectModel.En = core.StringPtr("testString")
@@ -2960,11 +3055,17 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Name = core.StringPtr("testString")
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EnforcementMethod = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Description = iamServiceRegistrationDescriptionObjectModel
 
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EnforcementMethod = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
 		iamServiceRegistrationSupportedNetworkOperationsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperations)
 		iamServiceRegistrationSupportedNetworkOperationsModel.ApiTypes = []partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems{*iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+		iamServiceRegistrationSupportedNetworkOperationsModel.Defaults = iamServiceRegistrationSupportedNetworkOperationsDefaultsModel
 
 		iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishing)
 		iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel.ApiTypes = []string{"testString"}
@@ -2987,6 +3088,9 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 	environmentAttributeModel["key"] = "testString"
 	environmentAttributeModel["values"] = []interface{}{"testString"}
 	environmentAttributeModel["options"] = []interface{}{environmentAttributeOptionsModel}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
 
 	iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 	iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
@@ -3017,11 +3121,17 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := make(map[string]interface{})
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["name"] = "testString"
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["enforcement_method"] = []interface{}{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["display_name"] = []interface{}{iamServiceRegistrationDisplayNameObjectModel}
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["description"] = []interface{}{iamServiceRegistrationDescriptionObjectModel}
 
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["enforcement_method"] = []interface{}{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
 	iamServiceRegistrationSupportedNetworkOperationsModel := make(map[string]interface{})
 	iamServiceRegistrationSupportedNetworkOperationsModel["api_types"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+	iamServiceRegistrationSupportedNetworkOperationsModel["defaults"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsDefaultsModel}
 
 	iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel := make(map[string]interface{})
 	iamServiceRegistrationSupportedNetworkSelfManagedAllowlistEnforcementEventPublishingModel["api_types"] = []interface{}{"testString"}
@@ -3083,6 +3193,9 @@ func TestResourceIbmOnboardingIamRegistrationMapToEnvironmentAttributeOptions(t 
 
 func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperations(t *testing.T) {
 	checkResult := func(result *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperations) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
+
 		iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 		iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
 		iamServiceRegistrationDisplayNameObjectModel.En = core.StringPtr("testString")
@@ -3112,14 +3225,23 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Name = core.StringPtr("testString")
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EnforcementMethod = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 		iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel.Description = iamServiceRegistrationDescriptionObjectModel
 
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EnforcementMethod = []string{"testString"}
+		iamServiceRegistrationSupportedNetworkOperationsDefaultsModel.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
 		model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperations)
 		model.ApiTypes = []partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems{*iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+		model.Defaults = iamServiceRegistrationSupportedNetworkOperationsDefaultsModel
 
 		assert.Equal(t, result, model)
 	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
 
 	iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 	iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
@@ -3150,11 +3272,17 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel := make(map[string]interface{})
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["name"] = "testString"
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["enforcement_method"] = []interface{}{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["display_name"] = []interface{}{iamServiceRegistrationDisplayNameObjectModel}
 	iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel["description"] = []interface{}{iamServiceRegistrationDescriptionObjectModel}
 
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["enforcement_method"] = []interface{}{"testString"}
+	iamServiceRegistrationSupportedNetworkOperationsDefaultsModel["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
 	model := make(map[string]interface{})
 	model["api_types"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsApiTypeItemsModel}
+	model["defaults"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsDefaultsModel}
 
 	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperations(model)
 	assert.Nil(t, err)
@@ -3163,6 +3291,9 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 
 func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsApiTypeItems(t *testing.T) {
 	checkResult := func(result *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
+
 		iamServiceRegistrationDisplayNameObjectModel := new(partnercentersellv1.IamServiceRegistrationDisplayNameObject)
 		iamServiceRegistrationDisplayNameObjectModel.Default = core.StringPtr("testString")
 		iamServiceRegistrationDisplayNameObjectModel.En = core.StringPtr("testString")
@@ -3192,11 +3323,15 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 		model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsApiTypeItems)
 		model.Name = core.StringPtr("testString")
 		model.EnforcementMethod = []string{"testString"}
+		model.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
 		model.DisplayName = iamServiceRegistrationDisplayNameObjectModel
 		model.Description = iamServiceRegistrationDescriptionObjectModel
 
 		assert.Equal(t, result, model)
 	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
 
 	iamServiceRegistrationDisplayNameObjectModel := make(map[string]interface{})
 	iamServiceRegistrationDisplayNameObjectModel["default"] = "testString"
@@ -3227,10 +3362,51 @@ func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupporte
 	model := make(map[string]interface{})
 	model["name"] = "testString"
 	model["enforcement_method"] = []interface{}{"testString"}
+	model["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
 	model["display_name"] = []interface{}{iamServiceRegistrationDisplayNameObjectModel}
 	model["description"] = []interface{}{iamServiceRegistrationDescriptionObjectModel}
 
 	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsApiTypeItems(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsEventPublishing(t *testing.T) {
+	checkResult := func(result *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing) {
+		model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+		model.State = core.StringPtr("enabled")
+
+		assert.Equal(t, result, model)
+	}
+
+	model := make(map[string]interface{})
+	model["state"] = "enabled"
+
+	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsEventPublishing(model)
+	assert.Nil(t, err)
+	checkResult(result)
+}
+
+func TestResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsDefaults(t *testing.T) {
+	checkResult := func(result *partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults) {
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsEventPublishing)
+		iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel.State = core.StringPtr("enabled")
+
+		model := new(partnercentersellv1.IamServiceRegistrationSupportedNetworkOperationsDefaults)
+		model.EnforcementMethod = []string{"testString"}
+		model.EventPublishing = iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel
+
+		assert.Equal(t, result, model)
+	}
+
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel := make(map[string]interface{})
+	iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel["state"] = "enabled"
+
+	model := make(map[string]interface{})
+	model["enforcement_method"] = []interface{}{"testString"}
+	model["event_publishing"] = []interface{}{iamServiceRegistrationSupportedNetworkOperationsEventPublishingModel}
+
+	result, err := partnercentersell.ResourceIbmOnboardingIamRegistrationMapToIamServiceRegistrationSupportedNetworkOperationsDefaults(model)
 	assert.Nil(t, err)
 	checkResult(result)
 }

--- a/ibm/service/partnercentersell/resource_ibm_onboarding_product.go
+++ b/ibm/service/partnercentersell/resource_ibm_onboarding_product.go
@@ -1,8 +1,8 @@
-// Copyright IBM Corp. 2025 All Rights Reserved.
+// Copyright IBM Corp. 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 /*
- * IBM OpenAPI Terraform Generator Version: 3.99.1-daeb6e46-20250131-173156
+ * IBM OpenAPI Terraform Generator Version: 3.114.2-b2884bfd-20260601-185447
  */
 
 package partnercentersell
@@ -146,6 +146,11 @@ func ResourceIbmOnboardingProduct() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IAM registration identifier.",
+			},
+			"oss_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the OSS record connected to the product.",
 			},
 		},
 	}
@@ -324,6 +329,12 @@ func resourceIbmOnboardingProductRead(context context.Context, d *schema.Resourc
 		if err = d.Set("iam_registration_id", onboardingProduct.IamRegistrationID); err != nil {
 			err = fmt.Errorf("Error setting iam_registration_id: %s", err)
 			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_onboarding_product", "read", "set-iam_registration_id").GetDiag()
+		}
+	}
+	if !core.IsNil(onboardingProduct.OssID) {
+		if err = d.Set("oss_id", onboardingProduct.OssID); err != nil {
+			err = fmt.Errorf("Error setting oss_id: %s", err)
+			return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_onboarding_product", "read", "set-oss_id").GetDiag()
 		}
 	}
 

--- a/website/docs/r/onboarding_catalog_deployment.html.markdown
+++ b/website/docs/r/onboarding_catalog_deployment.html.markdown
@@ -156,6 +156,9 @@ resource "ibm_onboarding_catalog_deployment" "onboarding_catalog_deployment_inst
 			location_url = "location_url"
 			target_crn = "target_crn"
 		}
+		other {
+			location_proxied_by = "location_proxied_by"
+		}
   }
   name = "deployment-eu-de"
   object_provider {
@@ -202,6 +205,10 @@ Nested schema for **metadata**:
 		* `location_url` - (Optional, String) The global catalog deployment URL of location.
 		  * Constraints: The maximum length is `2083` characters. The minimum length is `1` character. The value must match regular expression `/^(?!mailto:)(?:(?:http|https|ftp):\/\/)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(\/|\\?|#)[^\\s]*)?$/`.
 		* `target_crn` - (Optional, String) Region crn.
+		  * Constraints: The maximum length is `2000` characters. The minimum length is `1` character. The value must match regular expression `/^[ -~\\s]*$/`.
+	* `other` - (Optional, List) Additional deployment metadata for "other" location type.
+	Nested schema for **other**:
+		* `location_proxied_by` - (Optional, String) The region that proxies this deployment location.
 		  * Constraints: The maximum length is `2000` characters. The minimum length is `1` character. The value must match regular expression `/^[ -~\\s]*$/`.
 	* `rc_compatible` - (Optional, Boolean) Whether the object is compatible with the resource controller service.
 	* `service` - (Optional, List) The global catalog metadata of the service.
@@ -407,7 +414,7 @@ Nested schema for **overview_ui**:
 * `product_id` - (Required, Forces new resource, String) The unique ID of the resource.
   * Constraints: Length must be `71` characters. The value must match regular expression `/^[a-zA-Z0-9]{32}:o:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
 * `tags` - (Optional, List) A list of tags that carry information about your product. These tags can be used to find your product in the IBM Cloud catalog.
-  * Constraints: The list items must match regular expression `/^[a-z0-9\\-._]+$/`. The maximum length is `100` items. The minimum length is `0` items.
+  * Constraints: The list items must match regular expression `/^[a-z0-9\\-._ ]+$/`. The maximum length is `100` items. The minimum length is `0` items.
 
 ## Attribute Reference
 

--- a/website/docs/r/onboarding_iam_registration.html.markdown
+++ b/website/docs/r/onboarding_iam_registration.html.markdown
@@ -176,6 +176,9 @@ resource "ibm_onboarding_iam_registration" "onboarding_iam_registration_instance
 			api_types {
 				name = "name"
 				enforcement_method = [ "enforcement_method" ]
+				event_publishing {
+					state = "enabled"
+				}
 				display_name {
 					default = "default"
 					en = "en"
@@ -201,6 +204,12 @@ resource "ibm_onboarding_iam_registration" "onboarding_iam_registration_instance
 					pt_br = "pt_br"
 					zh_tw = "zh_tw"
 					zh_cn = "zh_cn"
+				}
+			}
+			defaults {
+				enforcement_method = [ "enforcement_method" ]
+				event_publishing {
+					state = "enabled"
 				}
 			}
 		}
@@ -568,8 +577,20 @@ Nested schema for **supported_network**:
 				  * Constraints: The maximum length is `256` characters. The minimum length is `0` characters. The value must match regular expression `/./`.
 			* `enforcement_method` - (Optional, List) The enforcement method used for the API type.
 			  * Constraints: The list items must match regular expression `/^[ -~\\s]*$/`. The maximum length is `100` items. The minimum length is `0` items.
+			* `event_publishing` - (Optional, List) Specifies the event publishing state.
+			Nested schema for **event_publishing**:
+				* `state` - (Optional, String) The event publishing state.
+				  * Constraints: Allowable values are: `enabled`, `disabled`.
 			* `name` - (Optional, String) The cloud resource name (CRN) or name of the API type.
 			  * Constraints: The maximum length is `100` characters. The minimum length is `0` characters. The value must match regular expression `/^[ -~\\s]*$/`.
+		* `defaults` - (Optional, List) Specifies default supported network operation behavior that applies when an API type does not explicitly set a value.
+		Nested schema for **defaults**:
+			* `enforcement_method` - (Optional, List) The default enforcement method used for API types.
+			  * Constraints: The list items must match regular expression `/^[ -~\\s]*$/`. The maximum length is `100` items. The minimum length is `0` items.
+			* `event_publishing` - (Optional, List) Specifies the event publishing state.
+			Nested schema for **event_publishing**:
+				* `state` - (Optional, String) The event publishing state.
+				  * Constraints: Allowable values are: `enabled`, `disabled`.
 	* `self_managed_allowlist_enforcement` - (Optional, List) Deprecated field, which is optionally specified only if the service uses additional enforcement mechanisms beyond the primary one.
 	Nested schema for **self_managed_allowlist_enforcement**:
 		* `event_publishing` - (Optional, List) Specifies API types that the service supports. This method is deprecated and is used only for older setups. Don't use this method when you create a context-based restrictions setup for the first time.
@@ -650,7 +671,7 @@ You can import the `ibm_onboarding_iam_registration` resource by using `name`.
 The `name` property can be formed from `product_id`, and `name` in the following format:
 
 <pre>
-&lt;product_id/name
+product_id/name
 </pre>
 * `product_id`: A string. The unique ID of the resource.
 * `name`: A string in the format `pet-store`. The IAM registration name, which must be the programmatic name of the product.

--- a/website/docs/r/onboarding_product.html.markdown
+++ b/website/docs/r/onboarding_product.html.markdown
@@ -67,6 +67,7 @@ After your resource is created, you can read values from the listed arguments an
   * Constraints: The value must match regular expression `/^\\S*$/`.
 * `iam_registration_id` - (String) IAM registration identifier.
   * Constraints: The maximum length is `512` characters. The minimum length is `2` characters. The value must match regular expression `/^\\S*$/`.
+* `oss_id` - (String) The ID of the OSS record connected to the product.
 * `private_catalog_id` - (String) The ID of the private catalog that contains the product. Only applicable for software type products.
   * Constraints: The value must match regular expression `/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/`.
 * `private_catalog_offering_id` - (String) The ID of the linked private catalog product. Only applicable for software type products.


### PR DESCRIPTION
adding metadata.other.location_proxied_by deployments, default values for cbr, also new parameter for them called event_publishing on the IAM service object

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
