### PR TITLE
Add suport for Schematics KMS Setting read

### DIFF
--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -729,6 +729,7 @@ func Provider() *schema.Provider {
 			"ibm_schematics_action":         schematics.DataSourceIBMSchematicsAction(),
 			"ibm_schematics_job":            schematics.DataSourceIBMSchematicsJob(),
 			"ibm_schematics_inventory":      schematics.DataSourceIBMSchematicsInventory(),
+			"ibm_schematics_kms":            schematics.DataSourceIBMSchematicsKMS(),
 			"ibm_schematics_resource_query": schematics.DataSourceIBMSchematicsResourceQuery(),
 			"ibm_schematics_policies":       schematics.DataSourceIbmSchematicsPolicies(),
 			"ibm_schematics_policy":         schematics.DataSourceIbmSchematicsPolicy(),

--- a/ibm/service/schematics/data_source_ibm_schematics_kms.go
+++ b/ibm/service/schematics/data_source_ibm_schematics_kms.go
@@ -1,0 +1,230 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package schematics
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/schematics-go-sdk/schematicsv1"
+)
+
+func DataSourceIBMSchematicsKMS() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMSchematicsKMSRead,
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The location to integrate kms instance. For example, location can be `US` and `EU`.",
+			},
+			"encryption_scheme": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The encryption scheme values. Allowable values: `byok`, `kyok`.",
+			},
+			"resource_group": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The kms instance resource group to integrate.",
+			},
+			"primary_crk": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The primary kms instance details.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The primary kms instance name.",
+						},
+						"kms_private_endpoint": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The primary kms instance private endpoint.",
+						},
+						"key_crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN of the primary root key.",
+						},
+					},
+				},
+			},
+			"secondary_crk": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The secondary kms instance details.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The secondary kms instance name.",
+						},
+						"kms_private_endpoint": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The secondary kms instance private endpoint.",
+						},
+						"key_crn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CRN of the secondary key.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMSchematicsKMSRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	schematicsClient, err := meta.(conns.ClientSession).SchematicsV1()
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead schematicsClient initialization failed: %s", err.Error()), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	// Get location from datasource or provider region
+	var region string
+	if r, ok := d.GetOk("location"); ok {
+		region = r.(string)
+	} else {
+		// Get region from provider
+		sess, err := meta.(conns.ClientSession).BluemixSession()
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed to get session: %s", err.Error()), "ibm_schematics_kms", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		region = sess.Config.Region
+	}
+
+	// Update the service URL based on region if needed
+	if region != "" {
+		schematicsURL, updatedURL, _ := SchematicsEndpointURL(region, meta)
+		if updatedURL {
+			schematicsClient.Service.Options.URL = schematicsURL
+		}
+	}
+
+	// Map region to KMS location (US or EU)
+	kmsLocation := mapRegionToKMSLocation(region)
+
+	getKmsSettingsOptions := &schematicsv1.GetKmsSettingsOptions{}
+	getKmsSettingsOptions.SetLocation(kmsLocation)
+
+	kmsSettings, response, err := schematicsClient.GetKmsSettingsWithContext(context, getKmsSettingsOptions)
+	if err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead GetKmsSettingsWithContext failed with error: %s and response:\n%s", err, response), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	d.SetId(fmt.Sprintf("%s", kmsLocation))
+
+	if err = d.Set("location", kmsSettings.Location); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed with error: %s", err), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("encryption_scheme", kmsSettings.EncryptionScheme); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed with error: %s", err), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	if err = d.Set("resource_group", kmsSettings.ResourceGroup); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed with error: %s", err), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	primaryCrk := []map[string]interface{}{}
+	if kmsSettings.PrimaryCrk != nil {
+		modelMap, err := dataSourceIBMSchematicsKMSPrimaryCrkToMap(kmsSettings.PrimaryCrk)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed: %s", err.Error()), "ibm_schematics_kms", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		primaryCrk = append(primaryCrk, modelMap)
+	}
+	if err = d.Set("primary_crk", primaryCrk); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed with error: %s", err), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	secondaryCrk := []map[string]interface{}{}
+	if kmsSettings.SecondaryCrk != nil {
+		modelMap, err := dataSourceIBMSchematicsKMSSecondaryCrkToMap(kmsSettings.SecondaryCrk)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed: %s", err.Error()), "ibm_schematics_kms", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		secondaryCrk = append(secondaryCrk, modelMap)
+	}
+	if err = d.Set("secondary_crk", secondaryCrk); err != nil {
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("dataSourceIBMSchematicsKMSRead failed with error: %s", err), "ibm_schematics_kms", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
+	}
+
+	return nil
+}
+
+func dataSourceIBMSchematicsKMSPrimaryCrkToMap(model *schematicsv1.KMSSettingsPrimaryCrk) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.KmsName != nil {
+		modelMap["kms_name"] = *model.KmsName
+	}
+	if model.KmsPrivateEndpoint != nil {
+		modelMap["kms_private_endpoint"] = *model.KmsPrivateEndpoint
+	}
+	if model.KeyCrn != nil {
+		modelMap["key_crn"] = *model.KeyCrn
+	}
+	return modelMap, nil
+}
+
+func dataSourceIBMSchematicsKMSSecondaryCrkToMap(model *schematicsv1.KMSSettingsSecondaryCrk) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.KmsName != nil {
+		modelMap["kms_name"] = *model.KmsName
+	}
+	if model.KmsPrivateEndpoint != nil {
+		modelMap["kms_private_endpoint"] = *model.KmsPrivateEndpoint
+	}
+	if model.KeyCrn != nil {
+		modelMap["key_crn"] = *model.KeyCrn
+	}
+	return modelMap, nil
+}
+
+// mapRegionToKMSLocation maps IBM Cloud regions to KMS location (US or EU)
+func mapRegionToKMSLocation(region string) string {
+	switch region {
+	case "us-south", "us-east":
+		return "US"
+	case "eu-de", "eu-gb":
+		return "EU"
+	default:
+		// For other regions or if already US/EU, return as-is
+		return region
+	}
+}

--- a/ibm/service/schematics/data_source_ibm_schematics_kms_test.go
+++ b/ibm/service/schematics/data_source_ibm_schematics_kms_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2024 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package schematics_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+)
+
+func TestAccIbmSchematicsKMSDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmSchematicsKMSDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "location"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmSchematicsKMSDataSourceWithLocation(t *testing.T) {
+	kmsLocation := "us-south"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmSchematicsKMSDataSourceConfig(kmsLocation),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "location"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIbmSchematicsKMSDataSourceAllArgs(t *testing.T) {
+	kmsLocation := "us-south"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIbmSchematicsKMSDataSourceConfig(kmsLocation),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "location"),
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "encryption_scheme"),
+					resource.TestCheckResourceAttrSet("data.ibm_schematics_kms.schematics_kms_instance", "resource_group"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIbmSchematicsKMSDataSourceConfigBasic() string {
+	return `
+		data "ibm_schematics_kms" "schematics_kms_instance" {
+		}
+	`
+}
+
+func testAccCheckIbmSchematicsKMSDataSourceConfig(kmsLocation string) string {
+	return fmt.Sprintf(`
+		data "ibm_schematics_kms" "schematics_kms_instance" {
+			location = "%s"
+		}
+	`, kmsLocation)
+}

--- a/website/docs/d/schematics_kms.html.markdown
+++ b/website/docs/d/schematics_kms.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "ibm"
+page_title: "IBM : ibm_schematics_kms"
+description: |-
+  Get information about schematics_kms
+subcategory: "Schematics"
+---
+
+# ibm_schematics_kms
+
+Retrieve the KMS (Key Management Service) settings integrated with IBM Cloud Schematics for a given location. This enables retrieval of BYOK (Bring Your Own Key) and KYOK (Keep Your Own Key) configuration details per geographic region. For more information, about Schematics KMS settings, see [Securing your data in Schematics](https://cloud.ibm.com/docs/schematics?topic=schematics-secure-data).
+
+## Example Usage
+
+```hcl
+data "ibm_schematics_kms" "schematics_kms" {
+	location = "us-south"
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+* `location` - (Optional, String) Location supported by IBM Cloud Schematics service.  
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+* `id` - The unique identifier of the schematics_kms.
+* `encryption_scheme` - (String) The encryption scheme values. Allowable values: `byok`, `kyok`.
+* `resource_group` - (String) The kms instance resource group to integrate.
+
+* `primary_crk` - (List) The primary kms instance details.
+Nested scheme for **primary_crk**:
+	* `kms_name` - (String) The primary kms instance name.
+	* `kms_private_endpoint` - (String) The primary kms instance private endpoint.
+	* `key_crn` - (String) The CRN of the primary root key.
+
+* `secondary_crk` - (List) The secondary kms instance details.
+Nested scheme for **secondary_crk**:
+	* `kms_name` - (String) The secondary kms instance name.
+	* `kms_private_endpoint` - (String) The secondary kms instance private endpoint.
+	* `key_crn` - (String) The CRN of the secondary key.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
[WARN] Set the environment variable IBM_IS_ADMIN_CONFIG for testing ibm_container_cluster_config datasource else tests will fail if this is not set correctly
=== RUN   TestAccIbmSchematicsKMSDataSourceBasic
--- PASS: TestAccIbmSchematicsKMSDataSourceBasic (32.72s)
=== RUN   TestAccIbmSchematicsKMSDataSourceWithLocation
--- PASS: TestAccIbmSchematicsKMSDataSourceWithLocation (28.55s)
=== RUN   TestAccIbmSchematicsKMSDataSourceAllArgs
--- PASS: TestAccIbmSchematicsKMSDataSourceAllArgs (31.32s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/schematics	95.994s
...
```
