### PR TITLE
Update CM acceptance tests and add documentation for CM override values for cm_validation resource

### DIFF
--- a/ibm/service/catalogmanagement/data_source_ibm_cm_version_test.go
+++ b/ibm/service/catalogmanagement/data_source_ibm_cm_version_test.go
@@ -42,6 +42,8 @@ func TestAccIBMCmVersionDataSourceSimpleArgs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_cm_version.cm_version", "version_locator"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_version.cm_version", "long_description"),
 					resource.TestCheckResourceAttrSet("data.ibm_cm_version.cm_version", "is_consumable"),
+					resource.TestCheckResourceAttr("data.ibm_cm_version.cm_version", "validation.#", "1"), // check that it is set and there is exactly 1 item.
+					resource.TestCheckResourceAttr("data.ibm_cm_version.cm_version", "validation.0.target.#", "0"),
 				),
 			},
 		},
@@ -50,7 +52,8 @@ func TestAccIBMCmVersionDataSourceSimpleArgs(t *testing.T) {
 
 func testAccCheckIBMCmVersionDataSourceConfig(versionZipurl string, versionTargetVersion string, versionIncludeConfig string) string {
 	return fmt.Sprintf(`
-		resource "ibm_cm_catalog" "cm_catalog" {
+
+	    resource "ibm_cm_catalog" "cm_catalog" {
 			label = "data_source_version_test_catalog_label"
 			kind = "offering"
 		}

--- a/ibm/service/catalogmanagement/resource_ibm_cm_validation_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_validation_test.go
@@ -16,7 +16,9 @@ import (
 
 func TestAccIBMCmValidationSimpleArgs(t *testing.T) {
 	var conf catalogmanagementv1.Version
-	versionLocator := "dba7e7dd-2bd7-4fcd-a846-4c370eab2672.98ba725b-86fa-4c6a-8430-70f38ec988da"
+	// this needs to be a real VL for a version that can be validated (i.e. the version is not published/ready).  A real validation
+	// will be done, so there will be a workspace created.
+	versionLocator := "f418eaf7-602a-472d-9e9f-ab75a7c193ab.46f1f0e2-3205-41d8-99e1-14dad4e1dfb8"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -28,6 +30,13 @@ func TestAccIBMCmValidationSimpleArgs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMCmValidationExists("ibm_cm_validation.cm_validation", conf),
 					resource.TestCheckResourceAttr("ibm_cm_validation.cm_validation", "version_locator", versionLocator),
+				),
+			},
+			{ // step 2 will wait for step 1 ^^ to finish.  'target' is not set until step 1 finishes.
+				Config: testAccCheckIBMCmValidationSimpleConfig(versionLocator),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cm_validation.cm_validation", "state", "valid"),         // state = valid
+					resource.TestCheckResourceAttrSet("ibm_cm_validation.cm_validation", "target.workspace_id"), // Check workspace_id key exists and has a value
 				),
 			},
 		},
@@ -52,9 +61,9 @@ func testAccCheckIBMCmValidationSimpleConfig(versionLocator string) string {
 			}
 
 			schematics {
-				name = "workspace name"
+				name = "acceptance-test-workspace"
 				description = "workspace description"
-				region = "us-south"
+				region = "eu-de"
 			}
 		}
 	`, versionLocator)

--- a/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
+++ b/ibm/service/catalogmanagement/resource_ibm_cm_version_test.go
@@ -53,6 +53,8 @@ func TestAccIBMCmVersionSimpleArgs(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_cm_version.cm_version", "zipurl", zipurl),
 					resource.TestCheckResourceAttr("ibm_cm_version.cm_version", "target_version", targetVersion),
 					resource.TestCheckResourceAttr("ibm_cm_version.cm_version", "include_config", includeConfig),
+					resource.TestCheckResourceAttr("ibm_cm_version.cm_version", "validation.#", "1"),          // check that it is set and there is exactly 1 item.
+					resource.TestCheckResourceAttr("ibm_cm_version.cm_version", "validation.0.target.#", "0"), // check that is it null
 				),
 			},
 		},
@@ -133,6 +135,7 @@ func TestAccIBMCmVersionVSI(t *testing.T) {
 
 func testAccCheckIBMCmVersionConfigBasic() string {
 	return fmt.Sprintf(`
+
 		resource "ibm_cm_catalog" "cm_catalog" {
 			label = "test_tf_catalog_label_1"
 			kind = "offering"

--- a/website/docs/r/cm_validation.html.markdown
+++ b/website/docs/r/cm_validation.html.markdown
@@ -23,6 +23,19 @@ resource "ibm_cm_validation" "cm_version_validation" {
   mark_version_consumable = true
 }
 ```
+where each 'example_override_key' is the name of one of the input variables.  The value should be appropriate for the input variable.  Override 
+values are optional and are one way to provide a value for an input that is different from the default value defined or provide a value when no default
+value has been defined.
+
+For example: 
+``` 
+resource "ibm_cm_validation" "cm_version_validation" {
+   version_locator = "11111111-1111-1111-111111111111.22222222-2222-2222-2222-222222222222"
+   override_values = {
+     "color" = "red"
+   }
+}
+```
 
 ## Argument Reference
 


### PR DESCRIPTION
Update documentation for resource ibm_cm_validation regarding the override values.
Update acceptance CM acceptance tests to validate the "target" validation property.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMCmVersionSimpleArgs
--- PASS: TestAccIBMCmVersionSimpleArgs (21.80s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/catalogmanagement	23.890s
=== RUN   TestAccIBMCmVersionDataSourceSimpleArgs
--- PASS: TestAccIBMCmVersionDataSourceSimpleArgs (25.72s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/catalogmanagement	27.766s
...
```
Additional info, this addresses issue https://github.ibm.com/ibmud/content-catalog/issues/6190