### PR TITLE
docs: fix Transit Gateway docs missing opening front matter delimiter

### DIFF
--- a/website/docs/d/tg_gateway.html.markdown
+++ b/website/docs/d/tg_gateway.html.markdown
@@ -1,3 +1,4 @@
+---
 
 subcategory: "Transit Gateway"
 layout: "ibm"

--- a/website/docs/r/tg_connection.html.markdown
+++ b/website/docs/r/tg_connection.html.markdown
@@ -1,3 +1,4 @@
+---
 
 subcategory: "Transit Gateway"
 layout: "ibm"
@@ -121,4 +122,4 @@ The `ibm_tg_connection` resource can be imported by using transit gateway ID and
 $ terraform import ibm_tg_connection.example 5ffda12064634723b079acdb018ef308/cea6651a-bd0a-4438-9f8a-a0770bbf3ebb
 
 ```
----
+---website/docs/r/tg_connection_tunnel.html.markdown

--- a/website/docs/r/tg_connection_tunnel.html.markdown
+++ b/website/docs/r/tg_connection_tunnel.html.markdown
@@ -1,3 +1,4 @@
+---
 
 subcategory: "Transit Gateway"
 layout: "ibm"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6707

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
