### PR TITLE
feat(database): Add backup_id support for Gen2 instances

### DIFF
--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -141,6 +141,88 @@ func isGen2Plan(plan string) bool {
 	return gen2Pattern.MatchString(strings.ToLower(plan))
 }
 
+// validateGen2BackupCRN validates if a backup CRN is allowed for Gen2 database restore.
+// Returns nil if the backup is allowed (Gen2 coupled or decoupled backup).
+// Returns an error if the backup is not allowed (Classic backup).
+//
+// Three backup types:
+//
+//  1. Classic backup - NOT ALLOWED
+//     CRN: crn:v1:bluemix:public:databases-for-*:region:a/account:instance-id:backup:backup-id
+//     Has instance ID in CRN (8th section), instance PlanId does NOT contain "-gen2"
+//
+//  2. Gen2 "coupled" backup - ALLOWED
+//     CRN: crn:v1:bluemix:public:databases-for-*:region:a/account:instance-id:backup:backup-id
+//     Has instance ID in CRN (8th section), instance PlanId DOES contain "-gen2"
+//
+//  3. Gen2 "decoupled" backup - ALLOWED
+//     CRN: crn:v1:bluemix:public:databases-independent-backups:region:a/account:backup-id::
+//     Contains "databases-independent-backups" in 5th section, no instance ID
+func validateGen2BackupCRN(backupCRN string, meta interface{}) error {
+	if backupCRN == "" {
+		return nil
+	}
+
+	// Parse CRN
+	parts := strings.Split(backupCRN, ":")
+	if len(parts) < 10 {
+		return fmt.Errorf("invalid backup CRN format: expected 10 parts, got %d", len(parts))
+	}
+
+	// Check if it's a decoupled backup (databases-independent-backups)
+	serviceName := parts[4] // 5th section (0-indexed)
+	if serviceName == "databases-independent-backups" {
+		// Decoupled backup - ALLOWED
+		return nil
+	}
+
+	// It's a coupled backup - need to check if the source instance is Gen2
+	instanceID := parts[7] // 8th section (0-indexed)
+	if instanceID == "" {
+		return fmt.Errorf("backup CRN does not contain instance ID and is not a decoupled backup")
+	}
+
+	// Construct instance CRN by clearing last 2 sections (resource-type and resource)
+	instanceCRN := strings.Join(parts[:8], ":") + "::"
+
+	// Get the instance to check its plan
+	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
+	if err != nil {
+		return fmt.Errorf("failed to initialize resource controller client: %w", err)
+	}
+
+	instance, response, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
+		ID: &instanceCRN,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get backup source instance %s: %w (response: %v)", instanceCRN, err, response)
+	}
+
+	if instance.ResourcePlanID == nil {
+		return fmt.Errorf("backup source instance %s has no resource plan ID", instanceCRN)
+	}
+
+	// Get the plan name to check if it's Gen2
+	rsCatClient, err := meta.(conns.ClientSession).ResourceCatalogAPI()
+	if err != nil {
+		return fmt.Errorf("failed to initialize catalog client: %w", err)
+	}
+
+	rsCatRepo := rsCatClient.ResourceCatalog()
+	servicePlan, err := rsCatRepo.GetServicePlanName(*instance.ResourcePlanID)
+	if err != nil {
+		return fmt.Errorf("failed to get service plan for backup source instance: %w", err)
+	}
+
+	// Check if the plan is Gen2
+	if !isGen2Plan(servicePlan) {
+		return fmt.Errorf("backup_id references a Classic backup (plan: %s). Gen2 databases can only restore from Gen2 coupled backups or Gen2 decoupled backups. Please use a Gen2 backup CRN", servicePlan)
+	}
+
+	// Gen2 coupled backup - ALLOWED
+	return nil
+}
+
 // extractLocationFromCRN extracts the location (region) from an IBM Cloud CRN.
 // CRN format: crn:version:cname:ctype:service-name:location:scope:service-instance:resource-type:resource
 // Returns the location field (index 5) or an error if the CRN is invalid.

--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -146,38 +146,28 @@ func isGen2Plan(plan string) bool {
 // Returns an error if the backup is not allowed (Classic backup).
 //
 // Three backup types:
-//
-//  1. Classic backup - NOT ALLOWED
-//     CRN: crn:v1:bluemix:public:databases-for-*:region:a/account:instance-id:backup:backup-id
-//     Has instance ID in CRN (8th section), instance PlanId does NOT contain "-gen2"
-//
+//  1. Classic backup - NOT ALLOWED at this point
 //  2. Gen2 "coupled" backup - ALLOWED
-//     CRN: crn:v1:bluemix:public:databases-for-*:region:a/account:instance-id:backup:backup-id
-//     Has instance ID in CRN (8th section), instance PlanId DOES contain "-gen2"
-//
 //  3. Gen2 "decoupled" backup - ALLOWED
-//     CRN: crn:v1:bluemix:public:databases-independent-backups:region:a/account:backup-id::
-//     Contains "databases-independent-backups" in 5th section, no instance ID
 func validateGen2BackupCRN(backupCRN string, meta interface{}) error {
 	if backupCRN == "" {
 		return nil
 	}
 
-	// Parse CRN
 	parts := strings.Split(backupCRN, ":")
 	if len(parts) < 10 {
 		return fmt.Errorf("invalid backup CRN format: expected 10 parts, got %d", len(parts))
 	}
 
 	// Check if it's a decoupled backup (databases-independent-backups)
-	serviceName := parts[4] // 5th section (0-indexed)
+	serviceName := parts[4]
 	if serviceName == "databases-independent-backups" {
 		// Decoupled backup - ALLOWED
 		return nil
 	}
 
 	// It's a coupled backup - need to check if the source instance is Gen2
-	instanceID := parts[7] // 8th section (0-indexed)
+	instanceID := parts[7]
 	if instanceID == "" {
 		return fmt.Errorf("backup CRN does not contain instance ID and is not a decoupled backup")
 	}

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -303,7 +303,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				ValidateFunc: validate.InvokeValidator("ibm_database", "service_endpoints"),
 			},
 			"backup_id": {
-				Description:      "The CRN of backup source database. Gen2: Plan fails if set. Restore from backup is not yet implemented for Gen2 instances.",
+				Description:      "The CRN of backup source database. Gen2: Supports restoring from Gen2 coupled backups (from Gen2 instances) and Gen2 decoupled backups (databases-independent-backups). Classic backups are not supported for Gen2 instances.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: flex.ApplyOnce,
@@ -319,7 +319,7 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				Optional:    true,
 			},
 			"async_restore": {
-				Description:      "Option to support FAST PG Restore. Only applicable when restoring a PostgreSQL instance. Gen2: Accepted but ignored. Async restore requires backup_id support which is not yet implemented for Gen2 instances.",
+				Description:      "Option to support FAST PG Restore. Only applicable when restoring a PostgreSQL instance from backup_id. Gen2: Accepted but ignored (Classic-only feature).",
 				Type:             schema.TypeBool,
 				Optional:         true,
 				DiffSuppressFunc: flex.ApplyOnce,

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -369,14 +369,15 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 	// Handle encryption
 	g.addEncryptionConfig(d, dataservices)
 
+	// Add restore_backup_id if provided (for restore from backup)
+	// Note: Gen2 uses "restore_backup_id" inside dataservices, not "backup_id" at top level
+	if backupID, ok := d.GetOk("backup_id"); ok {
+		dataservices["restore_backup_id"] = backupID.(string)
+	}
+
 	// Build final parameters structure
 	parameters := map[string]interface{}{
 		"dataservices": dataservices,
-	}
-
-	// Add backup_id if provided (for restore from backup)
-	if backupID, ok := d.GetOk("backup_id"); ok {
-		parameters["backup_id"] = backupID.(string)
 	}
 
 	return parameters, nil

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -24,7 +24,6 @@ import (
 )
 
 var gen2UnsupportedAttrs = []string{
-	"backup_id",
 	"point_in_time_recovery_deployment_id",
 	"point_in_time_recovery_time",
 	"backup_policy",
@@ -112,9 +111,6 @@ var gen2AttrGuidance = map[string]string{
 	"adminpassword": "Gen2 databases do not create default admin user during provisioning.\n" +
 		"Please use the Terraform resource 'ibm_resource_key' to create and manage one.\n" +
 		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_key",
-
-	"backup_id": "Gen2 databases do not support restoring from backups using the 'backup_id' attribute at this point.\n" +
-		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database",
 
 	"point_in_time_recovery_deployment_id": "Gen2 databases do not support restoring from backups using the 'point_in_time_recovery_deployment_id' attribute at this point.\n" +
 		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database",
@@ -343,9 +339,16 @@ func (g *resourceIBMDatabaseGen2Backend) setResourceGroup(d *schema.ResourceData
 }
 
 // buildGen2Parameters constructs the Gen2-specific parameters structure.
-// Includes database configuration and encryption settings.
-// Note: backup_id restore and PITR are not supported in Gen2.
+// Includes database configuration, encryption settings, and backup_id for restore.
+// Note: PITR is not supported in Gen2. backup_id is validated to ensure only Gen2 backups are used.
 func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceData, serviceName string, meta interface{}, catalogCRN string) (map[string]interface{}, error) {
+	// Validate backup_id if provided (only Gen2 coupled and decoupled backups are allowed at this point)
+	if backupID, ok := d.GetOk("backup_id"); ok {
+		if err := validateGen2BackupCRN(backupID.(string), meta); err != nil {
+			return nil, err
+		}
+	}
+
 	// Get the database type for the dataservices key
 	dbType := getDatabaseTypeFromResourceID(serviceName)
 	if dbType == "" {
@@ -369,6 +372,11 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 	// Build final parameters structure
 	parameters := map[string]interface{}{
 		"dataservices": dataservices,
+	}
+
+	// Add backup_id if provided (for restore from backup)
+	if backupID, ok := d.GetOk("backup_id"); ok {
+		parameters["backup_id"] = backupID.(string)
 	}
 
 	return parameters, nil

--- a/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
@@ -73,27 +73,27 @@ func TestGen2UnsupportedAttrsValidation(t *testing.T) {
 
 	t.Run("unsupported attr present returns error", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"backup_id": "backup-123",
+			"adminpassword": "very-secure-password-123",
 		})
 
 		err := g.ValidateUnsupportedAttrsData(d)
 
-		requireErrContains(t, err, "backup_id")
+		requireErrContains(t, err, "adminpassword")
 		requireErrContains(t, err, "not supported")
 	})
 
 	t.Run("multiple unsupported attrs present are all listed", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"backup_id":                 "backup-123",
 			"adminpassword":             "very-secure-password-123",
 			"backup_encryption_key_crn": "crn:v1:bluemix:public:kms:us-south:a/account-id:instance-id:key:key-id",
+			"remote_leader_id":          "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/account-id:instance-id::",
 		})
 
 		err := g.ValidateUnsupportedAttrsData(d)
 
-		requireErrContains(t, err, "backup_id")
 		requireErrContains(t, err, "adminpassword")
 		requireErrContains(t, err, "backup_encryption_key_crn")
+		requireErrContains(t, err, "remote_leader_id")
 	})
 
 	t.Run("ignored attr only does not return error", func(t *testing.T) {
@@ -110,13 +110,13 @@ func TestGen2UnsupportedAttrsValidation(t *testing.T) {
 
 	t.Run("ignored and unsupported attrs returns error for unsupported attrs only", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"backup_id":     "backup-123",
+			"adminpassword": "very-secure-password-123",
 			"configuration": `{"max_connections": 100}`,
 		})
 
 		err := g.ValidateUnsupportedAttrsData(d)
 
-		requireErrContains(t, err, "backup_id")
+		requireErrContains(t, err, "adminpassword")
 		requireErrNotContains(t, err, "configuration")
 	})
 }
@@ -195,13 +195,13 @@ func TestGen2IgnoredAttrsWarningsAreIndependentFromUnsupportedAttrs(t *testing.T
 	g := &resourceIBMDatabaseGen2Backend{}
 
 	d := testGen2DatabaseResourceData(t, map[string]interface{}{
-		"backup_id":                   "backup-123",
+		"adminpassword":               "very-secure-password-123",
 		"configuration":               `{"max_connections": 100}`,
 		"version_upgrade_skip_backup": true,
 	})
 
 	err := g.ValidateUnsupportedAttrsData(d)
-	requireErrContains(t, err, "backup_id")
+	requireErrContains(t, err, "adminpassword")
 	requireErrNotContains(t, err, "configuration")
 	requireErrNotContains(t, err, "version_upgrade_skip_backup")
 
@@ -224,7 +224,7 @@ func TestGen2DiagnosticsCanContainErrorsAndWarnings(t *testing.T) {
 		{
 			Severity: diag.Error,
 			Summary:  "unsupported attr error",
-			Detail:   "backup_id is not supported",
+			Detail:   "adminpassword is not supported",
 		},
 	}
 

--- a/ibm/service/database/resource_ibm_database_gen2_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_test.go
@@ -54,16 +54,16 @@ func TestGen2BackendCreate(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "create_with_backup_id",
+			name: "create_with_classic_backup_id",
 			resourceData: map[string]interface{}{
 				"service":   "databases-for-postgresql",
-				"plan":      "standard",
+				"plan":      "standard-gen2",
 				"name":      "test-db",
 				"location":  "us-south",
-				"backup_id": "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:backup-id",
+				"backup_id": "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/abc123:instance-id:backup:backup-id",
 			},
 			expectedError: true,
-			errorContains: "backup_id is not supported for Gen2 databases",
+			errorContains: "Classic backup",
 		},
 		{
 			name: "create_with_remote_leader",
@@ -922,7 +922,6 @@ func TestGen2ConfigureInstancePipeline(t *testing.T) {
 // TestGen2UnsupportedAttributesList tests the gen2UnsupportedAttrs list
 func TestGen2UnsupportedAttributesList(t *testing.T) {
 	expectedUnsupported := []string{
-		"backup_id",
 		"point_in_time_recovery_deployment_id",
 		"point_in_time_recovery_time",
 		"backup_policy",

--- a/ibm/service/database/resource_ibm_database_postgresql_test.go
+++ b/ibm/service/database/resource_ibm_database_postgresql_test.go
@@ -5,7 +5,6 @@ package database_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -67,11 +66,13 @@ func TestAccIBMDatabaseInstancePostgresBasic(t *testing.T) {
 	})
 }
 
-func TestAccIBMDatabaseInstancePostgresGen2Invalid(t *testing.T) {
+func TestAccIBMDatabaseInstancePostgresGen2Basic(t *testing.T) {
 	t.Parallel()
 	databaseResourceGroup := "default"
+	var databaseInstanceOne string
 	rnd := fmt.Sprintf("tf-Pgress-%d", acctest.RandIntRange(10, 100))
 	testName := rnd
+	name := "ibm_database." + testName
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -79,8 +80,17 @@ func TestAccIBMDatabaseInstancePostgresGen2Invalid(t *testing.T) {
 		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckIBMDatabaseInstancePostgreGen2Invalid(databaseResourceGroup, testName),
-				ExpectError: regexp.MustCompile(`allowlist`),
+				Config: testAccCheckIBMDatabaseInstancePostgreGen2Basic(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-postgresql"),
+					resource.TestCheckResourceAttr(name, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(name, "location", "ca-mon"),
+					resource.TestCheckResourceAttr(name, "groups.0.disk.0.allocation_mb", "10240"),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "private"),
+					resource.TestCheckResourceAttr(name, "tags.#", "1"),
+				),
 			},
 		},
 	})
@@ -414,7 +424,7 @@ func testAccCheckIBMDatabaseInstancePostgresBasic(databaseResourceGroup string, 
 	`, databaseResourceGroup, name, acc.Region())
 }
 
-func testAccCheckIBMDatabaseInstancePostgreGen2Invalid(databaseResourceGroup string, name string) string {
+func testAccCheckIBMDatabaseInstancePostgreGen2Basic(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
 		name = "%[1]s"
@@ -426,30 +436,20 @@ func testAccCheckIBMDatabaseInstancePostgreGen2Invalid(databaseResourceGroup str
 		service                      = "databases-for-postgresql"
 		plan                         = "standard-gen2"
 		location                     = "%[3]s"
-		adminpassword                = "secure-Password12345"
-		service_endpoints            = "public"
+		service_endpoints            = "private"
 		group {
 			group_id = "member"
-
-			memory {
-			  allocation_mb = 4096
+			members {
+				allocation_count = 2
 			}
 			host_flavor {
-				id = "multitenant"
+				id = "bx3d.4x20"
 			}
 			disk {
 			  allocation_mb = 10240
 			}
 		}
 		tags                         = ["one:two"]
-		users {
-			name     = "user123"
-			password = "secure-Password12345"
-		}
-		allowlist {
-			address     = "172.168.1.2/32"
-			description = "desc1"
-		}
 		configuration                = <<CONFIGURATION
 		{
 		  "wal_level": "logical",
@@ -463,7 +463,7 @@ func testAccCheckIBMDatabaseInstancePostgreGen2Invalid(databaseResourceGroup str
 			plugin_type = "wal2json"
 		}
 	}
-	`, databaseResourceGroup, name, acc.Region())
+	`, databaseResourceGroup, name, "ca-mon")
 }
 
 func testAccCheckIBMDatabaseInstancePostgresFullyspecified(databaseResourceGroup string, name string) string {

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -741,9 +741,11 @@ Review the argument reference that you can specify for your resource.
          - `rate_period_seconds` - (Optional, Integer) Auto scaling rate period in seconds.
          - `rate_units` - (Optional, String) Auto scaling rate in units.
 
-- `backup_id` - (Optional, String) The CRN of a backup resource to restore from. The backup is created by a database deployment with the same service ID. The backup is loaded after provisioning and the new deployment starts up that uses that data. A backup CRN is in the format `crn:v1:<…>:backup:`. If omitted, the database is provisioned empty.
+- `backup_id` - (Optional, String) The CRN of a backup resource to restore from. The backup is loaded after provisioning and the new deployment starts up that uses that data. If omitted, the database is provisioned empty.
 
-  **Gen2:** Plan fails if set. Restore from backup is not yet implemented for Gen2 instances.
+  **Classic:** Supports backups from Classic instances. Backup CRN format: `crn:v1:<…>:backup:<backup-id>`.
+
+  **Gen2:** Supports restoring from Gen2 coupled backups (from Gen2 instances with format `crn:v1:<…>:backup:<backup-id>`) and Gen2 decoupled backups (independent backups with format `crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account>:<backup-id>::`). Classic backups are not supported for Gen2 instances and will cause plan to fail with a validation error.
 
 - `backup_encryption_key_crn`- (Optional, Forces new resource, String) The CRN of a key protect key, that you want to use for encrypting disk that holds deployment backups. A key protect CRN is in the format `crn:v1:<...>:key:`. Backup_encryption_key_crn can be added only at the time of creation and no update support  are available.
 
@@ -813,7 +815,7 @@ Review the argument reference that you can specify for your resource.
 - `name` - (Required, String) A descriptive name that is used to identify the database instance. The name must not include spaces.
 - `offline_restore` - (Optional, Boolean) Enable or disable the Offline Restore option while performing a Point-in-time Recovery for MongoDB EE in a disaster recovery scenario when the source region is unavailable, see [Point-in-time Recovery](https://cloud.ibm.com/docs/databases-for-mongodb?topic=databases-for-mongodb-pitr&interface=api#pitr-offline-restore)
 
-  **Gen2:** Accepted but ignored. Offline restore requires `backup_id` support which is not yet implemented for Gen2 instances.
+  **Gen2:** Accepted but ignored (Classic-only feature).
 - `plan` - (Required, Forces new resource, String) The name of the service plan that you choose for your instance. The plan determines whether your instance uses Classic or Gen2 infrastructure:
   - **Classic plans**: `standard`, `enterprise`, `platinum`
   - **Gen2 plans**: `standard-gen2`, `enterprise-gen2`, `platinum-gen2`
@@ -833,9 +835,9 @@ Review the argument reference that you can specify for your resource.
 - `skip_initial_backup` - (Optional, Boolean) Should only be set when promoting a read-only replica. By setting this value to `true`, you skip the initial backup that would normally be taken upon promotion. Skipping the initial backup means that your replica becomes available more quickly, but there is no immediate backup available. The default is `false`. For more information, see [Configuring Read-only Replicas]
 
   **Gen2:** Accepted but ignored (Classic-only feature for read replica promotion).
-- `async_restore` - (Optional, Boolean) Should only be set for asynchronous restore. By setting this value to `true`, the restore is initiated as an asynchronous operation, which helps to reduce end-to-end restore time. Only applicable when restoring a PostgreSQL instance.
+- `async_restore` - (Optional, Boolean) Should only be set for asynchronous restore. By setting this value to `true`, the restore is initiated as an asynchronous operation, which helps to reduce end-to-end restore time. Only applicable when restoring a PostgreSQL instance from `backup_id`.
 
-  **Gen2:** Accepted but ignored. Async restore requires `backup_id` support which is not yet implemented for Gen2 instances.
+  **Gen2:** Accepted but ignored (Classic-only feature).
 - `resource_group_id` - (Optional, Forces new resource, String)  The ID of the resource group where you want to create the instance. To retrieve this value, run `ibmcloud resource groups` or use the `ibm_resource_group` data source. If no value is provided, the `default` resource group is used.
 - `service` - (Required, Forces new resource, String) The type of Cloud Databases that you want to create. Only the following services are currently accepted: `databases-for-etcd`, `databases-for-postgresql`, `databases-for-redis`, `databases-for-valkey`, `databases-for-elasticsearch`, `messages-for-rabbitmq`,`databases-for-mongodb`,`databases-for-mysql`, and `databases-for-enterprisedb`.
 
@@ -905,7 +907,7 @@ The following table summarizes feature availability for Classic and Gen2 plans:
 | Tags | ✅ Supported | ✅ Supported |
 | Encryption (key_protect_key) | ✅ Supported | ✅ Supported |
 | Backup encryption (backup_encryption_key_crn) | ✅ Supported | ❌ Plan fails if set |
-| Restore from backup (backup_id) | ✅ Supported | ❌ Plan fails if set |
+| Restore from backup (backup_id) | ✅ Supported (Classic backups) | ⚠️ Supported (Gen2 backups only) |
 | Point-in-time recovery (point_in_time_recovery_deployment_id, point_in_time_recovery_time) | ✅ Supported | ❌ Plan fails if set |
 | Offline restore (MongoDB) | ✅ Supported | ❌ Accepted but ignored |
 | Async restore (PostgreSQL) | ✅ Supported | ❌ Accepted but ignored |
@@ -927,7 +929,8 @@ The following table summarizes feature availability for Classic and Gen2 plans:
 Gen2 plans handle unsupported features in two ways:
 
 - **Plan fails if set**: Terraform plan will fail with a validation error if these attributes are configured. You must remove them from your configuration to use Gen2 plans.
-  - Examples: `backup_id`, `point_in_time_recovery_deployment_id`, `point_in_time_recovery_time`, `users`, `allowlist`, `adminpassword`, `remote_leader_id`, memory/cpu in `group`
+  - Examples: `point_in_time_recovery_deployment_id`, `point_in_time_recovery_time`, `users`, `allowlist`, `adminpassword`, `remote_leader_id`, memory/cpu in `group`
+  - Note: `backup_id` is supported for Gen2 but only with Gen2 backup CRNs. Using a Classic backup CRN will cause plan to fail.
 
 - **Accepted but ignored**: These attributes can remain in your configuration for easier migration, but they have no effect on Gen2 instances. They are silently ignored during apply and cleared during read operations.
   - Examples: `auto_scaling`, `configuration`, `logical_replication_slot`, `offline_restore`, `async_restore`


### PR DESCRIPTION
Enable backup_id attribute for Gen2 database instances with validation to ensure only Gen2 backups are used for restore operations.

Changes:
- Add validateGen2BackupCRN() helper function to validate backup CRN types
- Support Gen2 coupled backups (from Gen2 instances with -gen2 plan)
- Support Gen2 decoupled backups (databases-independent-backups)
- Reject Classic backups with clear validation error
- Remove backup_id from gen2UnsupportedAttrs array
- Update schema descriptions and documentation
- Update tests to reflect new backup_id support
- Use consistent 'Classic' terminology throughout

The validation logic identifies backup types by:
1. Checking for 'databases-independent-backups' in CRN (decoupled - allowed)
2. Extracting instance CRN from coupled backup CRN
3. Verifying source instance plan contains '-gen2' using isGen2Plan()
4. Rejecting Classic backups with informative error message

This allows users to restore Gen2 instances from Gen2 backups while preventing incompatible Classic backup usage.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMDatabaseInstancePostgresGen2Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/database -v -run=TestAccIBMDatabaseInstancePostgresGen2Basic -timeout 700m
...
=== RUN   TestAccIBMDatabaseInstancePostgresGen2Basic
=== PAUSE TestAccIBMDatabaseInstancePostgresGen2Basic
=== CONT  TestAccIBMDatabaseInstancePostgresGen2Basic
--- PASS: TestAccIBMDatabaseInstancePostgresGen2Basic (1083.29s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1084.903s
...
```
