### PR TITLE
docs: Fix endpoint_type allowed values for EN Integration

### DIFF
--- a/website/docs/d/logs_outgoing_webhook.html.markdown
+++ b/website/docs/d/logs_outgoing_webhook.html.markdown
@@ -45,7 +45,7 @@ Nested schema for **ibm_event_notifications**:
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
 	* `region_id` - (String) The region ID of the selected IBM Event Notifications instance.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `4` characters. The value must match regular expression `/^[a-z]{2}-[a-z]+$/`.
-	* `endpoint_type` - (String) The endpoint type of integration.
+	* `endpoint_type` - (String) The endpoint type of integration. Possible values: `default_or_public`, `private`.
   * `source_id` - (String) The ID of the created source in the IBM Event Notifications instance. Corresponds to the Cloud Logs instance crn. Not required when creating an Outbound Integration.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$`.
 	* `source_name` - (String) The name of the created source in the IBM Event Notifications instance. Not required when creating an Outbound Integration.

--- a/website/docs/r/logs_outgoing_webhook.html.markdown
+++ b/website/docs/r/logs_outgoing_webhook.html.markdown
@@ -39,7 +39,7 @@ Nested schema for **ibm_event_notifications**:
 	  * Constraints: The maximum length is `36` characters. The minimum length is `36` characters. The value must match regular expression `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`.
 	* `region_id` - (Required, String) The region ID of the selected IBM Event Notifications instance.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `4` characters. The value must match regular expression `/^[a-z]{2}-[a-z]+$/`.
-	* `endpoint_type` - (Optional, String) The endpoint type of integration. Allowed values: `private` and `public`. Default is `public`.
+	* `endpoint_type` - (Optional, String) The endpoint type of integration. Allowed values: `default_or_public` and `private`. Default is `default_or_public`.
 	* `source_id` - (Optional, String) The ID of the created source in the IBM Event Notifications instance. Corresponds to the Cloud Logs instance crn. Not required when creating an Outbound Integration.
 	  * Constraints: The maximum length is `4096` characters. The minimum length is `1` character. The value must match regular expression `^[\\p{L}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{M}]+$`.
 	* `source_name` - (Optional, String) The name of the created source in the IBM Event Notifications instance. Not required when creating an Outbound Integration.


### PR DESCRIPTION
### Summary

Fixed the endpoint_type documentation for Event Notifications integration in Cloud Logs Outgoing Webhooks to match the IBM Cloud Logs API specification.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/logs TESTARGS='-run=TestAccIbmLogsOutgoingWebhook'
=== RUN   TestAccIbmLogsOutgoingWebhookDataSourceBasic
--- PASS: TestAccIbmLogsOutgoingWebhookDataSourceBasic (26.58s)
=== RUN   TestAccIbmLogsOutgoingWebhooksDataSourceBasic
--- PASS: TestAccIbmLogsOutgoingWebhooksDataSourceBasic (17.73s)
=== RUN   TestAccIbmLogsOutgoingWebhookBasic
--- PASS: TestAccIbmLogsOutgoingWebhookBasic (27.82s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/logs	73.704s
...
```
