### PR TITLE
Allow deletion of disabled database instances with 0 members

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -1775,8 +1775,13 @@ func classicDatabaseInstanceRead(context context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] Error getting database groups: %s", err))
 	}
+
+	// Disabled instances can have 0 members - they can still be read/deleted
+	// Print a warning and return early
+	// The state will retain previous values, which is acceptable for disabled instances
 	if len(groupList.Groups) == 0 || groupList.Groups[0].Members == nil || groupList.Groups[0].Members.AllocationCount == nil || *groupList.Groups[0].Members.AllocationCount == 0 {
-		return diag.FromErr(fmt.Errorf("[ERROR] This database appears to have have 0 members. Unable to proceed"))
+		log.Printf("[WARN] Database instance %s has 0 members (disabled state), skipping detailed read to allow deletion", instanceID)
+		return nil
 	}
 
 	d.Set("groups", flex.FlattenIcdGroups(groupList))


### PR DESCRIPTION
Previously, terraform destroy would fail on disabled database instances with the error: 'This database appears to have 0 members. Unable to proceed'

This occurred because the Read operation in classicDatabaseInstanceRead treated 0 members as a fatal error, blocking all Terraform operations including destroy.

Changes:
- Modified the member count validation to log a warning instead of returning an error when 0 members are detected
- Added early return to skip subsequent API calls that would fail for disabled instances (GetAutoscalingConditions, GetAllowlist, etc.)
- Disabled instances now retain their previous state values, which is acceptable since they are typically only being deleted

Impact:
- Users can now successfully run 'terraform destroy' on disabled instances
- No breaking changes for active instances with members > 0
- Prevents cascading API failures for disabled instances

The fix addresses the issue at the Terraform Provider layer. Analysis of the middle-end and dispatcher layers confirmed they have no member count validation that would block deletion.

Fixes: Deletion of disabled database instances

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from testing:


```
Before:
========

 $ tf refresh     ok
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=1169a6365dfb4653aaef8cf5dea7bf08]
ibm_database.postgres_db: Refreshing state... [id=crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::]
╷
│ Error: [ERROR] This database appears to have have 0 members. Unable to proceed
│
│   with ibm_database.postgres_db,
│   on main.tf line 25, in resource "ibm_database" "postgres_db":
│   25: resource "ibm_database" "postgres_db" {
│
╵
 $ tf destroy
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/obai/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=1169a6365dfb4653aaef8cf5dea7bf08]
ibm_database.postgres_db: Refreshing state... [id=crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::]
╷
│ Error: [ERROR] This database appears to have have 0 members. Unable to proceed
│
│   with ibm_database.postgres_db,
│   on main.tf line 25, in resource "ibm_database" "postgres_db":
│   25: resource "ibm_database" "postgres_db" {
│
╵

After:
======

 $             
 $ tf refresh  
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=1169a6365dfb4653aaef8cf5dea7bf08]
ibm_database.postgres_db: Refreshing state... [id=crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::]

Outputs:

crn = "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::"
 $            ok  8s
 $ tf destroy
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - ibm-cloud/ibm in /Users/obai/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
data.ibm_resource_group.group: Reading...
data.ibm_resource_group.group: Read complete after 1s [id=1169a6365dfb4653aaef8cf5dea7bf08]
ibm_database.postgres_db: Refreshing state... [id=crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ibm_database.postgres_db will be destroyed
  - resource "ibm_database" "postgres_db" {
      ...
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - crn = "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

ibm_database.postgres_db: Destroying... [id=crn:v1:bluemix:public:databases-for-postgresql:us-south:a/40ddc34a953a8c02f10987b59085b60e:b368aefa-ac30-4d79-9848-947d99a96daa::]
ibm_database.postgres_db: Still destroying... [id=crn:v1:bluemix:public:databases-for-pos...b368aefa-ac30-4d79-9848-947d99a96daa::, 00m10s elapsed]
ibm_database.postgres_db: Destruction complete after 11s

Destroy complete! Resources: 1 destroyed.


...
```
