### PR TITLE
Update wording in source-crn option to remove mention of service broker

### DIFF
--- a/ibm/service/power/resource_ibm_pi_volume_onboarding.go
+++ b/ibm/service/power/resource_ibm_pi_volume_onboarding.go
@@ -66,7 +66,7 @@ func ResourceIBMPIVolumeOnboarding() *schema.Resource {
 							Type:     schema.TypeList,
 						},
 						Arg_SourceCRN: {
-							Description: "The crn of source service broker instance from where auxiliary volumes need to be onboarded.",
+							Description: "The CRN of the workspace in which the primary volume is located.",
 							Required:    true,
 							Type:        schema.TypeString,
 						},

--- a/website/docs/r/pi_volume_onboarding.html.markdown
+++ b/website/docs/r/pi_volume_onboarding.html.markdown
@@ -62,7 +62,7 @@ Review the argument references that you can specify for your resource.
 
   Nested scheme for **pi_onboarding_volumes**:
   - `pi_auxiliary_volumes` - (Required, List of objects) List auxiliary volumes.
-  - `pi_source_crn` - (Required, String) The crn of source service broker instance from where auxiliary volumes need to be onboarded.
+  - `pi_source_crn` - (Required, String) The CRN of the workspace in which the primary volume is located.
     - Constraints: The minimum length is `1` items.
 
     Nested scheme for **pi_auxiliary_volumes**:


### PR DESCRIPTION
Customers don't know about the service broker so that wording has been updated.