### PR TITLE
Fix inline rule update to always clear all and recreate 

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -902,7 +902,6 @@ func nwaclUpdate(context context.Context, d *schema.ResourceData, meta interface
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
 	}
-	rules := d.Get(isNetworkACLRules).([]interface{})
 	if hasChanged {
 		updateNetworkACLOptions := &vpcv1.UpdateNetworkACLOptions{
 			ID: &id,
@@ -941,7 +940,8 @@ func nwaclUpdate(context context.Context, d *schema.ResourceData, meta interface
 		}
 	}
 	if d.HasChange(isNetworkACLRules) {
-		err := validateInlineRules(d, rules)
+		rules := d.Get(isNetworkACLRules).([]interface{})
+		err := validateInlineRulesForUpdate(d, rules)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("validateInlineRules failed: %s", err.Error()), "ibm_is_network_acl", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -954,12 +954,13 @@ func nwaclUpdate(context context.Context, d *schema.ResourceData, meta interface
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
-		//Create the rules as per the def
-		err = createInlineRules(d, sess, id, rules)
-		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("createInlineRules failed: %s", err.Error()), "ibm_is_network_acl", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-			return tfErr.GetDiag()
+
+		for i, r := range rules {
+			if err := createSingleNwaclRuleForUpdate(d, sess, id, r.(map[string]interface{}), i, ""); err != nil {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("createSingleNwaclRuleForUpdate failed: %s", err.Error()), "ibm_is_network_acl", "update")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
 		}
 	}
 	return nil
@@ -1172,6 +1173,91 @@ func validateInlineRules(d *schema.ResourceData, rules []interface{}) error {
 			}
 		}
 
+	}
+	return nil
+}
+
+func validateInlineRulesForUpdate(d *schema.ResourceData, rules []interface{}) error {
+	// Read everything from GetRawConfig so state-merged values don't cause
+	// false positives on update. On create GetRawConfig is fully populated;
+	// on update it is also fully populated (only destroy returns null).
+	rawConfig := d.GetRawConfig()
+	var rawRulesAttr cty.Value
+	if rawConfig.IsKnown() && !rawConfig.IsNull() {
+		rawRulesAttr = rawConfig.GetAttr("rules")
+	} else {
+		rawRulesAttr = cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	for i := range rules {
+		hasIcmpBlock, hasTcpBlock, hasUdpBlock := false, false, false
+		protocol := ""
+		hasIcmpType, hasIcmpCode := false, false
+		hasPortMin, hasPortMax, hasSrcPortMin, hasSrcPortMax := false, false, false, false
+
+		if !rawRulesAttr.IsNull() && rawRulesAttr.IsKnown() && rawRulesAttr.LengthInt() > i {
+			ruleVal := rawRulesAttr.Index(cty.NumberIntVal(int64(i)))
+			if !ruleVal.IsNull() {
+				icmpAttr := ruleVal.GetAttr("icmp")
+				tcpAttr := ruleVal.GetAttr("tcp")
+				udpAttr := ruleVal.GetAttr("udp")
+				hasIcmpBlock = !icmpAttr.IsNull() && icmpAttr.LengthInt() > 0
+				hasTcpBlock = !tcpAttr.IsNull() && tcpAttr.LengthInt() > 0
+				hasUdpBlock = !udpAttr.IsNull() && udpAttr.LengthInt() > 0
+
+				if p := ruleVal.GetAttr("protocol"); !p.IsNull() && p.IsKnown() {
+					protocol = p.AsString()
+				}
+				if v := ruleVal.GetAttr("type"); !v.IsNull() && v.IsKnown() {
+					hasIcmpType = true
+				}
+				if v := ruleVal.GetAttr("code"); !v.IsNull() && v.IsKnown() {
+					hasIcmpCode = true
+				}
+				if v := ruleVal.GetAttr("port_min"); !v.IsNull() && v.IsKnown() {
+					hasPortMin = true
+				}
+				if v := ruleVal.GetAttr("port_max"); !v.IsNull() && v.IsKnown() {
+					hasPortMax = true
+				}
+				if v := ruleVal.GetAttr("source_port_min"); !v.IsNull() && v.IsKnown() {
+					hasSrcPortMin = true
+				}
+				if v := ruleVal.GetAttr("source_port_max"); !v.IsNull() && v.IsKnown() {
+					hasSrcPortMax = true
+				}
+			}
+		}
+
+		log.Printf("[DEBUG] validateInlineRules rule[%d] from RawConfig: icmp=%t, tcp=%t, udp=%t, protocol=%q", i, hasIcmpBlock, hasTcpBlock, hasUdpBlock, protocol)
+
+		if (hasIcmpBlock && hasTcpBlock) || (hasIcmpBlock && hasUdpBlock) || (hasTcpBlock && hasUdpBlock) {
+			return fmt.Errorf("Only one of icmp|tcp|udp can be defined per rule")
+		}
+
+		if protocol != "icmp" && protocol != "" {
+			if hasIcmpType {
+				return fmt.Errorf("attribute 'type' conflicts with protocol %q; 'type' is only valid for icmp protocol", protocol)
+			}
+			if hasIcmpCode {
+				return fmt.Errorf("attribute 'code' conflicts with protocol %q; 'code' is only valid for icmp protocol", protocol)
+			}
+		}
+
+		if protocol != "tcp" && protocol != "udp" && protocol != "" {
+			if hasPortMin {
+				return fmt.Errorf("attribute 'port_min' conflicts with protocol %s; ports apply only to tcp/udp protocol", protocol)
+			}
+			if hasPortMax {
+				return fmt.Errorf("attribute 'port_max' conflicts with protocol %s; ports apply only to tcp/udp protocol", protocol)
+			}
+			if hasSrcPortMin {
+				return fmt.Errorf("attribute 'source_port_min' conflicts with protocol %s; ports apply only to tcp/udp protocol", protocol)
+			}
+			if hasSrcPortMax {
+				return fmt.Errorf("attribute 'source_port_max' conflicts with protocol %s; ports apply only to tcp/udp protocol", protocol)
+			}
+		}
 	}
 	return nil
 }
@@ -1401,4 +1487,196 @@ func createInlineRules(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid stri
 
 func isNil(i interface{}) bool {
 	return i == nil || reflect.ValueOf(i).IsNil()
+}
+
+func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid string, rulex map[string]interface{}, i int, before string) (error) {
+	name := rulex[isNetworkACLRuleName].(string)
+	source := rulex[isNetworkACLRuleSource].(string)
+	destination := rulex[isNetworkACLRuleDestination].(string)
+	action := rulex[isNetworkACLRuleAction].(string)
+	direction := rulex[isNetworkACLRuleDirection].(string)
+
+	// Use GetRawConfig exclusively for all field values — never read from the
+	// merged state map (rulex/d.Get) for protocol or port/icmp fields, as
+	// Computed fields bleed old state values through on update.
+	hasIcmpBlock, hasTcpBlock, hasUdpBlock := false, false, false
+	protocol := "icmp_tcp_udp"
+	if action == "deny" {
+		protocol = "any"
+	}
+
+	// rawIcmpType/rawIcmpCode: nil means not set in config.
+	var rawIcmpType, rawIcmpCode *int64
+	var rawPortMin, rawPortMax, rawSrcPortMin, rawSrcPortMax *int64
+
+	rawConfig := d.GetRawConfig()
+	rulesAttr := rawConfig.GetAttr("rules")
+	if !rulesAttr.IsNull() && rulesAttr.LengthInt() > i {
+		ruleVal := rulesAttr.Index(cty.NumberIntVal(int64(i)))
+		if !ruleVal.IsNull() {
+			// Protocol
+			protocolAttr := ruleVal.GetAttr("protocol")
+			if !protocolAttr.IsNull() && protocolAttr.IsKnown() {
+				if p := protocolAttr.AsString(); p != "" {
+					protocol = p
+				}
+			}
+
+			// Deprecated blocks
+			icmpAttr := ruleVal.GetAttr("icmp")
+			tcpAttr := ruleVal.GetAttr("tcp")
+			udpAttr := ruleVal.GetAttr("udp")
+			hasIcmpBlock = !icmpAttr.IsNull() && icmpAttr.LengthInt() > 0
+			hasTcpBlock = !tcpAttr.IsNull() && tcpAttr.LengthInt() > 0
+			hasUdpBlock = !udpAttr.IsNull() && udpAttr.LengthInt() > 0
+
+			// icmp block fields
+			if hasIcmpBlock {
+				elem := icmpAttr.Index(cty.NumberIntVal(0))
+				if !elem.IsNull() {
+					if t := elem.GetAttr("type"); !t.IsNull() && t.IsKnown() {
+						v, _ := t.AsBigFloat().Int64()
+						rawIcmpType = &v
+					}
+					if c := elem.GetAttr("code"); !c.IsNull() && c.IsKnown() {
+						v, _ := c.AsBigFloat().Int64()
+						rawIcmpCode = &v
+					}
+				}
+			}
+
+			// top-level icmp fields (new style: protocol="icmp" + type/code flat)
+			if !hasIcmpBlock {
+				if t := ruleVal.GetAttr("type"); !t.IsNull() && t.IsKnown() {
+					v, _ := t.AsBigFloat().Int64()
+					rawIcmpType = &v
+				}
+				if c := ruleVal.GetAttr("code"); !c.IsNull() && c.IsKnown() {
+					v, _ := c.AsBigFloat().Int64()
+					rawIcmpCode = &v
+				}
+			}
+
+			// tcp block fields
+			if hasTcpBlock {
+				elem := tcpAttr.Index(cty.NumberIntVal(0))
+				if !elem.IsNull() {
+					if v := elem.GetAttr("port_min"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawPortMin = &n
+					}
+					if v := elem.GetAttr("port_max"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawPortMax = &n
+					}
+					if v := elem.GetAttr("source_port_min"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawSrcPortMin = &n
+					}
+					if v := elem.GetAttr("source_port_max"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawSrcPortMax = &n
+					}
+				}
+			}
+
+			// udp block fields
+			if hasUdpBlock {
+				elem := udpAttr.Index(cty.NumberIntVal(0))
+				if !elem.IsNull() {
+					if v := elem.GetAttr("port_min"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawPortMin = &n
+					}
+					if v := elem.GetAttr("port_max"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawPortMax = &n
+					}
+					if v := elem.GetAttr("source_port_min"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawSrcPortMin = &n
+					}
+					if v := elem.GetAttr("source_port_max"); !v.IsNull() && v.IsKnown() {
+						n, _ := v.AsBigFloat().Int64()
+						rawSrcPortMax = &n
+					}
+				}
+			}
+
+			// top-level port fields (new style: protocol="tcp"/"udp" + flat ports)
+			if !hasTcpBlock && !hasUdpBlock {
+				if v := ruleVal.GetAttr("port_min"); !v.IsNull() && v.IsKnown() {
+					n, _ := v.AsBigFloat().Int64()
+					rawPortMin = &n
+				}
+				if v := ruleVal.GetAttr("port_max"); !v.IsNull() && v.IsKnown() {
+					n, _ := v.AsBigFloat().Int64()
+					rawPortMax = &n
+				}
+				if v := ruleVal.GetAttr("source_port_min"); !v.IsNull() && v.IsKnown() {
+					n, _ := v.AsBigFloat().Int64()
+					rawSrcPortMin = &n
+				}
+				if v := ruleVal.GetAttr("source_port_max"); !v.IsNull() && v.IsKnown() {
+					n, _ := v.AsBigFloat().Int64()
+					rawSrcPortMax = &n
+				}
+			}
+		}
+	}
+
+	// Deprecated blocks override whatever the flat protocol attribute says.
+	if hasIcmpBlock {
+		protocol = "icmp"
+	} else if hasTcpBlock {
+		protocol = "tcp"
+	} else if hasUdpBlock {
+		protocol = "udp"
+	}
+
+	ruleTemplate := &vpcv1.NetworkACLRulePrototype{
+		Action:      &action,
+		Destination: &destination,
+		Direction:   &direction,
+		Source:      &source,
+		Name:        &name,
+	}
+
+	if before != "" {
+		ruleTemplate.Before = &vpcv1.NetworkACLRuleBeforePrototype{
+			ID: &before,
+		}
+	}
+
+	ruleTemplate.Protocol = &protocol
+
+	switch protocol {
+	case "icmp":
+		ruleTemplate.Type = rawIcmpType
+		ruleTemplate.Code = rawIcmpCode
+		// if one is set, the other must default to 0
+		if ruleTemplate.Type != nil && ruleTemplate.Code == nil {
+			v := int64(0)
+			ruleTemplate.Code = &v
+		}
+		if ruleTemplate.Code != nil && ruleTemplate.Type == nil {
+			v := int64(0)
+			ruleTemplate.Type = &v
+		}
+	case "tcp", "udp":
+		ruleTemplate.DestinationPortMin = rawPortMin
+		ruleTemplate.DestinationPortMax = rawPortMax
+		ruleTemplate.SourcePortMin = rawSrcPortMin
+		ruleTemplate.SourcePortMax = rawSrcPortMax
+	}
+
+	createNetworkAclRuleOptions := &vpcv1.CreateNetworkACLRuleOptions{
+		NetworkACLID:            &nwaclid,
+		NetworkACLRulePrototype: ruleTemplate,
+	}
+	_, response, err := nwaclC.CreateNetworkACLRule(createNetworkAclRuleOptions)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error Creating network ACL rule : %s\n%s", err, response)
+	}
+	return nil
 }

--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -1654,14 +1654,15 @@ func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1,
 	case "icmp":
 		ruleTemplate.Type = rawIcmpType
 		ruleTemplate.Code = rawIcmpCode
-		// if one is set, the other must default to 0
-		if ruleTemplate.Type != nil && ruleTemplate.Code == nil {
-			v := int64(0)
-			ruleTemplate.Code = &v
-		}
-		if ruleTemplate.Code != nil && ruleTemplate.Type == nil {
-			v := int64(0)
-			ruleTemplate.Type = &v
+		if hasIcmpBlock {
+			if ruleTemplate.Type != nil && ruleTemplate.Code == nil {
+				v := int64(0)
+				ruleTemplate.Code = &v
+			}
+			if ruleTemplate.Code != nil && ruleTemplate.Type == nil {
+				v := int64(0)
+				ruleTemplate.Type = &v
+			}
 		}
 	case "tcp", "udp":
 		ruleTemplate.DestinationPortMin = rawPortMin

--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -956,7 +956,7 @@ func nwaclUpdate(context context.Context, d *schema.ResourceData, meta interface
 		}
 
 		for i, r := range rules {
-			if err := createSingleNwaclRuleForUpdate(d, sess, id, r.(map[string]interface{}), i, ""); err != nil {
+			if err := createSingleNwaclRuleForUpdate(d, sess, id, r.(map[string]interface{}), i); err != nil {
 				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("createSingleNwaclRuleForUpdate failed: %s", err.Error()), "ibm_is_network_acl", "update")
 				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 				return tfErr.GetDiag()
@@ -1489,7 +1489,7 @@ func isNil(i interface{}) bool {
 	return i == nil || reflect.ValueOf(i).IsNil()
 }
 
-func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid string, rulex map[string]interface{}, i int, before string) error {
+func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid string, rulex map[string]interface{}, i int) error {
 	name := rulex[isNetworkACLRuleName].(string)
 	source := rulex[isNetworkACLRuleSource].(string)
 	destination := rulex[isNetworkACLRuleDestination].(string)
@@ -1646,12 +1646,6 @@ func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1,
 		Direction:   &direction,
 		Source:      &source,
 		Name:        &name,
-	}
-
-	if before != "" {
-		ruleTemplate.Before = &vpcv1.NetworkACLRuleBeforePrototype{
-			ID: &before,
-		}
 	}
 
 	ruleTemplate.Protocol = &protocol

--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -1489,7 +1489,7 @@ func isNil(i interface{}) bool {
 	return i == nil || reflect.ValueOf(i).IsNil()
 }
 
-func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid string, rulex map[string]interface{}, i int, before string) (error) {
+func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1, nwaclid string, rulex map[string]interface{}, i int, before string) error {
 	name := rulex[isNetworkACLRuleName].(string)
 	source := rulex[isNetworkACLRuleSource].(string)
 	destination := rulex[isNetworkACLRuleDestination].(string)

--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -1510,8 +1510,14 @@ func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1,
 	var rawPortMin, rawPortMax, rawSrcPortMin, rawSrcPortMax *int64
 
 	rawConfig := d.GetRawConfig()
-	rulesAttr := rawConfig.GetAttr("rules")
-	if !rulesAttr.IsNull() && rulesAttr.LengthInt() > i {
+	var rulesAttr cty.Value
+	if rawConfig.IsKnown() && !rawConfig.IsNull() {
+		rulesAttr = rawConfig.GetAttr("rules")
+	} else {
+		rulesAttr = cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	if rulesAttr.IsKnown() && !rulesAttr.IsNull() && rulesAttr.LengthInt() > i {
 		ruleVal := rulesAttr.Index(cty.NumberIntVal(int64(i)))
 		if !ruleVal.IsNull() {
 			// Protocol
@@ -1526,9 +1532,9 @@ func createSingleNwaclRuleForUpdate(d *schema.ResourceData, nwaclC *vpcv1.VpcV1,
 			icmpAttr := ruleVal.GetAttr("icmp")
 			tcpAttr := ruleVal.GetAttr("tcp")
 			udpAttr := ruleVal.GetAttr("udp")
-			hasIcmpBlock = !icmpAttr.IsNull() && icmpAttr.LengthInt() > 0
-			hasTcpBlock = !tcpAttr.IsNull() && tcpAttr.LengthInt() > 0
-			hasUdpBlock = !udpAttr.IsNull() && udpAttr.LengthInt() > 0
+			hasIcmpBlock = !icmpAttr.IsNull() && icmpAttr.IsKnown() && icmpAttr.LengthInt() > 0
+			hasTcpBlock = !tcpAttr.IsNull() && tcpAttr.IsKnown() && tcpAttr.LengthInt() > 0
+			hasUdpBlock = !udpAttr.IsNull() && udpAttr.IsKnown() && udpAttr.LengthInt() > 0
 
 			// icmp block fields
 			if hasIcmpBlock {

--- a/ibm/service/vpc/resource_ibm_is_network_acl.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl.go
@@ -943,7 +943,7 @@ func nwaclUpdate(context context.Context, d *schema.ResourceData, meta interface
 		rules := d.Get(isNetworkACLRules).([]interface{})
 		err := validateInlineRulesForUpdate(d, rules)
 		if err != nil {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("validateInlineRules failed: %s", err.Error()), "ibm_is_network_acl", "update")
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("validateInlineRulesForUpdate failed: %s", err.Error()), "ibm_is_network_acl", "update")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}

--- a/ibm/service/vpc/resource_ibm_is_network_acl_test.go
+++ b/ibm/service/vpc/resource_ibm_is_network_acl_test.go
@@ -543,3 +543,364 @@ func testAccCheckIBMISNetworkACLFlatUDP() string {
     }
     `
 }
+
+// ---------------------------------------------------------------------------
+// TestNetworkACL_InlineRuleUpdate* — cover the clear-all + recreate-all path
+// that fires on any inline rule change (field edit, add, remove, reorder,
+// protocol change).
+// ---------------------------------------------------------------------------
+
+// TestNetworkACL_InlineRuleFieldEdit verifies that editing a single field
+// (action, source, destination) on an existing rule triggers clear+recreate
+// and the new values are reflected in state.
+func TestNetworkACL_InlineRuleFieldEdit(t *testing.T) {
+	var nwACL string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with action=allow, source=0.0.0.0/0
+				Config: testAccCheckIBMISNetworkACLInlineUpdateBase(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.source", "0.0.0.0/0"),
+				),
+			},
+			{
+				// Step 2: change action to deny and narrow source — triggers clear+recreate
+				Config: testAccCheckIBMISNetworkACLInlineUpdateFieldEdit(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.action", "deny"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.source", "10.0.0.0/8"),
+				),
+			},
+		},
+	})
+}
+
+// TestNetworkACL_InlineRuleAdd verifies that adding a new rule triggers
+// clear-all + recreate-all and both rules appear in state.
+func TestNetworkACL_InlineRuleAdd(t *testing.T) {
+	var nwACL string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: one rule
+				Config: testAccCheckIBMISNetworkACLInlineUpdateBase(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+				),
+			},
+			{
+				// Step 2: add a second rule — triggers clear+recreate
+				Config: testAccCheckIBMISNetworkACLInlineUpdateAddRule(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "2"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.name", "rule-one"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.1.name", "rule-two"),
+				),
+			},
+		},
+	})
+}
+
+// TestNetworkACL_InlineRuleRemove verifies that removing a rule triggers
+// clear-all + recreate-all and only the remaining rule is in state.
+func TestNetworkACL_InlineRuleRemove(t *testing.T) {
+	var nwACL string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: two rules
+				Config: testAccCheckIBMISNetworkACLInlineUpdateAddRule(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "2"),
+				),
+			},
+			{
+				// Step 2: remove rule-two — triggers clear+recreate, only rule-one remains
+				Config: testAccCheckIBMISNetworkACLInlineUpdateBase(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.name", "rule-one"),
+				),
+			},
+		},
+	})
+}
+
+// TestNetworkACL_InlineRuleReorder verifies that reordering rules triggers
+// clear-all + recreate-all and the new order is reflected in state.
+func TestNetworkACL_InlineRuleReorder(t *testing.T) {
+	var nwACL string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: rule-one first, rule-two second
+				Config: testAccCheckIBMISNetworkACLInlineUpdateAddRule(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.name", "rule-one"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.1.name", "rule-two"),
+				),
+			},
+			{
+				// Step 2: swap order — triggers clear+recreate
+				Config: testAccCheckIBMISNetworkACLInlineUpdateReorder(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.name", "rule-two"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.1.name", "rule-one"),
+				),
+			},
+		},
+	})
+}
+
+// TestNetworkACL_InlineRuleProtocolChange verifies that changing the protocol
+// of a rule (tcp → udp) triggers clear-all + recreate-all.
+func TestNetworkACL_InlineRuleProtocolChange(t *testing.T) {
+	var nwACL string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: tcp rule
+				Config: testAccCheckIBMISNetworkACLInlineUpdateTCP(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.protocol", "tcp"),
+				),
+			},
+			{
+				// Step 2: change protocol to udp — triggers clear+recreate
+				Config: testAccCheckIBMISNetworkACLInlineUpdateUDP(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.protocol", "udp"),
+				),
+			},
+			{
+				// Step 3: change protocol to icmp — triggers clear+recreate
+				Config: testAccCheckIBMISNetworkACLInlineUpdateICMP(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISNetworkACLExists("ibm_is_network_acl.test_update_acl", nwACL),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_network_acl.test_update_acl", "rules.0.protocol", "icmp"),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers for inline-rule update tests
+// ---------------------------------------------------------------------------
+
+func testAccCheckIBMISNetworkACLInlineUpdateBase() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "any"
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateFieldEdit() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "deny"
+            source      = "10.0.0.0/8"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "any"
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateAddRule() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "any"
+        }
+        rules {
+            name        = "rule-two"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "outbound"
+            protocol    = "any"
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateReorder() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-two"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "outbound"
+            protocol    = "any"
+        }
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "any"
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateTCP() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "tcp"
+            port_min    = 80
+            port_max    = 80
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateUDP() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "udp"
+            port_min    = 53
+            port_max    = 53
+        }
+    }
+    `
+}
+
+func testAccCheckIBMISNetworkACLInlineUpdateICMP() string {
+	return `
+    resource "ibm_is_vpc" "testacc_vpc" {
+        name = "tf-nwacl-update-vpc"
+    }
+    resource "ibm_is_network_acl" "test_update_acl" {
+        name = "tf-nwacl-update"
+        vpc  = ibm_is_vpc.testacc_vpc.id
+        rules {
+            name        = "rule-one"
+            action      = "allow"
+            source      = "0.0.0.0/0"
+            destination = "0.0.0.0/0"
+            direction   = "inbound"
+            protocol    = "icmp"
+            type        = 8
+            code        = 0
+        }
+    }
+    `
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
