### PR TITLE
Fix Allow Remote Restart

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -146,6 +146,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Type:          schema.TypeString,
 			},
 			Arg_AllowRemoteRestart: {
+				Computed:    true,
 				Description: "Indicates if the server allows server to be restarted from remote",
 				Optional:    true,
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Fix `pi_allow_remote_restart` update in-place on second `terraform apply`

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMPIInstanceAllowRemoteRestart (901.20s)
PASS

...
```
