### PR TITLE
fix COS bucket replacement on import with key_protect

### DIFF
--- a/ibm/service/cos/data_source_ibm_cos_bucket.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket.go
@@ -746,7 +746,6 @@ func DataSourceIBMCosBucketValidator() *validate.ResourceValidator {
 }
 func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error {
 	var s3Conf *aws.Config
-	var keyProtectFlag bool
 	rsConClient, err := meta.(conns.ClientSession).BluemixSession()
 	if err != nil {
 		return err
@@ -756,9 +755,6 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	bucketType := d.Get("bucket_type").(string)
 	bucketRegion := d.Get("bucket_region").(string)
 	endpointType := d.Get("endpoint_type").(string)
-	if _, ok := d.GetOk("key_protect"); ok {
-		keyProtectFlag = true
-	}
 
 	var satlc_id, apiEndpoint, apiEndpointPublic, apiEndpointPrivate, directApiEndpoint, visibility string
 
@@ -860,11 +856,8 @@ func dataSourceIBMCosBucketRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(bucketID)
 	if head.IBMSSEKPEnabled != nil {
 		if *head.IBMSSEKPEnabled == true {
-			if keyProtectFlag == true {
-				d.Set("key_protect", head.IBMSSEKPCrkId)
-			} else {
-				d.Set("kms_key_crn", head.IBMSSEKPCrkId)
-			}
+			d.Set("key_protect", head.IBMSSEKPCrkId)
+			d.Set("kms_key_crn", head.IBMSSEKPCrkId)
 		}
 	}
 

--- a/ibm/service/cos/data_source_ibm_cos_bucket_test.go
+++ b/ibm/service/cos/data_source_ibm_cos_bucket_test.go
@@ -9,6 +9,7 @@ import (
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -38,4 +39,41 @@ func testAccIBMCOSBucketDataSourceConfig_basic_read(name string, crn string, reg
 			bucket_type          = "region_location"
 			bucket_region        = "%[3]s"
 		}`, name, crn, region)
+}
+
+func TestAccIBMCOSBucketDataSource_KeyProtect(t *testing.T) {
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMCOSBucketDataSourceConfig_keyProtectRead(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_cos_bucket.testacc", "key_protect"),
+					resource.TestCheckResourceAttrSet("data.ibm_cos_bucket.testacc", "kms_key_crn"),
+					resource.TestCheckResourceAttrPair("data.ibm_cos_bucket.testacc", "key_protect", "data.ibm_cos_bucket.testacc", "kms_key_crn"),
+					resource.TestCheckResourceAttrPair("data.ibm_cos_bucket.testacc", "key_protect", "ibm_cos_bucket.bucket", "key_protect"),
+					resource.TestCheckResourceAttrPair("data.ibm_cos_bucket.testacc", "kms_key_crn", "ibm_cos_bucket.bucket", "kms_key_crn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIBMCOSBucketDataSourceConfig_keyProtectRead(instanceName string, keyName string, serviceName string, bucketName string, bucketRegion string, bucketClass string) string {
+	return fmt.Sprintf(`%s
+
+	data "ibm_cos_bucket" "testacc" {
+		bucket_name          = ibm_cos_bucket.bucket.bucket_name
+		resource_instance_id = ibm_cos_bucket.bucket.resource_instance_id
+		bucket_type          = "cross_region_location"
+		bucket_region        = "%s"
+	}`, testAccCheckIBMKeyProtectRootkeyWithCOSBucket(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass), bucketRegion)
 }

--- a/ibm/service/cos/resource_ibm_cos_bucket.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket.go
@@ -102,6 +102,7 @@ func ResourceIBMCOSBucket() *schema.Resource {
 				Type:          schema.TypeString,
 				ForceNew:      true,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"kms_key_crn"},
 				Description:   "CRN of the key you want to use data at rest encryption",
 			},
@@ -109,6 +110,7 @@ func ResourceIBMCOSBucket() *schema.Resource {
 				Type:          schema.TypeString,
 				ForceNew:      true,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"key_protect"},
 				Description:   "CRN of the key you want to use data at rest encryption",
 			},
@@ -1089,7 +1091,6 @@ func resourceIBMCOSBucketUpdate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	var s3Conf *aws.Config
-	var keyProtectFlag bool
 	var archiveFlag, expireFlag, abortFlag, ncFlag bool
 	rsConClient, err := meta.(conns.ClientSession).BluemixSession()
 	if err != nil {
@@ -1104,9 +1105,6 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	apiType := parseBucketId(d.Id(), "apiType")
 	bLocation := parseBucketId(d.Id(), "bLocation")
 
-	if _, ok := d.GetOk("key_protect"); ok {
-		keyProtectFlag = true
-	}
 	if _, ok := d.GetOk("expire_rule"); ok {
 		expireFlag = true
 	}
@@ -1264,11 +1262,8 @@ func resourceIBMCOSBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if head.IBMSSEKPEnabled != nil {
 		if *head.IBMSSEKPEnabled == true {
-			if keyProtectFlag == true {
-				d.Set("key_protect", head.IBMSSEKPCrkId)
-			} else {
-				d.Set("kms_key_crn", head.IBMSSEKPCrkId)
-			}
+			d.Set("key_protect", head.IBMSSEKPCrkId)
+			d.Set("kms_key_crn", head.IBMSSEKPCrkId)
 		}
 	}
 

--- a/ibm/service/cos/resource_ibm_cos_bucket_test.go
+++ b/ibm/service/cos/resource_ibm_cos_bucket_test.go
@@ -2309,6 +2309,40 @@ func TestAccIBMCOSKP(t *testing.T) {
 	})
 }
 
+func TestAccIBMCOSKP_Import(t *testing.T) {
+	instanceName := fmt.Sprintf("kms_%d", acctest.RandIntRange(10, 100))
+	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
+	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))
+	keyName := fmt.Sprintf("key_%d", acctest.RandIntRange(10, 100))
+	bucketRegion := "us"
+	bucketClass := "standard"
+	bucketRegionType := "cross_region_location"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMKeyProtectRootkeyWithCOSBucket(instanceName, keyName, serviceName, bucketName, bucketRegion, bucketClass),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMCosBucketExists("ibm_resource_instance.instance", "ibm_cos_bucket.bucket", bucketRegionType, bucketRegion, bucketName),
+					resource.TestCheckResourceAttr("ibm_cos_bucket.bucket", "bucket_name", bucketName),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket.bucket", "key_protect"),
+					resource.TestCheckResourceAttrSet("ibm_cos_bucket.bucket", "kms_key_crn"),
+					resource.TestCheckResourceAttrPair("ibm_cos_bucket.bucket", "key_protect", "ibm_cos_bucket.bucket", "kms_key_crn"),
+				),
+			},
+			{
+				ResourceName:      "ibm_cos_bucket.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_time_minutes", "parameters", "force_delete"},
+			},
+		},
+	})
+}
+
 func TestAccIBMCOSHPCS(t *testing.T) {
 	serviceName := fmt.Sprintf("terraform_%d", acctest.RandIntRange(10, 100))
 	bucketName := fmt.Sprintf("terraform%d", acctest.RandIntRange(10, 100))

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -563,6 +563,8 @@ Review the argument references that you can specify for your resource.
 
  `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
 
+ `key_protect` and `kms_key_crn` are aliases for the same bucket property. On every read (including `terraform import`) the provider populates both attributes with the CRN of the root key that currently encrypts the bucket, so a configuration that uses either attribute name reconciles cleanly against the refreshed or imported state. If the root key of a bucket is migrated outside of Terraform (for example, from Hyper Protect Crypto Services to Key Protect), update the configured key CRN to the new value and run `terraform plan`; the refreshed state matches the configuration and no bucket replacement is planned.
+
 - `metrics_monitoring`- (Object) Enables sending metrics to IBM Cloud Monitoring.  All metrics are opt-in.
   
   (Recommended) When the `metrics_monitoring_crn` is not populated, then enabled metrics are sent to the Monitoring instance at the container's location unless otherwise specified in the Metrics Router service configuration.
@@ -635,7 +637,7 @@ In addition to all argument reference list, you can access the following attribu
 - `kms_key_crn` - (string) The CRN of the IBM Key Protect instance that you use to encrypt your data in IBM Cloud Object Storage.
     **Note:**
 
- `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers.
+ `key_protect` attribute has been renamed as `kms_key_crn` , hence it is recommended to all the new users to use `kms_key_crn`.Although the support for older attribute name `key_protect` will be continued for existing customers. Both attributes are kept in sync by the provider and always expose the CRN of the root key that currently encrypts the bucket.
 - `region_location` - (string) The location if you created a regional bucket.
 - `resource_instance_id` - (string) The ID of IBM Cloud Object Storage instance. 
 - `single_site_location` - (string) The location if you created a single site bucket.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
