### PR TITLE
fix(backup-recovery): remove connection from state when it no longer exists

### DIFF
--- a/ibm/service/backuprecovery/resource_ibm_backup_recovery_data_source_connection.go
+++ b/ibm/service/backuprecovery/resource_ibm_backup_recovery_data_source_connection.go
@@ -331,8 +331,15 @@ func resourceIbmBackupRecoveryDataSourceConnectionDelete(context context.Context
 	deleteDataSourceConnectionOptions.SetConnectionID(connectionId)
 	deleteDataSourceConnectionOptions.SetXIBMTenantID(tenantId)
 
-	_, err = backupRecoveryClient.DeleteDataSourceConnectionWithContext(context, deleteDataSourceConnectionOptions)
+	deleteResponse, err := backupRecoveryClient.DeleteDataSourceConnectionWithContext(context, deleteDataSourceConnectionOptions)
 	if err != nil {
+		// BRS returns HTTP 400 with "does not exist" when the connection is already
+		// gone — treat this the same as 404: the goal (resource absent) is achieved.
+		if (deleteResponse != nil && deleteResponse.StatusCode == 404) ||
+			strings.Contains(err.Error(), "does not exist") {
+			d.SetId("")
+			return nil
+		}
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteDataSourceConnectionWithContext failed: %s", err.Error()), "ibm_backup_recovery_data_source_connection", "delete")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()

--- a/ibm/service/backuprecovery/resource_ibm_backup_recovery_data_source_connection.go
+++ b/ibm/service/backuprecovery/resource_ibm_backup_recovery_data_source_connection.go
@@ -170,13 +170,17 @@ func resourceIbmBackupRecoveryDataSourceConnectionRead(context context.Context, 
 
 	dataSourceConnectionList, response, err := backupRecoveryClient.GetDataSourceConnectionsWithContext(context, getDataSourceConnectionsOptions)
 	if err != nil {
-		if response != nil && response.StatusCode == 404 {
+		if (response != nil && response.StatusCode == 404) || strings.Contains(err.Error(), "does not exist") {
 			d.SetId("")
 			return nil
 		}
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetDataSourceConnectionsWithContext failed: %s", err.Error()), "ibm_backup_recovery_data_source_connection", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 		return tfErr.GetDiag()
+	}
+	if len(dataSourceConnectionList.Connections) == 0 {
+		d.SetId("")
+		return nil
 	}
 	if !core.IsNil(dataSourceConnectionList.Connections[0].ConnectionEnvType) {
 		if err = d.Set("connection_env_type", dataSourceConnectionList.Connections[0].ConnectionEnvType); err != nil {


### PR DESCRIPTION
## Problem

The BRS (`backup-recovery`) API returns **HTTP 400** (not 404) with an application-level error message in the body when you query a connection ID that no longer exists:

```
GetDataSourceConnectionsWithContext failed: Data-source connection with
  ID '<id>' does not exist in organization "<tenant>".
```

The IBM Go SDK core treats any non-2xx status as an error and surfaces the body as `err.Error()`. Because `resourceIbmBackupRecoveryDataSourceConnectionRead` only checked `response.StatusCode == 404`, this 400 fell through to the fatal error path, making every subsequent `terraform plan` or `terraform destroy` fail with a non-retryable error whenever a stale connection ID was held in state.

### When does this happen?

BRS connection IDs are stored in Terraform state after `ibm_backup_recovery_data_source_connection` is created. The connection can be deleted out-of-band (e.g. BRS tenant rotation, instance re-provisioning, or manual deletion), leaving the stale ID in state. On the next plan or destroy Terraform calls the Read function to refresh state, which hits the 400 and hard-errors.

### Concrete failure

```
│ Error: ---
│ id: terraform-34c16bb1
│ summary: 'GetDataSourceConnectionsWithContext failed: Data-source connection with
│   ID '7506575555450499072' does not exist in organization "1o8kp0j3sw/".'
│ severity: error
│ resource: ibm_backup_recovery_data_source_connection
│ operation: read
```

## Fix

Two targeted changes in `resourceIbmBackupRecoveryDataSourceConnectionRead`:

### 1. Error path — handle HTTP 400 "does not exist" the same as 404

```go
// before
if response != nil && response.StatusCode == 404 {

// after
if (response != nil && response.StatusCode == 404) || strings.Contains(err.Error(), "does not exist") {
```

When the BRS API says the connection does not exist, the resource is removed from state (`d.SetId("")`) and Read returns nil. Terraform will plan to recreate it on the next apply if the config still requests it.

### 2. Success path — guard against empty Connections list

When the API call succeeds (HTTP 200) but returns an empty `Connections` slice (connection removed between the request being issued and the response being parsed), the old code would panic on `Connections[0]`. The fix removes the resource from state instead:

```go
if len(dataSourceConnectionList.Connections) == 0 {
    d.SetId("")
    return nil
}
```

## Effect

| Scenario | Before | After |
|----------|--------|-------|
| Connection exists | Normal read | No change |
| Connection deleted (API returns 400 "does not exist") | **Fatal error — terraform plan/destroy fails** | Resource removed from state; next apply recreates it |
| Connection deleted (API returns 404) | Resource removed from state | No change (already handled) |
| API returns 200 with empty list | **Panic: index out of range** | Resource removed from state |

## Testing

- Existing unit tests pass.
- The two new code paths (400 "does not exist" and empty list) were previously untested dead-code from a correctness standpoint; they now correctly self-heal stale state instead of hard-erroring or panicking.
- Acceptance-test reproducer: deploy a connection, manually delete it from the BRS console, run `terraform plan` — previously fatal, now shows the connection as to-be-added.