### PR TITLE
Fix: Dynamically detect platform for CDP/Gen2 instances during version upgrade validation

### DIFF
--- a/ibm/service/database/validators.go
+++ b/ibm/service/database/validators.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 	"github.com/IBM/go-sdk-core/v5/core"
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -110,8 +112,25 @@ func (v *Version) getAllowedVersionsList() []string {
 var fetchDeploymentVersionFn = fetchDeploymentVersion
 
 func fetchDeploymentVersion(instanceId string, location string, meta interface{}) *Version {
+	// Detect platform from instance plan
+	platform := classicPlatform
+
+	// Get the instance to determine if it's Gen2/CDP
+	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
+	if err == nil {
+		instance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
+			ID: &instanceId,
+		})
+		if err == nil && instance != nil && instance.ResourcePlanID != nil {
+			// Check if this is a Gen2 plan (includes CDP)
+			if isGen2Plan(*instance.ResourcePlanID) {
+				platform = "gen2"
+			}
+		}
+	}
+
 	options := DeploymentCapabilityOptions{
-		Platform:      classicPlatform,
+		Platform:      platform,
 		Location:      location,
 		IncludeHidden: core.BoolPtr(true),
 		IncludeBeta:   core.BoolPtr(true),

--- a/ibm/service/database/validators.go
+++ b/ibm/service/database/validators.go
@@ -15,6 +15,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// detectPlatform returns "gen2" when the instance is a Gen2/CDP plan, or
+// "classic" otherwise. It resolves the ResourcePlanID GUID to a human-readable
+// plan name before checking, because isGen2Plan matches the "-gen2" suffix.
+func detectPlatform(instanceId string, meta interface{}) string {
+	if planName, err := resolvePlanName(instanceId, meta); err == nil && isGen2Plan(planName) {
+		return "gen2"
+	}
+	return classicPlatform
+}
+
+// resolvePlanName fetches the human-readable plan name for the given instance.
+func resolvePlanName(instanceId string, meta interface{}) (string, error) {
+	cs := meta.(conns.ClientSession)
+
+	rsConClient, err := cs.ResourceControllerV2API()
+	if err != nil {
+		return "", err
+	}
+	instance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &instanceId})
+	if err != nil || instance == nil || instance.ResourcePlanID == nil {
+		return "", fmt.Errorf("could not retrieve instance plan")
+	}
+
+	rsCatClient, err := cs.ResourceCatalogAPI()
+	if err != nil {
+		return "", err
+	}
+	return rsCatClient.ResourceCatalog().GetServicePlanName(*instance.ResourcePlanID)
+}
+
 /* TODO move other validators in here */
 
 /* VERSION VALIDATOR */
@@ -112,22 +142,7 @@ func (v *Version) getAllowedVersionsList() []string {
 var fetchDeploymentVersionFn = fetchDeploymentVersion
 
 func fetchDeploymentVersion(instanceId string, location string, meta interface{}) *Version {
-	// Detect platform from instance plan
-	platform := classicPlatform
-
-	// Get the instance to determine if it's Gen2/CDP
-	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
-	if err == nil {
-		instance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
-			ID: &instanceId,
-		})
-		if err == nil && instance != nil && instance.ResourcePlanID != nil {
-			// Check if this is a Gen2 plan (includes CDP)
-			if isGen2Plan(*instance.ResourcePlanID) {
-				platform = "gen2"
-			}
-		}
-	}
+	platform := detectPlatform(instanceId, meta)
 
 	options := DeploymentCapabilityOptions{
 		Platform:      platform,
@@ -138,7 +153,8 @@ func fetchDeploymentVersion(instanceId string, location string, meta interface{}
 
 	capability, err := getDeploymentCapability(versions, instanceId, options, meta)
 	if err != nil {
-		log.Fatalf("Error fetching deployment versions: %v", err)
+		log.Printf("[WARN] Error fetching deployment versions for instance %s: %v", instanceId, err)
+		return nil
 	}
 
 	if capability == nil || capability.Versions == nil || len(capability.Versions) == 0 {

--- a/ibm/service/database/validators_test.go
+++ b/ibm/service/database/validators_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 )
 
 func TestIsVersionUpgradeAllowed(t *testing.T) {
@@ -233,7 +233,7 @@ func TestGetAllowedVersionsList(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
 			result := tc.version.getAllowedVersionsList()
-			assert.DeepEqual(t, tc.expectedResult, result)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
@@ -514,6 +514,50 @@ func TestValidateGroupScaling(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestFetchDeploymentVersionPlatformDetection(t *testing.T) {
+	tests := []struct {
+		description      string
+		planID           string
+		expectedPlatform string
+	}{
+		{
+			description:      "When plan is classic, expect platform 'classic'",
+			planID:           "databases-for-postgresql-standard",
+			expectedPlatform: classicPlatform,
+		},
+		{
+			description:      "When plan is Gen2, expect platform 'gen2'",
+			planID:           "databases-for-postgresql-gen2-standard",
+			expectedPlatform: "gen2",
+		},
+		{
+			description:      "When plan is CDP with gen2, expect platform 'gen2'",
+			planID:           "messages-for-rabbitmq-gen2-cdp-dev",
+			expectedPlatform: "gen2",
+		},
+		{
+			description:      "When plan is CDP Valkey, expect platform 'gen2'",
+			planID:           "databases-for-valkey-gen2-cdp-dev",
+			expectedPlatform: "gen2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			isGen2 := isGen2Plan(tc.planID)
+
+			var actualPlatform string
+			if isGen2 {
+				actualPlatform = "gen2"
+			} else {
+				actualPlatform = classicPlatform
+			}
+
+			require.Equal(t, tc.expectedPlatform, actualPlatform)
 		})
 	}
 }


### PR DESCRIPTION

The target_platform was hardcoded to 'classic' in validators.go, causing 403 errors when validating in version upgrade for CDP/Gen2 database instances.

Changes:
- Added imports for conns and resourcecontrollerv2 packages
- Modified fetchDeploymentVersion() to detect platform from instance plan
- Uses GetResourceInstance() to check if plan is Gen2/CDP via isGen2Plan()
- Sets platform to 'gen2' for Gen2/CDP instances, 'classic' otherwise
- This allows the ICD API to return correct version capabilities per platform

**Validation Screenshots**
<img width="1242" height="950" alt="Screenshot 2026-07-24 at 2 35 18 PM" src="https://github.com/user-attachments/assets/4a726019-7563-4a5c-b58b-8c4e07d1d4cf" />
<img width="1244" height="816" alt="Screenshot 2026-07-24 at 3 02 09 PM" src="https://github.com/user-attachments/assets/2a13fa0d-7374-41c4-bd5a-dc86c797eac7" />
<img width="1314" height="301" alt="Screenshot 2026-07-24 at 3 20 38 PM" src="https://github.com/user-attachments/assets/2674623b-aead-44d7-817d-2a5437b9a31e" />



Output from testing:

```
$ /usr/local/go/bin/go test -test.fullpath=true -timeout 30s -run ^TestValidateVersion$ github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database

ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database	1.821s

```
