### PR TITLE
Ensure an assignment is retryable when ends in a failed state. A destroy/create is unnecessary

### DIFF
--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -225,7 +225,27 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
-	return resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
+	// Read persists the final state. When status is "failed"/"superseded", Read
+	// writes template_version=0 so the next plan shows a visible update diff.
+	diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
+	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Assignment completed with status '%s'.", status.(string)),
+			Detail: fmt.Sprintf(
+				"The assignment %s is in a '%s' state. Terraform has marked this resource as tainted.\n"+
+					"To retry without destroying and recreating the assignment, run:\n\n"+
+					"  terraform untaint ibm_iam_account_settings_template_assignment.<RESOURCE_NAME>\n"+
+					"  terraform apply\n\n"+
+					"Replace <RESOURCE_NAME> with the name of your resource block (e.g. if your config\n"+
+					"is 'resource \"ibm_iam_account_settings_template_assignment\" \"assignment\"', use:\n\n"+
+					"  terraform untaint ibm_iam_account_settings_template_assignment.assignment\n"+
+					"  terraform apply\n\n"+
+					"This will perform an in-place update (PUT) to retry only the failed resources.",
+				d.Id(), status.(string)),
+		})
+	}
+	return diags
 }
 
 func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -255,7 +275,15 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 		err = fmt.Errorf("Error setting template_id: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
-	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
+	// When the assignment is in a failed/superseded state, write 0 for
+	// template_version so Terraform sees a diff against the config value on the
+	// next plan and calls Update, which retries the assignment via PUT.
+	templateVersion := flex.IntValue(templateAssignmentResponse.TemplateVersion)
+	if templateAssignmentResponse.Status != nil &&
+		(*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
+		templateVersion = 0
+	}
+	if err = d.Set("template_version", templateVersion); err != nil {
 		err = fmt.Errorf("Error setting template_version: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_version").GetDiag()
 	}
@@ -315,7 +343,6 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 		err = fmt.Errorf("Error setting entity_tag: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
-
 	return nil
 }
 
@@ -331,14 +358,12 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 	updateAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
 	updateAccountSettingsAssignmentOptions.SetIfMatch(d.Get("entity_tag").(string))
 
-	hasChange := false
+	// Always set template_version on the options. When retrying a failed/superseded
+	// assignment, Read wrote 0 to state so HasChange is true and d.Get returns the
+	// config value (the real version the user specified).
+	updateAccountSettingsAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
 
 	if d.HasChange("template_version") {
-		updateAccountSettingsAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
-		hasChange = true
-	}
-
-	if hasChange || d.Get("status") == "failed" { // allow the same version to retry failed assignments
 		_, response, err := iamIdentityClient.UpdateAccountSettingsAssignmentWithContext(context, updateAccountSettingsAssignmentOptions)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "update")
@@ -352,7 +377,14 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 		}
 	}
 
-	return resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
+	diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
+	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Assignment completed with status '%s'. Run terraform apply again to retry.", status.(string)),
+		})
+	}
+	return diags
 }
 
 func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -473,9 +505,13 @@ func isAccountSettingsAssignmentRemoved(id string, meta interface{}) retry.State
 			}
 
 			return nil, READY, fmt.Errorf("[ERROR] The assignment %s failed to delete or deletion was not completed within specific timeout period: %s\n%s", id, err, response)
-		} else {
-			log.Printf("Assignment removal still in progress\n")
 		}
+
+		if assignment != nil && assignment.Status != nil && *assignment.Status == "failed" {
+			return assignment, READY, fmt.Errorf("[ERROR] The deletion of assignment %s completed with a 'failed' status. Please check the assignment resource for detailed errors", id)
+		}
+
+		log.Printf("Assignment removal still in progress\n")
 
 		return assignment, WAITING, nil
 	}
@@ -500,8 +536,9 @@ func isAccountSettingsTemplateAssigned(id string, meta interface{}) retry.StateR
 				return assignment, WAITING, nil
 			}
 
-			if *assignment.Status == "failed" {
-				return assignment, READY, fmt.Errorf("[ERROR] The assignment %s did complete but with a 'failed' status. Please check assignment resource for detailed errors: %s", id, response)
+			if *assignment.Status == "failed" || *assignment.Status == "superseded" {
+				log.Printf("[WARN] Assignment %s completed with status '%s'\n", id, *assignment.Status)
+				return assignment, READY, nil
 			}
 
 			return assignment, READY, nil

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -225,6 +227,19 @@ func resourceIBMAccountSettingsTemplateAssignmentCreate(context context.Context,
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
+	// Capture the real template version now, before Read potentially writes 0 to
+	// state when the assignment is in a failed state.
+	realTemplateVersion := int64(d.Get("template_version").(int))
+
+	// Read before retry so status and entity_tag are populated in d.
+	if diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta); diags.HasError() {
+		return diags
+	}
+
+	if err = retryAccountSettingsFailedAssignment(context, d, meta, iamIdentityClient, realTemplateVersion); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "create", "retry-failed-assignment").GetDiag()
+	}
+
 	// Read persists the final state. When status is "failed"/"superseded", Read
 	// writes template_version=0 so the next plan shows a visible update diff.
 	diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
@@ -275,12 +290,11 @@ func resourceIBMAccountSettingsTemplateAssignmentRead(context context.Context, d
 		err = fmt.Errorf("Error setting template_id: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "read", "set-template_id").GetDiag()
 	}
-	// When the assignment is in a failed/superseded state, write 0 for
-	// template_version so Terraform sees a diff against the config value on the
-	// next plan and calls Update, which retries the assignment via PUT.
+	// When the assignment is in a terminal-failure state, persist template_version=0
+	// so that the next terraform plan detects a diff (0 vs the config value) and
+	// triggers an in-place Update (PUT) retry instead of reporting "No changes."
 	templateVersion := flex.IntValue(templateAssignmentResponse.TemplateVersion)
-	if templateAssignmentResponse.Status != nil &&
-		(*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
+	if !core.IsNil(templateAssignmentResponse.Status) && (*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
 		templateVersion = 0
 	}
 	if err = d.Set("template_version", templateVersion); err != nil {
@@ -358,10 +372,10 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 	updateAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
 	updateAccountSettingsAssignmentOptions.SetIfMatch(d.Get("entity_tag").(string))
 
-	// Always set template_version on the options. When retrying a failed/superseded
-	// assignment, Read wrote 0 to state so HasChange is true and d.Get returns the
-	// config value (the real version the user specified).
-	updateAccountSettingsAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
+	// Capture the real template version from the planned config value before any
+	// Read call, which may write 0 to state when the assignment is in a failed state.
+	realTemplateVersion := int64(d.Get("template_version").(int))
+	updateAccountSettingsAssignmentOptions.SetTemplateVersion(realTemplateVersion)
 
 	if d.HasChange("template_version") {
 		_, response, err := iamIdentityClient.UpdateAccountSettingsAssignmentWithContext(context, updateAccountSettingsAssignmentOptions)
@@ -377,6 +391,16 @@ func resourceIBMAccountSettingsTemplateAssignmentUpdate(context context.Context,
 		}
 	}
 
+	// Read before retry so status and entity_tag are populated in d.
+	if diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta); diags.HasError() {
+		return diags
+	}
+
+	if err := retryAccountSettingsFailedAssignment(context, d, meta, iamIdentityClient, realTemplateVersion); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "update", "retry-failed-assignment").GetDiag()
+	}
+
+	// Final read — persists state and surfaces error if still failed/superseded.
 	diags := resourceIBMAccountSettingsTemplateAssignmentRead(context, d, meta)
 	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
 		diags = append(diags, diag.Diagnostic{
@@ -395,24 +419,107 @@ func resourceIBMAccountSettingsTemplateAssignmentDelete(context context.Context,
 		return tfErr.GetDiag()
 	}
 
-	deleteAccountSettingsAssignmentOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{}
+	// maxRetries is the number of retries after the initial attempt.
+	// Total attempts = maxRetries + 1. Default: 1 retry (2 total attempts).
+	maxRetries := 1
+	if v := os.Getenv("IBMCLOUD_IAM_ACCOUNT_SETTINGS_ASSIGNMENT_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxRetries = n
+		}
+	}
+	maxAttempts := maxRetries + 1
 
-	deleteAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		deleteAccountSettingsAssignmentOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{}
+		deleteAccountSettingsAssignmentOptions.SetAssignmentID(d.Id())
 
-	_, _, err = iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "delete")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		_, _, err = iamIdentityClient.DeleteAccountSettingsAssignmentWithContext(context, deleteAccountSettingsAssignmentOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteAccountSettingsAssignmentWithContext failed: %s", err.Error()), "ibm_iam_account_settings_template_assignment", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+
+		remaining := d.Timeout(schema.TimeoutDelete)
+		if deadline, ok := context.Deadline(); ok {
+			remaining = time.Until(deadline)
+		}
+		if remaining <= 0 {
+			return flex.DiscriminatedTerraformErrorf(fmt.Errorf("timed out"), "timed out waiting for assignment deletion", "ibm_iam_account_settings_template_assignment", "delete", "timeout").GetDiag()
+		}
+
+		_, lastErr = waitForAssignment(remaining, meta, d, isAccountSettingsAssignmentRemoved)
+		if lastErr == nil {
+			// Deletion confirmed.
+			d.SetId("")
+			return nil
+		}
+
+		if attempt < maxAttempts {
+			log.Printf("[INFO] Deletion of assignment %s failed, retrying (%d/%d): %s", d.Id(), attempt, maxRetries, lastErr)
+		}
 	}
 
-	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isAccountSettingsAssignmentRemoved)
-	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_account_settings_template_assignment", "delete", "wait-for-assignment").GetDiag()
+	return flex.DiscriminatedTerraformErrorf(lastErr, lastErr.Error(), "ibm_iam_account_settings_template_assignment", "delete", "wait-for-assignment").GetDiag()
+}
+
+// retryAccountSettingsFailedAssignment issues a PUT retry for each attempt while
+// the assignment status remains "failed", up to the count in
+// IBMCLOUD_IAM_ACCOUNT_SETTINGS_ASSIGNMENT_RETRIES (default 1, set to 0 to disable).
+// Each retry waits only for the time remaining on the parent context deadline so
+// the total duration of all retries never exceeds the configured resource timeout.
+// "superseded" is not retried automatically as it requires external action.
+func retryAccountSettingsFailedAssignment(ctx context.Context, d *schema.ResourceData, meta interface{}, iamIdentityClient *iamidentityv1.IamIdentityV1, templateVersion int64) error {
+	maxRetries := 1
+	if v := os.Getenv("IBMCLOUD_IAM_ACCOUNT_SETTINGS_ASSIGNMENT_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxRetries = n
+		}
 	}
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Only retry when status is "failed"; anything else (success, superseded) exits early.
+		status := d.Get("status").(string)
+		if status != "failed" {
+			return nil
+		}
 
-	d.SetId("")
+		// Use remaining time on the context deadline so all retries together stay
+		// within the configured resource timeout (create or update).
+		remaining := d.Timeout(schema.TimeoutCreate)
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining = time.Until(deadline)
+		}
+		if remaining <= 0 {
+			return fmt.Errorf("timed out waiting for assignment %s to succeed after %d/%d retries", d.Id(), attempt-1, maxRetries)
+		}
 
+		log.Printf("[INFO] Assignment %s is in 'failed' state, issuing PUT retry %d/%d (%s remaining)", d.Id(), attempt, maxRetries, remaining.Round(time.Second))
+
+		updateOptions := &iamidentityv1.UpdateAccountSettingsAssignmentOptions{}
+		updateOptions.SetAssignmentID(d.Id())
+		updateOptions.SetIfMatch(d.Get("entity_tag").(string))
+		updateOptions.SetTemplateVersion(templateVersion)
+
+		if _, _, err := iamIdentityClient.UpdateAccountSettingsAssignmentWithContext(ctx, updateOptions); err != nil {
+			return fmt.Errorf("PUT retry %d/%d failed: %s", attempt, maxRetries, err)
+		}
+
+		if _, err := waitForAssignment(remaining, meta, d, isAccountSettingsTemplateAssigned); err != nil {
+			return fmt.Errorf("PUT retry %d/%d wait failed: %s", attempt, maxRetries, err)
+		}
+
+		// Re-read to refresh entity_tag and status for the next iteration.
+		// Skip on the last attempt — the caller always reads after this function returns.
+		// Note: Read may write template_version=0 to state if still failed, but
+		// templateVersion (the real version) is passed as a parameter so the next
+		// PUT iteration is unaffected.
+		if attempt < maxRetries {
+			if diags := resourceIBMAccountSettingsTemplateAssignmentRead(ctx, d, meta); diags.HasError() {
+				return fmt.Errorf("failed to read assignment after retry %d/%d", attempt, maxRetries)
+			}
+		}
+	}
 	return nil
 }
 

--- a/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go
@@ -50,7 +50,7 @@ func TestAccIBMAccountSettingsTemplateAssignmentBasic(t *testing.T) {
 				),
 			},
 			{
-				ExpectError: regexp.MustCompile("Template version '2' is not found."),
+				ExpectError: regexp.MustCompile(`Assignment version cannot`),
 				Config:      testAccCheckIBMAccountSettingsTemplateAssignmentConfigBasicUpdate(enterpriseAccountId, targetId, name),
 			},
 		},

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -303,7 +303,27 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
-	return resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
+	// Read persists the final state. When status is "failed"/"superseded", Read
+	// writes template_version=0 so the next plan shows a visible update diff.
+	diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
+	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Assignment completed with status '%s'.", status.(string)),
+			Detail: fmt.Sprintf(
+				"The assignment %s is in a '%s' state. Terraform has marked this resource as tainted.\n"+
+					"To retry without destroying and recreating the assignment, run:\n\n"+
+					"  terraform untaint ibm_iam_trusted_profile_template_assignment.<RESOURCE_NAME>\n"+
+					"  terraform apply\n\n"+
+					"Replace <RESOURCE_NAME> with the name of your resource block (e.g. if your config\n"+
+					"is 'resource \"ibm_iam_trusted_profile_template_assignment\" \"assignment\"', use:\n\n"+
+					"  terraform untaint ibm_iam_trusted_profile_template_assignment.assignment\n"+
+					"  terraform apply\n\n"+
+					"This will perform an in-place update (PUT) to retry only the failed resources.",
+				d.Id(), status.(string)),
+		})
+	}
+	return diags
 }
 
 func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -333,7 +353,15 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 		err = fmt.Errorf("Error setting template_id: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-template_id").GetDiag()
 	}
-	if err = d.Set("template_version", flex.IntValue(templateAssignmentResponse.TemplateVersion)); err != nil {
+	// When the assignment is in a failed/superseded state, write 0 for
+	// template_version so Terraform sees a diff against the config value on the
+	// next plan and calls Update, which retries the assignment via PUT.
+	templateVersion := flex.IntValue(templateAssignmentResponse.TemplateVersion)
+	if templateAssignmentResponse.Status != nil &&
+		(*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
+		templateVersion = 0
+	}
+	if err = d.Set("template_version", templateVersion); err != nil {
 		err = fmt.Errorf("Error setting template_version: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-template_version").GetDiag()
 	}
@@ -393,7 +421,6 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 		err = fmt.Errorf("Error setting entity_tag: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-entity_tag").GetDiag()
 	}
-
 	return nil
 }
 
@@ -409,18 +436,16 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 	updateTrustedProfileAssignmentOptions.SetAssignmentID(d.Id())
 	updateTrustedProfileAssignmentOptions.SetIfMatch(d.Get("entity_tag").(string))
 
-	hasChange := false
+	// Always set template_version on the options. When retrying a failed/superseded
+	// assignment, Read wrote 0 to state so HasChange is true and d.Get returns the
+	// config value (the real version the user specified).
+	updateTrustedProfileAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
 
 	if d.HasChange("template_version") {
-		updateTrustedProfileAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
-		hasChange = true
-	}
-
-	if hasChange || d.Get("status") == "failed" { // allow the same version to retry failed assignments
-		_, _, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(context, updateTrustedProfileAssignmentOptions)
+		_, response, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(context, updateTrustedProfileAssignmentOptions)
 		if err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("UpdateTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "update")
-			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			log.Printf("[DEBUG]\n%s\n%s", tfErr.GetDebugMessage(), response)
 			return tfErr.GetDiag()
 		}
 
@@ -430,7 +455,14 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 		}
 	}
 
-	return resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
+	diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
+	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Assignment completed with status '%s'. Run terraform apply again to retry.", status.(string)),
+		})
+	}
+	return diags
 }
 
 func resourceIBMTrustedProfileTemplateAssignmentDelete(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -489,9 +521,14 @@ func isTrustedProfileAssignmentRemoved(id string, meta interface{}) resource.Sta
 			}
 
 			return nil, READY, fmt.Errorf("[ERROR] The assignment %s failed to delete or deletion was not completed within specific timeout period: %s\n%s", id, err, response)
-		} else {
-			log.Printf("Assignment removal still in progress\n")
 		}
+
+		if assignment != nil && assignment.Status != nil && *assignment.Status == "failed" {
+			return assignment, READY, fmt.Errorf("[ERROR] The deletion of assignment %s completed with a 'failed' status. Please check the assignment resource for detailed errors", id)
+		}
+
+		log.Printf("Assignment removal still in progress\n")
+
 		return assignment, WAITING, nil
 	}
 }
@@ -515,8 +552,9 @@ func isTrustedProfileTemplateAssigned(id string, meta interface{}) retry.StateRe
 				return assignment, WAITING, nil
 			}
 
-			if *assignment.Status == "failed" {
-				return assignment, READY, fmt.Errorf("[ERROR] The assignment %s did complete but with a 'failed' status. Please check assignment resource for detailed errors: %s\n", id, response)
+			if *assignment.Status == "failed" || *assignment.Status == "superseded" {
+				log.Printf("[WARN] Assignment %s completed with status '%s'\n", id, *assignment.Status)
+				return assignment, READY, nil
 			}
 
 			return assignment, READY, nil

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -303,6 +305,19 @@ func resourceIBMTrustedProfileTemplateAssignmentCreate(context context.Context, 
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "wait-for-assignment").GetDiag()
 	}
 
+	// Capture the real template version now, before Read potentially writes 0 to
+	// state when the assignment is in a failed state.
+	realTemplateVersion := int64(d.Get("template_version").(int))
+
+	// Read before retry so status and entity_tag are populated in d.
+	if diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta); diags.HasError() {
+		return diags
+	}
+
+	if err = retryTrustedProfileFailedAssignment(context, d, meta, iamIdentityClient, realTemplateVersion); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "create", "retry-failed-assignment").GetDiag()
+	}
+
 	// Read persists the final state. When status is "failed"/"superseded", Read
 	// writes template_version=0 so the next plan shows a visible update diff.
 	diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
@@ -353,12 +368,11 @@ func resourceIBMTrustedProfileTemplateAssignmentRead(context context.Context, d 
 		err = fmt.Errorf("Error setting template_id: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "read", "set-template_id").GetDiag()
 	}
-	// When the assignment is in a failed/superseded state, write 0 for
-	// template_version so Terraform sees a diff against the config value on the
-	// next plan and calls Update, which retries the assignment via PUT.
+	// When the assignment is in a terminal-failure state, persist template_version=0
+	// so that the next terraform plan detects a diff (0 vs the config value) and
+	// triggers an in-place Update (PUT) retry instead of reporting "No changes."
 	templateVersion := flex.IntValue(templateAssignmentResponse.TemplateVersion)
-	if templateAssignmentResponse.Status != nil &&
-		(*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
+	if !core.IsNil(templateAssignmentResponse.Status) && (*templateAssignmentResponse.Status == "failed" || *templateAssignmentResponse.Status == "superseded") {
 		templateVersion = 0
 	}
 	if err = d.Set("template_version", templateVersion); err != nil {
@@ -436,10 +450,10 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 	updateTrustedProfileAssignmentOptions.SetAssignmentID(d.Id())
 	updateTrustedProfileAssignmentOptions.SetIfMatch(d.Get("entity_tag").(string))
 
-	// Always set template_version on the options. When retrying a failed/superseded
-	// assignment, Read wrote 0 to state so HasChange is true and d.Get returns the
-	// config value (the real version the user specified).
-	updateTrustedProfileAssignmentOptions.SetTemplateVersion(int64(d.Get("template_version").(int)))
+	// Capture the real template version from the planned config value before any
+	// Read call, which may write 0 to state when the assignment is in a failed state.
+	realTemplateVersion := int64(d.Get("template_version").(int))
+	updateTrustedProfileAssignmentOptions.SetTemplateVersion(realTemplateVersion)
 
 	if d.HasChange("template_version") {
 		_, response, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(context, updateTrustedProfileAssignmentOptions)
@@ -455,6 +469,16 @@ func resourceIBMTrustedProfileTemplateAssignmentUpdate(context context.Context, 
 		}
 	}
 
+	// Read before retry so status and entity_tag are populated in d.
+	if diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta); diags.HasError() {
+		return diags
+	}
+
+	if err := retryTrustedProfileFailedAssignment(context, d, meta, iamIdentityClient, realTemplateVersion); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "update", "retry-failed-assignment").GetDiag()
+	}
+
+	// Final read — persists state and surfaces error if still failed/superseded.
 	diags := resourceIBMTrustedProfileTemplateAssignmentRead(context, d, meta)
 	if status, ok := d.GetOk("status"); ok && (status.(string) == "failed" || status.(string) == "superseded") {
 		diags = append(diags, diag.Diagnostic{
@@ -473,24 +497,107 @@ func resourceIBMTrustedProfileTemplateAssignmentDelete(context context.Context, 
 		return tfErr.GetDiag()
 	}
 
-	deleteTrustedProfileAssignmentOptions := &iamidentityv1.DeleteTrustedProfileAssignmentOptions{}
+	// maxRetries is the number of retries after the initial attempt.
+	// Total attempts = maxRetries + 1. Default: 1 retry (2 total attempts).
+	maxRetries := 1
+	if v := os.Getenv("IBMCLOUD_IAM_TRUSTED_PROFILE_ASSIGNMENT_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxRetries = n
+		}
+	}
+	maxAttempts := maxRetries + 1
 
-	deleteTrustedProfileAssignmentOptions.SetAssignmentID(d.Id())
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		deleteTrustedProfileAssignmentOptions := &iamidentityv1.DeleteTrustedProfileAssignmentOptions{}
+		deleteTrustedProfileAssignmentOptions.SetAssignmentID(d.Id())
 
-	_, _, err = iamIdentityClient.DeleteTrustedProfileAssignmentWithContext(context, deleteTrustedProfileAssignmentOptions)
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "delete")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		_, _, err = iamIdentityClient.DeleteTrustedProfileAssignmentWithContext(context, deleteTrustedProfileAssignmentOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("DeleteTrustedProfileAssignmentWithContext failed: %s", err.Error()), "ibm_iam_trusted_profile_template_assignment", "delete")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+
+		remaining := d.Timeout(schema.TimeoutDelete)
+		if deadline, ok := context.Deadline(); ok {
+			remaining = time.Until(deadline)
+		}
+		if remaining <= 0 {
+			return flex.DiscriminatedTerraformErrorf(fmt.Errorf("timed out"), "timed out waiting for assignment deletion", "ibm_iam_trusted_profile_template_assignment", "delete", "timeout").GetDiag()
+		}
+
+		_, lastErr = waitForAssignment(remaining, meta, d, isTrustedProfileAssignmentRemoved)
+		if lastErr == nil {
+			// Deletion confirmed.
+			d.SetId("")
+			return nil
+		}
+
+		if attempt < maxAttempts {
+			log.Printf("[INFO] Deletion of assignment %s failed, retrying (%d/%d): %s", d.Id(), attempt, maxRetries, lastErr)
+		}
 	}
 
-	_, err = waitForAssignment(d.Timeout(schema.TimeoutDelete), meta, d, isTrustedProfileAssignmentRemoved)
-	if err != nil {
-		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "wait-for-assignment").GetDiag()
+	return flex.DiscriminatedTerraformErrorf(lastErr, lastErr.Error(), "ibm_iam_trusted_profile_template_assignment", "delete", "wait-for-assignment").GetDiag()
+}
+
+// retryTrustedProfileFailedAssignment issues a PUT retry for each attempt while
+// the assignment status remains "failed", up to the count in
+// IBMCLOUD_IAM_TRUSTED_PROFILE_ASSIGNMENT_RETRIES (default 1, set to 0 to disable).
+// Each retry waits only for the time remaining on the parent context deadline so
+// the total duration of all retries never exceeds the configured resource timeout.
+// "superseded" is not retried automatically as it requires external action.
+func retryTrustedProfileFailedAssignment(ctx context.Context, d *schema.ResourceData, meta interface{}, iamIdentityClient *iamidentityv1.IamIdentityV1, templateVersion int64) error {
+	maxRetries := 1
+	if v := os.Getenv("IBMCLOUD_IAM_TRUSTED_PROFILE_ASSIGNMENT_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxRetries = n
+		}
 	}
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Only retry when status is "failed"; anything else (success, superseded) exits early.
+		status := d.Get("status").(string)
+		if status != "failed" {
+			return nil
+		}
 
-	d.SetId("")
+		// Use remaining time on the context deadline so all retries together stay
+		// within the configured resource timeout (create or update).
+		remaining := d.Timeout(schema.TimeoutCreate)
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining = time.Until(deadline)
+		}
+		if remaining <= 0 {
+			return fmt.Errorf("timed out waiting for assignment %s to succeed after %d/%d retries", d.Id(), attempt-1, maxRetries)
+		}
 
+		log.Printf("[INFO] Assignment %s is in 'failed' state, issuing PUT retry %d/%d (%s remaining)", d.Id(), attempt, maxRetries, remaining.Round(time.Second))
+
+		updateOptions := &iamidentityv1.UpdateTrustedProfileAssignmentOptions{}
+		updateOptions.SetAssignmentID(d.Id())
+		updateOptions.SetIfMatch(d.Get("entity_tag").(string))
+		updateOptions.SetTemplateVersion(templateVersion)
+
+		if _, _, err := iamIdentityClient.UpdateTrustedProfileAssignmentWithContext(ctx, updateOptions); err != nil {
+			return fmt.Errorf("PUT retry %d/%d failed: %s", attempt, maxRetries, err)
+		}
+
+		if _, err := waitForAssignment(remaining, meta, d, isTrustedProfileTemplateAssigned); err != nil {
+			return fmt.Errorf("PUT retry %d/%d wait failed: %s", attempt, maxRetries, err)
+		}
+
+		// Re-read to refresh entity_tag and status for the next iteration.
+		// Skip on the last attempt — the caller always reads after this function returns.
+		// Note: Read may write template_version=0 to state if still failed, but
+		// templateVersion (the real version) is passed as a parameter so the next
+		// PUT iteration is unaffected.
+		if attempt < maxRetries {
+			if diags := resourceIBMTrustedProfileTemplateAssignmentRead(ctx, d, meta); diags.HasError() {
+				return fmt.Errorf("failed to read assignment after retry %d/%d", attempt, maxRetries)
+			}
+		}
+	}
 	return nil
 }
 

--- a/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
+++ b/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
@@ -49,7 +49,7 @@ func TestAccIBMTrustedProfileTemplateAssignmentBasic(t *testing.T) {
 				),
 			},
 			{
-				ExpectError: regexp.MustCompile("Template version '3' is not found."),
+				ExpectError: regexp.MustCompile(`Assignment version cannot`),
 				Config:      testAccCheckIBMTrustedProfileTemplateAssignmentConfigBasic(enterpriseAccountId, targetId, name, 3),
 			},
 			{

--- a/website/docs/r/account_settings_template_assignment.html.markdown
+++ b/website/docs/r/account_settings_template_assignment.html.markdown
@@ -63,6 +63,35 @@ After your resource is created, you can read values from the listed arguments an
 * `last_modified_by_id` - (String) IAMid of the identity that last modified the assignment.
 * `entity_tag` - (String) Entity tag for this assignment record.
 
+## Failed or Superseded Assignment Retry
+
+Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state, the provider will surface an error and Terraform will mark the resource as **tainted**.
+
+* **`failed`** — The assignment encountered an error during processing. A PUT retry will attempt to apply only the sub-resources that failed.
+* **`superseded`** — Another existing assignment has taken precedence over this one. A retry should only be attempted once the superseding assignment has been removed, otherwise the retry will result in the same `superseded` state.
+
+A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry should issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
+
+```bash
+terraform untaint ibm_iam_account_settings_template_assignment.<NAME>
+terraform apply
+```
+
+Replace `<NAME>` with the label of your resource block. For example, if your configuration is:
+
+```hcl
+resource "ibm_iam_account_settings_template_assignment" "assignment" { ... }
+```
+
+Run:
+
+```bash
+terraform untaint ibm_iam_account_settings_template_assignment.assignment
+terraform apply
+```
+
+On the next `terraform apply` after untainting, the provider will detect the `failed` status and automatically issue a PUT retry against the existing assignment. Subsequent failures will produce an error directly from the update operation (no taint, no untaint required — just run `terraform apply` again).
+
 ## Import
 
 You can import the `ibm_iam_account_settings_template_assignment` resource by using `id`. Assignment record Id.

--- a/website/docs/r/account_settings_template_assignment.html.markdown
+++ b/website/docs/r/account_settings_template_assignment.html.markdown
@@ -65,12 +65,12 @@ After your resource is created, you can read values from the listed arguments an
 
 ## Failed or Superseded Assignment Retry
 
-Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state, the provider will surface an error and Terraform will mark the resource as **tainted**.
+Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state after all automatic retries are exhausted, the provider will surface an error and Terraform will mark the resource as **tainted**.
 
 * **`failed`** — The assignment encountered an error during processing. A PUT retry will attempt to apply only the sub-resources that failed.
 * **`superseded`** — Another existing assignment has taken precedence over this one. A retry should only be attempted once the superseding assignment has been removed, otherwise the retry will result in the same `superseded` state.
 
-A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry should issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
+A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry must issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
 
 ```bash
 terraform untaint ibm_iam_account_settings_template_assignment.<NAME>
@@ -90,7 +90,22 @@ terraform untaint ibm_iam_account_settings_template_assignment.assignment
 terraform apply
 ```
 
-On the next `terraform apply` after untainting, the provider will detect the `failed` status and automatically issue a PUT retry against the existing assignment. Subsequent failures will produce an error directly from the update operation (no taint, no untaint required — just run `terraform apply` again).
+After untainting, the provider records `template_version = 0` in state so that the next `terraform apply` detects a difference and issues an in-place PUT retry. Subsequent failures from the update path (no taint involved) require no untaint — just run `terraform apply` again.
+
+### Automatic retries
+
+Before surfacing the error, the provider automatically retries failed assignments up to a configurable number of times within the same `terraform apply`. The retry count is controlled by the environment variable:
+
+```
+IBMCLOUD_IAM_ACCOUNT_SETTINGS_ASSIGNMENT_RETRIES
+```
+
+The default is `1`. Set to `0` to disable automatic retries. For example, to retry up to 3 times:
+
+```bash
+export IBMCLOUD_IAM_ACCOUNT_SETTINGS_ASSIGNMENT_RETRIES=3
+terraform apply
+```
 
 ## Import
 

--- a/website/docs/r/trusted_profile_template_assignment.html.markdown
+++ b/website/docs/r/trusted_profile_template_assignment.html.markdown
@@ -75,6 +75,35 @@ Nested schema for **resources**:
 	* `target` - (String) Target account where the IAM resource is created.
 * `status` - (String) Assignment status.
 
+## Failed or Superseded Assignment Retry
+
+Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state, the provider will surface an error and Terraform will mark the resource as **tainted**.
+
+* **`failed`** — The assignment encountered an error during processing. A PUT retry will attempt to apply only the sub-resources that failed.
+* **`superseded`** — Another existing assignment has taken precedence over this one. A retry should only be attempted once the superseding assignment has been removed, otherwise the retry will result in the same `superseded` state.
+
+A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry should issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
+
+```bash
+terraform untaint ibm_iam_trusted_profile_template_assignment.<NAME>
+terraform apply
+```
+
+Replace `<NAME>` with the label of your resource block. For example, if your configuration is:
+
+```hcl
+resource "ibm_iam_trusted_profile_template_assignment" "assignment" { ... }
+```
+
+Run:
+
+```bash
+terraform untaint ibm_iam_trusted_profile_template_assignment.assignment
+terraform apply
+```
+
+On the next `terraform apply` after untainting, the provider will detect the `failed` status and automatically issue a PUT retry against the existing assignment. Subsequent failures will produce an error directly from the update operation (no taint, no untaint required — just run `terraform apply` again).
+
 ## Import
 
 You can import the `ibm_iam_trusted_profile_template_assignment` resource by using `id`. Assignment record Id.

--- a/website/docs/r/trusted_profile_template_assignment.html.markdown
+++ b/website/docs/r/trusted_profile_template_assignment.html.markdown
@@ -77,12 +77,12 @@ Nested schema for **resources**:
 
 ## Failed or Superseded Assignment Retry
 
-Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state, the provider will surface an error and Terraform will mark the resource as **tainted**.
+Creating or updating an assignment is an asynchronous operation. If the assignment reaches a `failed` or `superseded` terminal state after all automatic retries are exhausted, the provider will surface an error and Terraform will mark the resource as **tainted**.
 
 * **`failed`** — The assignment encountered an error during processing. A PUT retry will attempt to apply only the sub-resources that failed.
 * **`superseded`** — Another existing assignment has taken precedence over this one. A retry should only be attempted once the superseding assignment has been removed, otherwise the retry will result in the same `superseded` state.
 
-A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry should issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
+A tainted resource would normally be destroyed and recreated on the next `terraform apply`. Because an assignment retry must issue a PUT (to retry only the failed sub-resources) rather than a DELETE + POST, you must **untaint** the resource before retrying:
 
 ```bash
 terraform untaint ibm_iam_trusted_profile_template_assignment.<NAME>
@@ -102,7 +102,22 @@ terraform untaint ibm_iam_trusted_profile_template_assignment.assignment
 terraform apply
 ```
 
-On the next `terraform apply` after untainting, the provider will detect the `failed` status and automatically issue a PUT retry against the existing assignment. Subsequent failures will produce an error directly from the update operation (no taint, no untaint required — just run `terraform apply` again).
+After untainting, the provider records `template_version = 0` in state so that the next `terraform apply` detects a difference and issues an in-place PUT retry. Subsequent failures from the update path (no taint involved) require no untaint — just run `terraform apply` again.
+
+### Automatic retries
+
+Before surfacing the error, the provider automatically retries failed assignments up to a configurable number of times within the same `terraform apply`. The retry count is controlled by the environment variable:
+
+```
+IBMCLOUD_IAM_TRUSTED_PROFILE_ASSIGNMENT_RETRIES
+```
+
+The default is `1`. Set to `0` to disable automatic retries. For example, to retry up to 3 times:
+
+```bash
+export IBMCLOUD_IAM_TRUSTED_PROFILE_ASSIGNMENT_RETRIES=3
+terraform apply
+```
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
terraform-provider-ibm (assignment-retry) make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go                                                                                                                                                                          ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go -v  -timeout 700m 
=== RUN   TestAccIBMAccountSettingsTemplateAssignmentBasic
--- PASS: TestAccIBMAccountSettingsTemplateAssignmentBasic (209.17s)
PASS
ok      command-line-arguments  211.667s

terraform-provider-ibm (assignment-retry) make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go                                                                                                                                                                           ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go -v  -timeout 700m 
=== RUN   TestAccIBMTrustedProfileTemplateAssignmentBasic
--- PASS: TestAccIBMTrustedProfileTemplateAssignmentBasic (364.13s)
PASS
ok      command-line-arguments  366.330s
...
```


**Output from acceptance testing: second commit**
```
➜  terraform-provider-ibm (assignment-retry) make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/iamidentity/resource_ibm_iam_account_settings_template_assignment_test.go -v  -timeout 700m 
=== RUN   TestAccIBMAccountSettingsTemplateAssignmentBasic
--- PASS: TestAccIBMAccountSettingsTemplateAssignmentBasic (257.17s)
PASS
ok      command-line-arguments  259.522s


➜  terraform-provider-ibm (assignment-retry) make testacc TEST=./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go
TF_ACC=1 go test ./ibm/service/iamidentity/resource_ibm_iam_trusted_profile_template_assignment_test.go -v  -timeout 700m 
=== RUN   TestAccIBMTrustedProfileTemplateAssignmentBasic
--- PASS: TestAccIBMTrustedProfileTemplateAssignmentBasic (335.57s)
PASS
ok      command-line-arguments  337.880s
```
