### PR TITLE
Add IBM Cloudant Gen 2 plan support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2391,6 +2391,74 @@
         "verified_result": null
       }
     ],
+    "ibm/service/cloudant/cloudant_utils.go": [
+      {
+        "hashed_secret": "0498bc9e372a86de4cec00c77e2a05a79c9d0e5f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 217,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 231,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2e81e24c4d2c84cca06ec032fc31fd9ac5409454",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 277,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2d5288d4f7c026f96dd685827fe1c43337571e8a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 336,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 372,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm/service/cloudant/cloudant_utils_test.go": [
+      {
+        "hashed_secret": "6da9eab371358a331c59a76d80a0ffcd589fe3c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 414,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8e2d2b7918839eef755ecb9181235cc83934befb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 645,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "724ba0f0a4c4226b95478a7f304efd7951250ed3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 730,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "ibm/service/cloudant/data_source_ibm_cloudant.go": [
       {
         "hashed_secret": "f855f5027fd8fdb2df3f6a6f1cf858fffcbedb0c",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2464,7 +2464,7 @@
         "hashed_secret": "f855f5027fd8fdb2df3f6a6f1cf858fffcbedb0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 85,
+        "line_number": 77,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2474,7 +2474,7 @@
         "hashed_secret": "3046d9f6cfaaeea6eed9bb7a4ab010fe49b0cfd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 52,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2482,31 +2482,7 @@
         "hashed_secret": "f855f5027fd8fdb2df3f6a6f1cf858fffcbedb0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2e81e24c4d2c84cca06ec032fc31fd9ac5409454",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0498bc9e372a86de4cec00c77e2a05a79c9d0e5f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 398,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 410,
+        "line_number": 109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2514,7 +2490,7 @@
         "hashed_secret": "3db21c9f89f3c840de8358b5af922eb7f9eed330",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 556,
+        "line_number": 467,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5582,7 +5558,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 82,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/ibm-cloudant/standard-gen2-plan-with-database/README.md
+++ b/examples/ibm-cloudant/standard-gen2-plan-with-database/README.md
@@ -1,0 +1,25 @@
+# IBM Cloudant example for Standard Gen 2 plan with a new database
+
+This example shows how to create a Standard Gen 2 plan Cloudant instance with a new database.
+
+To run, configure your IBM Cloudant provider
+
+Running the example
+
+For planning phase
+
+```sh
+terraform plan
+```
+
+For apply phase
+
+```sh
+terraform apply
+```
+
+For destroy
+
+```sh
+terraform destroy
+```

--- a/examples/ibm-cloudant/standard-gen2-plan-with-database/main.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan-with-database/main.tf
@@ -1,0 +1,30 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region           = var.service_region
+}
+
+// Provision cloudant resource instance with Standard Gen 2 plan and 2 capacity throughput blocks
+resource "ibm_cloudant" "cloudant" {
+  // Required arguments:
+  name     = "test_standard_gen2_plan_cloudant"
+  location = var.service_region
+  plan     = "standard-gen2"
+  // Optional arguments:
+  capacity = 2
+}
+
+// Create cloudant data source
+data "ibm_cloudant" "cloudant" {
+  name = ibm_cloudant.cloudant.name
+}
+
+// Create database
+resource "ibm_cloudant_database" "database" {
+  db           = var.db_name
+  instance_crn = ibm_cloudant.cloudant.crn
+}
+
+data "ibm_cloudant_database" "database" {
+  db           = ibm_cloudant_database.database.db
+  instance_crn = ibm_cloudant_database.database.instance_crn
+}

--- a/examples/ibm-cloudant/standard-gen2-plan-with-database/outputs.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan-with-database/outputs.tf
@@ -1,0 +1,6 @@
+// This allows cloudant data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+output "ibm_cloudant" {
+  value       = ibm_cloudant.cloudant
+  description = "cloudant resource instance"
+}

--- a/examples/ibm-cloudant/standard-gen2-plan-with-database/variables.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan-with-database/variables.tf
@@ -1,0 +1,19 @@
+// Resource arguments for ibmcloud_api_key
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key."
+  type        = string
+  sensitive   = true
+}
+
+// Resource arguments for service_region
+variable "service_region" {
+  description = "Region in which service has to be provisioned."
+  type        = string
+  default     = "us-south"
+}
+
+// Resource arguments for db
+variable "db_name" {
+  description = "A name of database to create."
+  type        = string
+}

--- a/examples/ibm-cloudant/standard-gen2-plan-with-database/versions.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan-with-database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/examples/ibm-cloudant/standard-gen2-plan/README.md
+++ b/examples/ibm-cloudant/standard-gen2-plan/README.md
@@ -1,0 +1,25 @@
+# IBM Cloudant example for Standard Gen 2 plan with custom capacity
+
+This example shows how to create a Standard Gen 2 plan Cloudant instance with 2 capacity throughput blocks.
+
+To run, configure your IBM Cloudant provider
+
+Running the example
+
+For planning phase
+
+```sh
+terraform plan
+```
+
+For apply phase
+
+```sh
+terraform apply
+```
+
+For destroy
+
+```sh
+terraform destroy
+```

--- a/examples/ibm-cloudant/standard-gen2-plan/main.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan/main.tf
@@ -1,0 +1,19 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region           = var.service_region
+}
+
+// Provision cloudant resource instance with Standard Gen 2 plan and 2 capacity throughput blocks
+resource "ibm_cloudant" "cloudant" {
+  // Required arguments:
+  name     = "test_standard_gen2_plan_cloudant"
+  location = var.service_region
+  plan     = "standard-gen2"
+  // Optional arguments:
+  capacity = 2
+}
+
+// Create cloudant data source
+data "ibm_cloudant" "cloudant" {
+  name = ibm_cloudant.cloudant.name
+}

--- a/examples/ibm-cloudant/standard-gen2-plan/outputs.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan/outputs.tf
@@ -1,0 +1,6 @@
+// This allows cloudant data to be referenced by other resources and the terraform CLI
+// Modify this if only certain data should be exposed
+output "ibm_cloudant" {
+  value       = ibm_cloudant.cloudant
+  description = "cloudant resource instance"
+}

--- a/examples/ibm-cloudant/standard-gen2-plan/variables.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan/variables.tf
@@ -1,0 +1,13 @@
+// Resource arguments for ibmcloud_api_key
+variable "ibmcloud_api_key" {
+  description = "IBM Cloud API key."
+  type        = string
+  sensitive   = true
+}
+
+// Resource arguments for service_region
+variable "service_region" {
+  description = "Region in which service has to be provisioned."
+  type        = string
+  default     = "us-south"
+}

--- a/examples/ibm-cloudant/standard-gen2-plan/versions.tf
+++ b/examples/ibm-cloudant/standard-gen2-plan/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/ibm/service/cloudant/cloudant_utils.go
+++ b/ibm/service/cloudant/cloudant_utils.go
@@ -1,0 +1,475 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/version"
+	"github.com/IBM/cloudant-go-sdk/cloudantv1"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
+	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var cloudantGen1PlanNames = map[string]struct{}{
+	"dedicated-hardware": {},
+	"lite":               {},
+	"standard":           {},
+}
+
+// isCloudantGen2Plan reports whether the given plan name identifies a Gen 2
+// Cloudant instance. Any plan not in the known Gen 1 set is treated as Gen 2.
+// An empty or whitespace-only plan defaults to Gen 1 behaviour.
+func isCloudantGen2Plan(plan string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(plan))
+	if normalized == "" {
+		return false
+	}
+	_, ok := cloudantGen1PlanNames[normalized]
+	return !ok
+}
+
+// isCloudantGen2PlanFrom is a convenience wrapper around isCloudantGen2Plan
+// that reads the "plan" attribute from rd, accepting either *schema.ResourceData
+// or *schema.ResourceDiff via the resourceDataGetter interface.
+func isCloudantGen2PlanFrom(rd resourceDataGetter) bool {
+	return isCloudantGen2Plan(rd.Get("plan").(string))
+}
+
+// GetCloudantClientFromCrn creates an authenticated Cloudant SDK client for a given instance CRN.
+func GetCloudantClientFromCrn(instanceCRN string, meta interface{}, resourceName string, operation string) (*cloudantv1.CloudantV1, *flex.TerraformProblem) {
+	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
+	if err != nil {
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "get-resource-controller-client")
+	}
+
+	resourceInstanceGet := rc.GetResourceInstanceOptions{
+		ID: flex.PtrToString(instanceCRN),
+	}
+
+	instance, resp, err := rsConClient.GetResourceInstance(&resourceInstanceGet)
+	if err != nil {
+		err = fmt.Errorf("Error retrieving resource instance: %s with resp code: %s", err, resp)
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "get-resource-instance")
+	}
+
+	instanceExtensionMap, tfErr := getCloudantExtensions(instance.Extensions, resourceName, operation)
+	if tfErr != nil {
+		return nil, tfErr
+	}
+
+	return getCloudantClientFromExtensions(instanceExtensionMap, meta, resourceName, operation)
+}
+
+// GetCloudantClientFromResource creates an authenticated Cloudant SDK client from resource data extensions.
+func GetCloudantClientFromResource(d *schema.ResourceData, meta interface{}, resourceName string, operation string) (*cloudantv1.CloudantV1, *flex.TerraformProblem) {
+	instanceExtensionMap, tfErr := getCloudantExtensions(d.Get("extensions"), resourceName, operation)
+	if tfErr != nil {
+		return nil, tfErr
+	}
+
+	return getCloudantClientFromExtensions(instanceExtensionMap, meta, resourceName, operation)
+}
+
+func getCloudantExtensions(rawExtensions interface{}, resourceName string, operation string) (flex.Map, *flex.TerraformProblem) {
+	extensions, ok := rawExtensions.(map[string]interface{})
+	if !ok || extensions == nil {
+		err := fmt.Errorf("Missing Cloudant extensions")
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "missing-extensions")
+	}
+
+	result := flex.Flatten(extensions)
+	if len(result) == 0 {
+		err := fmt.Errorf("Cloudant extensions are empty — instance may not be fully provisioned")
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "empty-extensions")
+	}
+	return result, nil
+}
+
+// getCloudantClientFromExtensions creates an authenticated Cloudant SDK client from flattened Cloudant extensions.
+func getCloudantClientFromExtensions(instanceExtensionMap flex.Map, meta interface{}, resourceName string, operation string) (*cloudantv1.CloudantV1, *flex.TerraformProblem) {
+	endpoint, isGen2, err := getCloudantInstanceUrl(instanceExtensionMap, meta)
+	if err != nil {
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "get-instance-url")
+	}
+
+	client, err := getCloudantClientForUrl(endpoint, isGen2, meta)
+	if err != nil {
+		return nil, flex.DiscriminatedTerraformErrorf(err, err.Error(), resourceName, operation, "get-client")
+	}
+
+	return client, nil
+}
+
+// getCloudantInstanceUrl retrieves the Cloudant instance URL from flattened extensions.
+// It handles both Gen1 and Gen2 endpoint formats and respects the visibility
+// configuration (private, public, or public-and-private) from the provider.
+// Returns the endpoint URL and a boolean indicating if it's a Gen2 instance.
+func getCloudantInstanceUrl(instanceExtensionMap flex.Map, meta interface{}) (string, bool, error) {
+	bxSession, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return "", false, fmt.Errorf("Error getting session: %s", err)
+	}
+
+	cloudantInstanceUrl, isGen2 := selectCloudantEndpoint(instanceExtensionMap, bxSession.Config.Visibility)
+	if cloudantInstanceUrl == "" {
+		if bxSession.Config.Visibility == "private" {
+			return "", false, fmt.Errorf("Unable to get private URL for Cloudant instance: no private endpoint available")
+		}
+		return "", false, fmt.Errorf("Unable to get URL for cloudant instance")
+	}
+
+	cloudantInstanceUrl = conns.EnvFallBack([]string{"IBMCLOUD_CLOUDANT_API_ENDPOINT"}, cloudantInstanceUrl)
+	return cloudantInstanceUrl, isGen2, nil
+}
+
+// selectCloudantEndpoint selects the appropriate Cloudant endpoint based on
+// visibility configuration and available endpoint formats (Gen1 vs Gen2).
+// Returns the selected endpoint URL and a boolean indicating if it's a Gen2 instance.
+//
+// Visibility modes:
+// - "private": Only use private endpoints
+// - "public-and-private": Prefer private, fallback to public
+// - default: Use public endpoints
+func selectCloudantEndpoint(instanceExtensionMap flex.Map, visibility string) (string, bool) {
+	// Determine which generation is available and set public/private URLs accordingly
+	var publicURL, privateURL string
+	var isGen2 bool
+
+	// Check Gen2 format: extensions.dataservices.connection
+	gen2Public := instanceExtensionMap["dataservices.connection.public_endpoint_url"]
+	gen2Private := instanceExtensionMap["dataservices.connection.vpe_url"]
+
+	if gen2Public != "" || gen2Private != "" {
+		// Gen2 instance
+		publicURL = gen2Public
+		privateURL = gen2Private
+		isGen2 = true
+	} else {
+		// Gen1 instance: extensions.endpoints
+		publicURL = normalizeEndpoint(instanceExtensionMap["endpoints.public"])
+		privateURL = normalizeEndpoint(instanceExtensionMap["endpoints.private"])
+		isGen2 = false
+	}
+
+	// Select endpoint based on visibility configuration
+	var selectedURL string
+	switch visibility {
+	case "private":
+		selectedURL = privateURL
+	case "public-and-private":
+		if privateURL != "" {
+			selectedURL = privateURL
+		} else {
+			selectedURL = publicURL
+		}
+	default:
+		selectedURL = publicURL
+	}
+
+	return selectedURL, isGen2
+}
+
+// normalizeEndpoint ensures the endpoint has the https:// scheme prefix.
+// Gen2 endpoints already include the scheme, but Gen1 endpoints do not.
+func normalizeEndpoint(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	if strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "http://") {
+		return endpoint
+	}
+	return "https://" + endpoint
+}
+
+// getCloudantClientForUrl creates an authenticated Cloudant SDK client for the given endpoint.
+// It handles both bearer token and API key authentication, and configures the IAM URL
+// based on visibility settings and instance generation.
+//
+// Gen 2 instances use the VPE private IAM URL: https://private.iam.cloud.ibm.com
+// Gen 1 instances use regional private IAM URLs: https://private.{region}.iam.cloud.ibm.com
+//
+// This function is shared between cloudant_resource and cloudant_resource_database.
+func getCloudantClientForUrl(endpoint string, isGen2 bool, meta interface{}) (*cloudantv1.CloudantV1, error) {
+	session, err := meta.(conns.ClientSession).BluemixSession()
+	if err != nil {
+		return nil, err
+	}
+
+	var authenticator core.Authenticator
+	token := session.Config.IAMAccessToken
+
+	if token != "" {
+		token = strings.Replace(token, "Bearer ", "", -1)
+		authenticator = &core.BearerTokenAuthenticator{
+			BearerToken: token,
+		}
+	} else {
+		apiKey := session.Config.BluemixAPIKey
+		region := session.Config.Region
+		visibility := session.Config.Visibility
+		iamURL := iamidentityv1.DefaultServiceURL
+		if visibility == "private" || visibility == "public-and-private" {
+			if isGen2 {
+				// Gen 2 uses VPE private IAM URL
+				iamURL = conns.ContructEndpoint("private.iam", "cloud.ibm.com")
+			} else {
+				// Gen 1 uses regional private IAM URLs: private.{region}.iam.cloud.ibm.com
+				iamURL = conns.ContructEndpoint(fmt.Sprintf("private.%s.iam", region), "cloud.ibm.com")
+			}
+		}
+		authenticator = &core.IamAuthenticator{
+			ApiKey: apiKey,
+			URL:    conns.EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL) + "/identity/token",
+		}
+	}
+
+	client, err := cloudantv1.NewCloudantV1(&cloudantv1.CloudantV1Options{
+		Authenticator: authenticator,
+		URL:           endpoint,
+	})
+	if err != nil {
+		return nil, flex.FmtErrorf("[ERROR] Error occured while configuring Cloudant service: %q", err)
+	}
+	client.Service.SetUserAgent("cloudant-terraform/" + version.Version)
+
+	return client, nil
+}
+
+// cloudantToResourceInstance mutates d in-place to prepare it for an RC CRUD
+// call. Cloudant-only schema attributes are mapped into the RC transport fields:
+//
+//   - Gen 1: legacy_credentials and environment_crn are merged into parameters
+//     alongside any user-supplied keys. Typed schema attributes win over
+//     any conflicting user-supplied values.
+//   - Gen 2: capacity, enable_cors, and cors_config are encoded as a nested JSON
+//     object and written to parameters_json, which the RC layer unmarshals
+//     into the correct nested broker payload. User-supplied parameters are
+//     folded into the same JSON object; typed schema attributes take
+//     precedence over any conflicting user-supplied dataservices.cloudant.*
+//     keys.
+func cloudantToResourceInstance(d *schema.ResourceData) error {
+	if isCloudantGen2PlanFrom(d) {
+		// Seed from user-supplied parameters so that typed fields written below
+		// always take precedence over any conflicting user-supplied values.
+		paramsJSON, err := cloudantGen2ParamsAsJSON(seedParamsFromExisting(d), d)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("parameters_json", paramsJSON); err != nil {
+			return fmt.Errorf("error setting parameters_json: %s", err)
+		}
+	} else {
+		// Gen 1: merge Cloudant-only fields into parameters. Start with any
+		// user-supplied keys so that typed fields written below take precedence.
+		params := seedParamsFromExisting(d)
+		// Always send legacyCredentials explicitly — the server default is true,
+		// so omitting it when the user set false would silently enable it.
+		params["legacyCredentials"] = fmt.Sprintf("%t", d.Get("legacy_credentials").(bool))
+		if environmentCRN, ok := d.GetOk("environment_crn"); ok {
+			params["environment_crn"] = environmentCRN
+		}
+		if err := d.Set("parameters", params); err != nil {
+			return fmt.Errorf("error setting parameters: %s", err)
+		}
+	}
+	return nil
+}
+
+// resourceInstanceToCloudant mutates d in-place after an RC CRUD call, mapping
+// RC response fields back into Cloudant-specific schema attributes and cleaning
+// up the transport fields so they do not leak into state:
+//
+//   - Gen 1: extracts legacy_credentials and environment_crn from the parameters
+//     map (populated before the RC call by cloudantToResourceInstance),
+//     then removes those keys from parameters so only user-supplied keys
+//     remain in state.
+//   - Gen 2: reads capacity, enable_cors, and cors_config from the extensions
+//     flat TypeMap (populated by the RC read);
+//     throughput is Gen 1-only so it is set to an empty map.
+func resourceInstanceToCloudant(d *schema.ResourceData) {
+	if isCloudantGen2PlanFrom(d) {
+		if err := d.Set("throughput", map[string]interface{}{}); err != nil {
+			log.Printf("[WARN] error clearing throughput for Gen 2 instance: %s", err)
+		}
+
+		ext, ok := d.Get("extensions").(map[string]interface{})
+		if !ok || len(ext) == 0 {
+			return
+		}
+
+		if capacityStr, ok := extStr(ext, "dataservices.cloudant.capacity_units"); ok {
+			if capacity, err := strconv.Atoi(capacityStr); err == nil {
+				if err := d.Set("capacity", capacity); err != nil {
+					log.Printf("[WARN] error setting capacity: %s", err)
+				}
+			}
+		}
+
+		if dataEventsStr, ok := extStr(ext, "dataservices.cloudant.configuration.audit.data_events"); ok {
+			includeDataEvents := dataEventsStr == "true"
+			if err := d.Set("include_data_events", includeDataEvents); err != nil {
+				log.Printf("[WARN] error setting include_data_events: %s", err)
+			}
+		}
+
+		if enabledStr, ok := extStr(ext, "dataservices.cloudant.configuration.cors.enabled"); ok {
+			enabled := enabledStr == "true"
+			if err := d.Set("enable_cors", enabled); err != nil {
+				log.Printf("[WARN] error setting enable_cors: %s", err)
+			}
+			if enabled {
+				corsState := map[string]interface{}{
+					"allow_credentials": false,
+					"origins":           []string{},
+				}
+				if acStr, ok := extStr(ext, "dataservices.cloudant.configuration.cors.allowCredentials"); ok {
+					corsState["allow_credentials"] = acStr == "true"
+				}
+				if countStr, ok := extStr(ext, "dataservices.cloudant.configuration.cors.origins.#"); ok {
+					if count, err := strconv.Atoi(countStr); err == nil && count > 0 {
+						origins := make([]string, 0, count)
+						for i := 0; i < count; i++ {
+							key := fmt.Sprintf("dataservices.cloudant.configuration.cors.origins.%d", i)
+							if origin, ok := extStr(ext, key); ok {
+								origins = append(origins, origin)
+							}
+						}
+						corsState["origins"] = origins
+					}
+				}
+				if err := d.Set("cors_config", []map[string]interface{}{corsState}); err != nil {
+					log.Printf("[WARN] error setting cors_config: %s", err)
+				}
+			}
+		}
+	} else {
+		// Gen 1: extract Cloudant-specific fields from parameters and remove
+		// them so only user-supplied keys remain in state.
+		parameters, ok := d.Get("parameters").(map[string]interface{})
+		if !ok || parameters == nil {
+			return
+		}
+
+		if legacyCredentials, ok := parameters["legacyCredentials"]; ok {
+			var val bool
+			switch v := legacyCredentials.(type) {
+			case bool:
+				val = v
+			case string:
+				val = v == "true"
+			}
+			if err := d.Set("legacy_credentials", val); err != nil {
+				log.Printf("[WARN] error setting legacy_credentials: %s", err)
+			}
+			delete(parameters, "legacyCredentials")
+		}
+
+		if crn, ok := parameters["environment_crn"].(string); ok {
+			if err := d.Set("environment_crn", crn); err != nil {
+				log.Printf("[WARN] error setting environment_crn: %s", err)
+			}
+			delete(parameters, "environment_crn")
+		}
+
+		// Write back the cleaned parameters map (user keys only).
+		// Always call Set so the SDK sees the mutation; use an empty map
+		// rather than nil so the TypeMap is explicitly cleared.
+		if err := d.Set("parameters", parameters); err != nil {
+			log.Printf("[WARN] error setting parameters: %s", err)
+		}
+	}
+}
+
+// resourceDataGetter is satisfied by both *schema.ResourceData and
+// *schema.ResourceDiff, which share a Get(string) interface{} method.
+type resourceDataGetter interface {
+	Get(string) interface{}
+}
+
+// cloudantGen2ParamsAsJSON builds the nested Cloudant Gen 2 broker payload
+// (capacity_units and cors configuration) from rd, merges it with any
+// user-supplied parameters already present in params, and returns the result
+// as a marshalled JSON string. Typed schema attributes always overwrite
+// any conflicting user-supplied dataservices.cloudant.* keys.
+//
+// This function is called both from cloudantToResourceInstance (at CRUD time)
+// and from the ResourceIBMCloudant CustomizeDiff closure (at plan time) so that
+// the two places never drift out of sync.
+func cloudantGen2ParamsAsJSON(params map[string]interface{}, rd resourceDataGetter) (string, error) {
+	dataservices, _ := params["dataservices"].(map[string]interface{})
+	if dataservices == nil {
+		dataservices = map[string]interface{}{}
+		params["dataservices"] = dataservices
+	}
+	cloudant, _ := dataservices["cloudant"].(map[string]interface{})
+	if cloudant == nil {
+		cloudant = map[string]interface{}{}
+		dataservices["cloudant"] = cloudant
+	}
+	cloudant["capacity_units"] = rd.Get("capacity").(int)
+
+	configuration, _ := cloudant["configuration"].(map[string]interface{})
+	if configuration == nil {
+		configuration = map[string]interface{}{}
+		cloudant["configuration"] = configuration
+	}
+	enableCors := rd.Get("enable_cors").(bool)
+	corsConfig := map[string]interface{}{"enabled": enableCors}
+	if enableCors {
+		corsConfig["allowCredentials"] = true
+		corsConfig["origins"] = []string{}
+		if corsConfigRaw := rd.Get("cors_config").([]interface{}); len(corsConfigRaw) > 0 {
+			m := corsConfigRaw[0].(map[string]interface{})
+			corsConfig["allowCredentials"] = m["allow_credentials"].(bool)
+			corsConfig["origins"] = flex.ExpandStringList(m["origins"].([]interface{}))
+		}
+	}
+	configuration["cors"] = corsConfig
+
+	auditConfig := map[string]interface{}{
+		"data_events": rd.Get("include_data_events").(bool),
+	}
+	configuration["audit"] = auditConfig
+
+	b, err := json.Marshal(params)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling Gen 2 parameters: %s", err)
+	}
+	return string(b), nil
+}
+
+// seedParamsFromExisting returns a new map pre-seeded with any user-supplied
+// parameters from d, so that typed schema attributes written afterwards
+// always win over any conflicting user-provided values.
+func seedParamsFromExisting(d *schema.ResourceData) map[string]interface{} {
+	params := make(map[string]interface{})
+	if existing, ok := d.GetOk("parameters"); ok {
+		for k, v := range existing.(map[string]interface{}) {
+			params[k] = v
+		}
+	}
+	return params
+}
+
+// extStr returns the string value for key from a flat extensions map,
+// reporting false if the key is absent or its value is not a non-empty string.
+func extStr(ext map[string]interface{}, key string) (string, bool) {
+	v, ok := ext[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok && s != ""
+}
+
+// Made with Bob

--- a/ibm/service/cloudant/cloudant_utils_test.go
+++ b/ibm/service/cloudant/cloudant_utils_test.go
@@ -1,0 +1,1008 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcecontroller"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestMain seeds the provider validator registry before any tests run.
+// ResourceIBMResourceInstance() (called by ResourceIBMCloudant()) invokes
+// validate.InvokeValidator, which dereferences the ResourceValidatorDictionary
+// pointer entries; without registration every call panics with a nil pointer
+// dereference. Registering the actual RC validator is sufficient — unit tests
+// here never exercise field-level validation so the exact schema content does
+// not matter.
+func TestMain(m *testing.M) {
+	validate.SetValidatorDict(validate.ValidatorDict{
+		ResourceValidatorDictionary: map[string]*validate.ResourceValidator{
+			"ibm_resource_instance": resourcecontroller.ResourceIBMResourceInstanceValidator(),
+		},
+		DataSourceValidatorDictionary: map[string]*validate.ResourceValidator{},
+	})
+	os.Exit(m.Run())
+}
+
+// Realistic instance UUIDs and endpoint hostnames used across tests.
+const (
+	// Gen 1 — extensions.endpoints values are bare hostnames (no scheme).
+	gen1PublicHost  = "00000000-0000-0000-0000-000000000000-bluemix.cloudantnosqldb.appdomain.cloud"
+	gen1PrivateHost = "00000000-0000-0000-0000-000000000000-bluemix.private.cloudantnosqldb.appdomain.cloud"
+	gen1PublicURL   = "https://" + gen1PublicHost
+	gen1PrivateURL  = "https://" + gen1PrivateHost
+
+	// Gen 2 — dataservices.connection values already include https://.
+	gen2PublicURL  = "https://00000000-0000-0000-0000-000000000000.zzz.cloudant.us-south.dataservices.appdomain.cloud"
+	gen2PrivateURL = "https://00000000-0000-0000-0000-000000000000.private.zzz.cloudant.us-south.dataservices.appdomain.cloud"
+)
+
+// gen1Ext builds a Gen 1 flattened extensions map with bare hostnames.
+func gen1Ext(pub, priv string) flex.Map {
+	m := flex.Map{}
+	if pub != "" {
+		m["endpoints.public"] = pub
+	}
+	if priv != "" {
+		m["endpoints.private"] = priv
+	}
+	return m
+}
+
+// gen2Ext builds a Gen 2 flattened extensions map with full URLs.
+func gen2Ext(pub, priv string) flex.Map {
+	m := flex.Map{}
+	if pub != "" {
+		m["dataservices.connection.public_endpoint_url"] = pub
+	}
+	if priv != "" {
+		m["dataservices.connection.vpe_url"] = priv
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// normalizeEndpoint
+// ---------------------------------------------------------------------------
+
+func TestNormalizeEndpoint_empty(t *testing.T) {
+	if got := normalizeEndpoint(""); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestNormalizeEndpoint_alreadyHttps(t *testing.T) {
+	if got := normalizeEndpoint(gen1PublicURL); got != gen1PublicURL {
+		t.Fatalf("expected %q unchanged, got %q", gen1PublicURL, got)
+	}
+}
+
+func TestNormalizeEndpoint_alreadyHttp(t *testing.T) {
+	in := "http://" + gen1PublicHost
+	if got := normalizeEndpoint(in); got != in {
+		t.Fatalf("expected %q unchanged, got %q", in, got)
+	}
+}
+
+func TestNormalizeEndpoint_bareHostname(t *testing.T) {
+	if got := normalizeEndpoint(gen1PublicHost); got != gen1PublicURL {
+		t.Fatalf("expected %q, got %q", gen1PublicURL, got)
+	}
+}
+
+func TestNormalizeEndpoint_barePrivateHostname(t *testing.T) {
+	if got := normalizeEndpoint(gen1PrivateHost); got != gen1PrivateURL {
+		t.Fatalf("expected %q, got %q", gen1PrivateURL, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// selectCloudantEndpoint
+// ---------------------------------------------------------------------------
+
+// Gen 1 — default (public) visibility selects the public endpoint
+func TestSelectCloudantEndpoint_gen1_public(t *testing.T) {
+	ext := gen1Ext(gen1PublicHost, gen1PrivateHost)
+	url, isGen2 := selectCloudantEndpoint(ext, "public")
+	if isGen2 {
+		t.Fatal("expected Gen 1")
+	}
+	if url != gen1PublicURL {
+		t.Fatalf("expected %q, got %q", gen1PublicURL, url)
+	}
+}
+
+// Gen 1 — private visibility selects the private endpoint
+func TestSelectCloudantEndpoint_gen1_private(t *testing.T) {
+	ext := gen1Ext(gen1PublicHost, gen1PrivateHost)
+	url, isGen2 := selectCloudantEndpoint(ext, "private")
+	if isGen2 {
+		t.Fatal("expected Gen 1")
+	}
+	if url != gen1PrivateURL {
+		t.Fatalf("expected %q, got %q", gen1PrivateURL, url)
+	}
+}
+
+// Gen 1 — public-and-private visibility prefers private when available
+func TestSelectCloudantEndpoint_gen1_publicAndPrivate_prefersPrivate(t *testing.T) {
+	ext := gen1Ext(gen1PublicHost, gen1PrivateHost)
+	url, _ := selectCloudantEndpoint(ext, "public-and-private")
+	if url != gen1PrivateURL {
+		t.Fatalf("expected %q, got %q", gen1PrivateURL, url)
+	}
+}
+
+// Gen 1 — public-and-private with no private endpoint falls back to public
+func TestSelectCloudantEndpoint_gen1_publicAndPrivate_fallsBackToPublic(t *testing.T) {
+	ext := gen1Ext(gen1PublicHost, "")
+	url, _ := selectCloudantEndpoint(ext, "public-and-private")
+	if url != gen1PublicURL {
+		t.Fatalf("expected %q, got %q", gen1PublicURL, url)
+	}
+}
+
+// Gen 2 — public visibility returns the public endpoint URL as-is (scheme preserved)
+func TestSelectCloudantEndpoint_gen2_public(t *testing.T) {
+	ext := gen2Ext(gen2PublicURL, gen2PrivateURL)
+	url, isGen2 := selectCloudantEndpoint(ext, "public")
+	if !isGen2 {
+		t.Fatal("expected Gen 2")
+	}
+	if url != gen2PublicURL {
+		t.Fatalf("expected %q, got %q", gen2PublicURL, url)
+	}
+}
+
+// Gen 2 — private visibility returns the VPE URL
+func TestSelectCloudantEndpoint_gen2_private(t *testing.T) {
+	ext := gen2Ext(gen2PublicURL, gen2PrivateURL)
+	url, isGen2 := selectCloudantEndpoint(ext, "private")
+	if !isGen2 {
+		t.Fatal("expected Gen 2")
+	}
+	if url != gen2PrivateURL {
+		t.Fatalf("expected %q, got %q", gen2PrivateURL, url)
+	}
+}
+
+// Gen 2 — public-and-private prefers the VPE URL
+func TestSelectCloudantEndpoint_gen2_publicAndPrivate_prefersVPE(t *testing.T) {
+	ext := gen2Ext(gen2PublicURL, gen2PrivateURL)
+	url, _ := selectCloudantEndpoint(ext, "public-and-private")
+	if url != gen2PrivateURL {
+		t.Fatalf("expected %q, got %q", gen2PrivateURL, url)
+	}
+}
+
+// Gen 2 — only a VPE URL present is still detected as Gen 2
+func TestSelectCloudantEndpoint_gen2_onlyPrivate(t *testing.T) {
+	ext := gen2Ext("", gen2PrivateURL)
+	_, isGen2 := selectCloudantEndpoint(ext, "public")
+	if !isGen2 {
+		t.Fatal("expected Gen 2 when only VPE URL present")
+	}
+}
+
+// Empty extensions return an empty URL
+func TestSelectCloudantEndpoint_empty(t *testing.T) {
+	url, _ := selectCloudantEndpoint(flex.Map{}, "public")
+	if url != "" {
+		t.Fatalf("expected empty URL for empty extensions, got %q", url)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getCloudantExtensions
+// ---------------------------------------------------------------------------
+
+func TestGetCloudantExtensions_valid(t *testing.T) {
+	raw := map[string]interface{}{
+		"endpoints": map[string]interface{}{
+			"public":  gen1PublicHost,
+			"private": gen1PrivateHost,
+		},
+	}
+	result, tfErr := getCloudantExtensions(raw, "test", "read")
+	if tfErr != nil {
+		t.Fatalf("unexpected error: %s", tfErr)
+	}
+	if result["endpoints.public"] != gen1PublicHost {
+		t.Fatalf("expected endpoints.public=%q, got %q", gen1PublicHost, result["endpoints.public"])
+	}
+}
+
+func TestGetCloudantExtensions_nil(t *testing.T) {
+	_, tfErr := getCloudantExtensions(nil, "test", "read")
+	if tfErr == nil {
+		t.Fatal("expected error for nil extensions")
+	}
+}
+
+func TestGetCloudantExtensions_wrongType(t *testing.T) {
+	_, tfErr := getCloudantExtensions("not-a-map", "test", "read")
+	if tfErr == nil {
+		t.Fatal("expected error for non-map extensions")
+	}
+}
+
+func TestGetCloudantExtensions_empty(t *testing.T) {
+	_, tfErr := getCloudantExtensions(map[string]interface{}{}, "test", "read")
+	if tfErr == nil {
+		t.Fatal("expected error for empty extensions map")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isCloudantGen2Plan / isCloudantGen2PlanFrom
+// ---------------------------------------------------------------------------
+
+func TestIsCloudantGen2Plan_gen1Plans(t *testing.T) {
+	for _, plan := range []string{"lite", "standard", "dedicated-hardware", "Lite", "STANDARD", "  standard  "} {
+		if isCloudantGen2Plan(plan) {
+			t.Errorf("plan %q should be Gen 1, got Gen 2", plan)
+		}
+	}
+}
+
+func TestIsCloudantGen2Plan_gen2Plans(t *testing.T) {
+	for _, plan := range []string{"standard-gen2", "another-gen2"} {
+		if !isCloudantGen2Plan(plan) {
+			t.Errorf("plan %q should be Gen 2, got Gen 1", plan)
+		}
+	}
+}
+
+func TestIsCloudantGen2Plan_empty(t *testing.T) {
+	if isCloudantGen2Plan("") {
+		t.Fatal("empty plan should default to Gen 1 (false)")
+	}
+}
+
+func TestIsCloudantGen2Plan_whitespaceOnly(t *testing.T) {
+	if isCloudantGen2Plan("   ") {
+		t.Fatal("whitespace-only plan should default to Gen 1 (false)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cloudantToResourceInstance / resourceInstanceToCloudant — helpers
+// ---------------------------------------------------------------------------
+
+// makeGen1CloudantRD builds a Gen 1 Cloudant ResourceData populated with shared
+// RC fields plus Gen 1-specific Cloudant-only fields.
+func makeGen1CloudantRD(t *testing.T) *schema.ResourceData {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		// shared RC fields
+		"name":              "my-cloudant",
+		"plan":              "standard",
+		"location":          "us-south",
+		"resource_group_id": "rg-abc",
+		"service":           "cloudantnosqldb",
+		"guid":              "guid-123",
+		"crn":               "crn:v1:bluemix:public:cloudantnosqldb:us-south:::",
+		"status":            "active",
+		// Gen 1 Cloudant-only fields
+		"legacy_credentials":  true,
+		"environment_crn":     "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abc:hw-instance::",
+		"include_data_events": true,
+		"capacity":            1,
+		"enable_cors":         false,
+	})
+	d.SetId("instance-id-001")
+	return d
+}
+
+// makeGen2CloudantRD builds a Gen 2 Cloudant ResourceData populated with shared
+// RC fields plus Gen 2-specific Cloudant-only fields.
+func makeGen2CloudantRD(t *testing.T) *schema.ResourceData {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		// shared RC fields
+		"name":              "my-cloudant-gen2",
+		"plan":              "standard-gen2",
+		"location":          "us-south",
+		"resource_group_id": "rg-abc",
+		"service":           "cloudantnosqldb",
+		"guid":              "guid-456",
+		"crn":               "crn:v1:bluemix:public:cloudantnosqldb:us-south:::",
+		"status":            "active",
+		// Gen 2 Cloudant-only fields
+		"capacity":    3,
+		"enable_cors": true,
+		"cors_config": []interface{}{
+			map[string]interface{}{
+				"allow_credentials": true,
+				"origins":           []interface{}{"https://example.com", "https://other.com"},
+			},
+		},
+	})
+	d.SetId("instance-id-002")
+	return d
+}
+
+// unmarshalParamsJSON decodes the parameters_json field on d into a map.
+func unmarshalParamsJSON(t *testing.T, d *schema.ResourceData) map[string]interface{} {
+	t.Helper()
+	raw := d.Get("parameters_json").(string)
+	if raw == "" {
+		t.Fatal("parameters_json is empty")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("failed to unmarshal parameters_json: %s", err)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// cloudantToResourceInstance — Gen 1
+// ---------------------------------------------------------------------------
+
+func TestCloudantToResourceInstance_gen1_legacyCredentialsTrue(t *testing.T) {
+	d := makeGen1CloudantRD(t) // legacy_credentials=true
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	if params["legacyCredentials"] != "true" {
+		t.Errorf("expected legacyCredentials=%q, got %v", "true", params["legacyCredentials"])
+	}
+}
+
+func TestCloudantToResourceInstance_gen1_legacyCredentialsFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":               "standard",
+		"legacy_credentials": false,
+		"capacity":           1,
+		"enable_cors":        false,
+	})
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	if params["legacyCredentials"] != "false" {
+		t.Errorf("expected legacyCredentials=%q, got %v", "false", params["legacyCredentials"])
+	}
+}
+
+func TestCloudantToResourceInstance_gen1_environmentCRN(t *testing.T) {
+	d := makeGen1CloudantRD(t)
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	if params["environment_crn"] != "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abc:hw-instance::" {
+		t.Errorf("unexpected environment_crn: %v", params["environment_crn"])
+	}
+}
+
+func TestCloudantToResourceInstance_gen1_noGen2Fields(t *testing.T) {
+	d := makeGen1CloudantRD(t)
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	if _, ok := params["dataservices"]; ok {
+		t.Error("Gen 1 parameters should not contain dataservices key")
+	}
+}
+
+func TestCloudantToResourceInstance_gen1_userParamsPassthrough(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":               "standard",
+		"legacy_credentials": false,
+		"capacity":           1,
+		"enable_cors":        false,
+		"parameters": map[string]interface{}{
+			"custom_key": "custom_value",
+		},
+	})
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	// Unrelated user key must pass through.
+	if params["custom_key"] != "custom_value" {
+		t.Errorf("expected user parameter custom_key to pass through, got %v", params["custom_key"])
+	}
+	// Typed field must also be present.
+	if params["legacyCredentials"] != "false" {
+		t.Errorf("expected legacyCredentials=%q, got %v", "false", params["legacyCredentials"])
+	}
+}
+
+func TestCloudantToResourceInstance_gen1_typedFieldWinsOverUserParam(t *testing.T) {
+	// User sets legacy_credentials=true via the schema field but also sneaks
+	// "legacyCredentials": "false" into the raw parameters map. The typed
+	// schema field must win.
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":               "standard",
+		"legacy_credentials": true,
+		"capacity":           1,
+		"enable_cors":        false,
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "false",
+		},
+	})
+	cloudantToResourceInstance(d)
+
+	params := d.Get("parameters").(map[string]interface{})
+	if params["legacyCredentials"] != "true" {
+		t.Errorf("typed legacy_credentials=true should win over user param, got %v", params["legacyCredentials"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cloudantToResourceInstance — Gen 2
+// ---------------------------------------------------------------------------
+
+func TestCloudantToResourceInstance_gen2_capacityAndCorsEnabled(t *testing.T) {
+	d := makeGen2CloudantRD(t)
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+
+	if _, ok := params["legacyCredentials"]; ok {
+		t.Error("Gen 2 parameters_json should not contain legacyCredentials")
+	}
+
+	ds, ok := params["dataservices"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected dataservices map, got %T", params["dataservices"])
+	}
+	cloudant, ok := ds["cloudant"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected cloudant map, got %T", ds["cloudant"])
+	}
+	// JSON numbers unmarshal as float64.
+	if cloudant["capacity_units"].(float64) != 3 {
+		t.Fatalf("expected capacity_units=3, got %v", cloudant["capacity_units"])
+	}
+	cfg, ok := cloudant["configuration"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected configuration map, got %T", cloudant["configuration"])
+	}
+	cors, ok := cfg["cors"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected cors map, got %T", cfg["cors"])
+	}
+	if cors["enabled"] != true {
+		t.Fatalf("expected cors.enabled=true, got %v", cors["enabled"])
+	}
+	if cors["allowCredentials"] != true {
+		t.Fatalf("expected cors.allowCredentials=true, got %v", cors["allowCredentials"])
+	}
+	origins := cors["origins"].([]interface{})
+	if len(origins) != 2 || origins[0] != "https://example.com" || origins[1] != "https://other.com" {
+		t.Fatalf("unexpected origins: %v", origins)
+	}
+}
+
+func TestCloudantToResourceInstance_gen2_corsDisabled(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":        "standard-gen2",
+		"capacity":    1,
+		"enable_cors": false,
+	})
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+	ds := params["dataservices"].(map[string]interface{})
+	cloudant := ds["cloudant"].(map[string]interface{})
+	cfg := cloudant["configuration"].(map[string]interface{})
+	cors := cfg["cors"].(map[string]interface{})
+
+	if cors["enabled"] != false {
+		t.Fatalf("expected cors.enabled=false, got %v", cors["enabled"])
+	}
+	if _, ok := cors["allowCredentials"]; ok {
+		t.Fatal("cors.allowCredentials should not be set when CORS is disabled")
+	}
+	if _, ok := cors["origins"]; ok {
+		t.Fatal("cors.origins should not be set when CORS is disabled")
+	}
+}
+
+func TestCloudantToResourceInstance_gen2_noGen1Fields(t *testing.T) {
+	d := makeGen2CloudantRD(t)
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+	if _, ok := params["legacyCredentials"]; ok {
+		t.Error("Gen 2 parameters_json should not contain legacyCredentials")
+	}
+	if _, ok := params["environment_crn"]; ok {
+		t.Error("Gen 2 parameters_json should not contain environment_crn")
+	}
+}
+
+func TestCloudantToResourceInstance_gen2_userParamsPassthrough(t *testing.T) {
+	// User supplies a custom key and a conflicting typed key via parameters.
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":        "standard-gen2",
+		"capacity":    2,
+		"enable_cors": false,
+		"parameters": map[string]interface{}{
+			"custom_key": "custom_value",
+		},
+	})
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+	// Unrelated user key must pass through into the top-level JSON object.
+	if params["custom_key"] != "custom_value" {
+		t.Errorf("expected user parameter custom_key to pass through, got %v", params["custom_key"])
+	}
+	// Typed capacity=2 must be present in the nested structure.
+	ds := params["dataservices"].(map[string]interface{})
+	cloudant := ds["cloudant"].(map[string]interface{})
+	if cloudant["capacity_units"].(float64) != 2 {
+		t.Errorf("expected capacity_units=2, got %v", cloudant["capacity_units"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resourceInstanceToCloudant — shared fields
+// ---------------------------------------------------------------------------
+
+func TestResourceInstanceToCloudant_sharedFieldsCopied(t *testing.T) {
+	// resourceInstanceToCloudant only mutates Cloudant-specific fields; shared
+	// RC fields are already set by the RC read before it is called. Verify that
+	// a Gen 1 d with pre-set RC fields is not disturbed.
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"name":     "rc-instance",
+		"plan":     "lite",
+		"location": "eu-gb",
+		"guid":     "guid-789",
+		"status":   "active",
+		"crn":      "crn:v1:bluemix:public:cloudantnosqldb:eu-gb:::",
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "false",
+		},
+	})
+	d.SetId("rc-instance-id-002")
+	resourceInstanceToCloudant(d)
+
+	if d.Id() != "rc-instance-id-002" {
+		t.Errorf("expected ID=%q, got %q", "rc-instance-id-002", d.Id())
+	}
+	if d.Get("name") != "rc-instance" {
+		t.Errorf("expected name=%q, got %v", "rc-instance", d.Get("name"))
+	}
+	if d.Get("plan") != "lite" {
+		t.Errorf("expected plan=%q, got %v", "lite", d.Get("plan"))
+	}
+	if d.Get("guid") != "guid-789" {
+		t.Errorf("expected guid=%q, got %v", "guid-789", d.Get("guid"))
+	}
+}
+
+func TestResourceInstanceToCloudant_flexFieldsPreserved(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"name":                     "rc-instance",
+		"plan":                     "standard",
+		"location":                 "us-south",
+		flex.ResourceName:          "rc-instance",
+		flex.ResourceCRN:           "crn:v1:bluemix:public:::",
+		flex.ResourceStatus:        "active",
+		flex.ResourceGroupName:     "default",
+		flex.ResourceControllerURL: "https://cloud.ibm.com/services/",
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "false",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get(flex.ResourceCRN) != "crn:v1:bluemix:public:::" {
+		t.Errorf("expected %s preserved, got %v", flex.ResourceCRN, d.Get(flex.ResourceCRN))
+	}
+	if d.Get(flex.ResourceControllerURL) != "https://cloud.ibm.com/services/" {
+		t.Errorf("expected %s preserved, got %v", flex.ResourceControllerURL, d.Get(flex.ResourceControllerURL))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resourceInstanceToCloudant — Gen 1
+// ---------------------------------------------------------------------------
+
+func TestResourceInstanceToCloudant_gen1_legacyCredentials(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard",
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "true",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if !d.Get("legacy_credentials").(bool) {
+		t.Error("expected legacy_credentials=true")
+	}
+	// Key must be removed from parameters.
+	params := d.Get("parameters")
+	if params != nil {
+		if m, ok := params.(map[string]interface{}); ok {
+			if _, found := m["legacyCredentials"]; found {
+				t.Error("legacyCredentials should have been removed from parameters")
+			}
+		}
+	}
+}
+
+func TestResourceInstanceToCloudant_gen1_legacyCredentialsFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard",
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "false",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get("legacy_credentials").(bool) {
+		t.Error("expected legacy_credentials=false")
+	}
+}
+
+func TestResourceInstanceToCloudant_gen1_environmentCRN(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "dedicated-hardware",
+		"parameters": map[string]interface{}{
+			"environment_crn": "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abc:hw-instance::",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get("environment_crn") != "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abc:hw-instance::" {
+		t.Errorf("unexpected environment_crn: %v", d.Get("environment_crn"))
+	}
+	// Key must be removed from parameters.
+	params := d.Get("parameters")
+	if params != nil {
+		if m, ok := params.(map[string]interface{}); ok {
+			if _, found := m["environment_crn"]; found {
+				t.Error("environment_crn should have been removed from parameters")
+			}
+		}
+	}
+}
+
+func TestResourceInstanceToCloudant_gen1_userKeysPreservedAfterUnmerge(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard",
+		"parameters": map[string]interface{}{
+			"legacyCredentials": "true",
+			"custom_key":        "custom_value",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	// legacyCredentials extracted and removed; custom_key must survive.
+	params := d.Get("parameters").(map[string]interface{})
+	if _, found := params["legacyCredentials"]; found {
+		t.Error("legacyCredentials should have been removed from parameters")
+	}
+	if params["custom_key"] != "custom_value" {
+		t.Errorf("expected custom_key to survive, got %v", params["custom_key"])
+	}
+}
+
+func TestResourceInstanceToCloudant_gen1_noParameters(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard",
+	})
+	// Must not panic when no parameters are present.
+	resourceInstanceToCloudant(d)
+}
+
+// ---------------------------------------------------------------------------
+// resourceInstanceToCloudant — Gen 2
+// ---------------------------------------------------------------------------
+
+func TestResourceInstanceToCloudant_gen2_capacityAndCors(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units":                      "3",
+			"dataservices.cloudant.configuration.cors.enabled":          "true",
+			"dataservices.cloudant.configuration.cors.allowCredentials": "true",
+			"dataservices.cloudant.configuration.cors.origins.#":        "2",
+			"dataservices.cloudant.configuration.cors.origins.0":        "https://example.com",
+			"dataservices.cloudant.configuration.cors.origins.1":        "https://other.com",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if got := d.Get("capacity").(int); got != 3 {
+		t.Errorf("expected capacity=3, got %d", got)
+	}
+	if !d.Get("enable_cors").(bool) {
+		t.Error("expected enable_cors=true")
+	}
+	cors := d.Get("cors_config").([]interface{})
+	if len(cors) != 1 {
+		t.Fatalf("expected 1 cors_config entry, got %d", len(cors))
+	}
+	entry := cors[0].(map[string]interface{})
+	if !entry["allow_credentials"].(bool) {
+		t.Error("expected allow_credentials=true")
+	}
+	origins := entry["origins"].([]interface{})
+	if len(origins) != 2 || origins[0] != "https://example.com" || origins[1] != "https://other.com" {
+		t.Fatalf("unexpected origins: %v", origins)
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_corsDisabled(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units":               "1",
+			"dataservices.cloudant.configuration.cors.enabled":   "false",
+			"dataservices.cloudant.configuration.cors.origins.#": "0",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get("enable_cors").(bool) {
+		t.Error("expected enable_cors=false")
+	}
+	if cors := d.Get("cors_config").([]interface{}); len(cors) != 0 {
+		t.Errorf("expected empty cors_config when CORS disabled, got %d entries", len(cors))
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_noExtensions(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+	})
+	// Must not panic when extensions are absent.
+	resourceInstanceToCloudant(d)
+}
+
+func TestResourceInstanceToCloudant_gen2_doesNotClearParametersJSON(t *testing.T) {
+	const original = `{"dataservices":{"cloudant":{"capacity_units":3}}}`
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":            "standard-gen2",
+		"parameters_json": original,
+	})
+	resourceInstanceToCloudant(d)
+
+	if got := d.Get("parameters_json").(string); got != original {
+		t.Errorf("expected parameters_json to be left unchanged, got %q", got)
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_setsThroughputEmpty(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units": "1",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	throughput := d.Get("throughput").(map[string]interface{})
+	if len(throughput) != 0 {
+		t.Errorf("expected throughput to be empty map for Gen 2, got %v", throughput)
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_gen1FieldsUnchanged(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units": "2",
+		},
+		"legacy_credentials": false,
+	})
+	resourceInstanceToCloudant(d)
+
+	// Gen 2 path must not touch legacy_credentials.
+	if d.Get("legacy_credentials").(bool) {
+		t.Error("Gen 2 path must not modify legacy_credentials")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip — Gen 1
+// ---------------------------------------------------------------------------
+
+func TestRoundTrip_gen1_cloudantToRCAndBack(t *testing.T) {
+	d := makeGen1CloudantRD(t)
+
+	// Step 1: prepare for RC call — merges Cloudant fields into parameters.
+	cloudantToResourceInstance(d)
+
+	// Verify the merged parameters are present before the simulated RC call.
+	params := d.Get("parameters").(map[string]interface{})
+	if params["legacyCredentials"] != "true" {
+		t.Fatalf("expected legacyCredentials=true in parameters before RC call, got %v", params["legacyCredentials"])
+	}
+
+	// Step 2: simulate RC call returning (parameters still on d), then
+	// resourceInstanceToCloudant extracts and removes Cloudant-specific keys.
+	resourceInstanceToCloudant(d)
+
+	// Shared fields must be untouched.
+	if d.Get("name") != "my-cloudant" {
+		t.Errorf("unexpected name: %v", d.Get("name"))
+	}
+	if d.Get("plan") != "standard" {
+		t.Errorf("unexpected plan: %v", d.Get("plan"))
+	}
+
+	// Cloudant-specific fields must be extracted.
+	if !d.Get("legacy_credentials").(bool) {
+		t.Error("legacy_credentials should be true after round-trip")
+	}
+	if d.Get("environment_crn") != "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abc:hw-instance::" {
+		t.Errorf("unexpected environment_crn: %v", d.Get("environment_crn"))
+	}
+
+	// Cloudant-specific keys must be removed from parameters.
+	cleanParams := d.Get("parameters")
+	if cleanParams != nil {
+		if m, ok := cleanParams.(map[string]interface{}); ok {
+			if _, found := m["legacyCredentials"]; found {
+				t.Error("legacyCredentials should be removed from parameters after round-trip")
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip — Gen 2
+// ---------------------------------------------------------------------------
+
+func TestRoundTrip_gen2_cloudantToRCAndBack(t *testing.T) {
+	d := makeGen2CloudantRD(t)
+
+	// Step 1: prepare for RC call — encodes Cloudant fields into parameters_json.
+	cloudantToResourceInstance(d)
+
+	// Verify parameters_json is set.
+	if d.Get("parameters_json").(string) == "" {
+		t.Fatal("parameters_json should be set after cloudantToResourceInstance")
+	}
+
+	// Step 2: simulate RC response — extensions are populated (mirroring what
+	// flex.Flatten would produce from the broker's nested response).
+	d.Set("extensions", map[string]interface{}{
+		"dataservices.cloudant.capacity_units":                      "3",
+		"dataservices.cloudant.configuration.cors.enabled":          "true",
+		"dataservices.cloudant.configuration.cors.allowCredentials": "true",
+		"dataservices.cloudant.configuration.cors.origins.#":        "2",
+		"dataservices.cloudant.configuration.cors.origins.0":        "https://example.com",
+		"dataservices.cloudant.configuration.cors.origins.1":        "https://other.com",
+	})
+	resourceInstanceToCloudant(d)
+
+	// Shared fields must survive.
+	if d.Get("name") != "my-cloudant-gen2" {
+		t.Errorf("unexpected name: %v", d.Get("name"))
+	}
+	if d.Get("plan") != "standard-gen2" {
+		t.Errorf("unexpected plan: %v", d.Get("plan"))
+	}
+
+	// Gen 2 Cloudant fields must be populated from extensions.
+	if got := d.Get("capacity").(int); got != 3 {
+		t.Errorf("expected capacity=3 after Gen 2 round-trip, got %v", got)
+	}
+	if !d.Get("enable_cors").(bool) {
+		t.Error("expected enable_cors=true after Gen 2 round-trip")
+	}
+	cors := d.Get("cors_config").([]interface{})
+	if len(cors) != 1 {
+		t.Fatalf("expected 1 cors_config entry after Gen 2 round-trip, got %d", len(cors))
+	}
+	entry := cors[0].(map[string]interface{})
+	origins := entry["origins"].([]interface{})
+	if len(origins) != 2 {
+		t.Errorf("expected 2 origins after Gen 2 round-trip, got %d", len(origins))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// include_data_events — Gen 2 (cloudantToResourceInstance)
+// ---------------------------------------------------------------------------
+
+func TestCloudantToResourceInstance_gen2_includeDataEventsTrue(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":                "standard-gen2",
+		"capacity":            1,
+		"enable_cors":         false,
+		"include_data_events": true,
+	})
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+	ds := params["dataservices"].(map[string]interface{})
+	cloudant := ds["cloudant"].(map[string]interface{})
+	cfg := cloudant["configuration"].(map[string]interface{})
+	audit, ok := cfg["audit"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected audit map in configuration, got %T", cfg["audit"])
+	}
+	if audit["data_events"] != true {
+		t.Fatalf("expected audit.data_events=true, got %v", audit["data_events"])
+	}
+}
+
+func TestCloudantToResourceInstance_gen2_includeDataEventsFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan":                "standard-gen2",
+		"capacity":            1,
+		"enable_cors":         false,
+		"include_data_events": false,
+	})
+	cloudantToResourceInstance(d)
+
+	params := unmarshalParamsJSON(t, d)
+	ds := params["dataservices"].(map[string]interface{})
+	cloudant := ds["cloudant"].(map[string]interface{})
+	cfg := cloudant["configuration"].(map[string]interface{})
+	audit, ok := cfg["audit"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected audit map in configuration, got %T", cfg["audit"])
+	}
+	if audit["data_events"] != false {
+		t.Fatalf("expected audit.data_events=false, got %v", audit["data_events"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// include_data_events — Gen 2 (resourceInstanceToCloudant)
+// ---------------------------------------------------------------------------
+
+func TestResourceInstanceToCloudant_gen2_includeDataEventsTrue(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units":                  "1",
+			"dataservices.cloudant.configuration.audit.data_events": "true",
+			"dataservices.cloudant.configuration.cors.enabled":      "false",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if !d.Get("include_data_events").(bool) {
+		t.Error("expected include_data_events=true")
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_includeDataEventsFalse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units":                  "1",
+			"dataservices.cloudant.configuration.audit.data_events": "false",
+			"dataservices.cloudant.configuration.cors.enabled":      "false",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get("include_data_events").(bool) {
+		t.Error("expected include_data_events=false")
+	}
+}
+
+func TestResourceInstanceToCloudant_gen2_includeDataEventsAbsent(t *testing.T) {
+	// When the extension key is absent the attribute should remain at its zero
+	// value (false); it must not panic.
+	d := schema.TestResourceDataRaw(t, ResourceIBMCloudant().Schema, map[string]interface{}{
+		"plan": "standard-gen2",
+		"extensions": map[string]interface{}{
+			"dataservices.cloudant.capacity_units":             "1",
+			"dataservices.cloudant.configuration.cors.enabled": "false",
+		},
+	})
+	resourceInstanceToCloudant(d)
+
+	if d.Get("include_data_events").(bool) {
+		t.Error("expected include_data_events=false when extension key is absent")
+	}
+}

--- a/ibm/service/cloudant/data_source_ibm_cloudant.go
+++ b/ibm/service/cloudant/data_source_ibm_cloudant.go
@@ -1,10 +1,11 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudant
 
 import (
 	"log"
+	"maps"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcecontroller"
@@ -13,67 +14,58 @@ import (
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
 )
 
-func DataSourceIBMCloudant() *schema.Resource {
-	riSchema := resourcecontroller.DataSourceIBMResourceInstance().Schema
-
-	riSchema["service"] = &schema.Schema{
+// Cloudant specific resource instance additional schema
+var cloudantSchema = map[string]*schema.Schema{
+	"service": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The service type of the instance",
-	}
-
-	riSchema["version"] = &schema.Schema{
+	},
+	"version": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "Vendor version.",
-	}
-
-	riSchema["features"] = &schema.Schema{
+	},
+	"features": {
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "List of enabled optional features.",
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},
-	}
-
-	riSchema["features_flags"] = &schema.Schema{
+	},
+	"features_flags": {
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "List of feature flags.",
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},
-	}
-
-	riSchema["include_data_events"] = &schema.Schema{
+	},
+	"include_data_events": {
 		Type:        schema.TypeBool,
 		Computed:    true,
-		Description: "Include data event types in events sent to IBM Cloud Activity Tracker with LogDNA for the IBM Cloudant instance. By default only emitted events are of \"management\" type.",
-	}
-
-	riSchema["capacity"] = &schema.Schema{
+		Description: "Include data event types in events sent to IBM Cloud Activity Tracker Event Routing for the IBM Cloudant instance. By default only emitted events are of \"management\" type.",
+	},
+	"capacity": {
 		Type:        schema.TypeInt,
 		Computed:    true,
 		Description: "A number of blocks of throughput units. A block consists of 100 reads/sec, 50 writes/sec, and 5 global queries/sec of provisioned throughput capacity.",
-	}
-
-	riSchema["throughput"] = &schema.Schema{
+	},
+	"throughput": {
 		Type:        schema.TypeMap,
 		Computed:    true,
-		Description: "Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes.",
+		Description: "Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes. This is only available for IBM Cloudant Gen 1.",
 		Elem: &schema.Schema{
 			Type: schema.TypeInt,
 		},
-	}
-
-	riSchema["enable_cors"] = &schema.Schema{
+	},
+	"enable_cors": {
 		Type:        schema.TypeBool,
 		Computed:    true,
 		Description: "Boolean value to turn CORS on and off.",
-	}
-
-	riSchema["cors_config"] = &schema.Schema{
+	},
+	"cors_config": {
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "Configuration for CORS.",
@@ -94,11 +86,24 @@ func DataSourceIBMCloudant() *schema.Resource {
 				},
 			},
 		},
+	},
+}
+
+func DataSourceIBMCloudant() *schema.Resource {
+
+	// Make a Cloudant resource instance schema from the resource instance schema and Cloudant's additional entries
+	resourceInstanceSchema := resourcecontroller.DataSourceIBMResourceInstance().Schema
+
+	// Clone the resource instance schema
+	cloudantResourceInstanceSchema := maps.Clone(resourceInstanceSchema)
+	// Add Cloudant additional entries
+	for key, value := range cloudantSchema {
+		cloudantResourceInstanceSchema[key] = value
 	}
 
 	return &schema.Resource{
 		Read:   dataSourceIBMCloudantRead,
-		Schema: riSchema,
+		Schema: cloudantResourceInstanceSchema,
 	}
 }
 
@@ -113,9 +118,9 @@ func dataSourceIBMCloudantRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	client, err := getCloudantClient(d, meta)
-	if err != nil {
-		return err
+	client, tfErr := GetCloudantClientFromResource(d, meta, "ibm_cloudant", "read")
+	if tfErr != nil {
+		return tfErr
 	}
 
 	err = setCloudantServerInformation(client, d)
@@ -123,19 +128,23 @@ func dataSourceIBMCloudantRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	err = setCloudantActivityTrackerEvents(client, d)
-	if err != nil {
-		return err
-	}
+	resourceInstanceToCloudant(d)
 
-	err = setCloudantInstanceCapacity(client, d)
-	if err != nil {
-		return err
-	}
+	if !isCloudantGen2PlanFrom(d) {
+		err = setCloudantActivityTrackerEvents(client, d)
+		if err != nil {
+			return err
+		}
 
-	err = setCloudantInstanceCors(client, d)
-	if err != nil {
-		return err
+		err = setCloudantInstanceCapacity(client, d)
+		if err != nil {
+			return err
+		}
+
+		err = setCloudantInstanceCors(client, d)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/ibm/service/cloudant/data_source_ibm_cloudant_database.go
+++ b/ibm/service/cloudant/data_source_ibm_cloudant_database.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021, 2022 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudant
@@ -148,15 +148,8 @@ func DataSourceIBMCloudantDatabase() *schema.Resource {
 
 func dataSourceIBMCloudantDatabaseRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	instanceCRN := d.Get("instance_crn").(string)
-	cUrl, err := GetCloudantInstanceUrl(instanceCRN, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "read", "get-instance-url")
-		return tfErr.GetDiag()
-	}
-
-	cloudantClient, err := GetCloudantClientForUrl(cUrl, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "read", "get-client")
+	cloudantClient, tfErr := GetCloudantClientFromCrn(instanceCRN, meta, "ibm_cloudant_database", "read")
+	if tfErr != nil {
 		return tfErr.GetDiag()
 	}
 

--- a/ibm/service/cloudant/resource_ibm_cloudant.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant.go
@@ -1,62 +1,77 @@
-// Copyright IBM Corp. 2021 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudant
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"maps"
 	"net/url"
-	"strings"
 	"time"
 
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/resourcecontroller"
-	"github.com/IBM-Cloud/terraform-provider-ibm/version"
-	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/IBM/cloudant-go-sdk/cloudantv1"
-	"github.com/IBM/go-sdk-core/v5/core"
-	iamidentity "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 )
 
-func ResourceIBMCloudant() *schema.Resource {
-	riSchema := resourcecontroller.ResourceIBMResourceInstance().Schema
+// suppressMissingCorsConfig suppresses a diff when cors_config is absent from
+// the configuration. Defaults are applied during update, so an omitted
+// cors_config block should not be treated as a removal.
+func suppressMissingCorsConfig(k, _, new string, _ *schema.ResourceData) bool {
+	return k == "cors_config.#" && new == "0"
+}
 
-	riSchema["service"] = &schema.Schema{
+func ResourceIBMCloudant() *schema.Resource {
+	// Clone to avoid mutating the shared resource-controller schema map.
+	cloudantResourceInstanceSchema := maps.Clone(resourcecontroller.ResourceIBMResourceInstance().Schema)
+
+	// parameters_json is used internally to ferry nested Gen 2 broker parameters
+	// (dataservices.cloudant.*) through the RC layer without TypeMap string corruption.
+	// It is not a user-facing attribute: mark it Computed-only so it cannot be set
+	// in HCL config.
+	pj := cloudantResourceInstanceSchema["parameters_json"]
+	cloudantResourceInstanceSchema["parameters_json"] = &schema.Schema{
+		Type:        pj.Type,
+		Computed:    true,
+		Description: pj.Description,
+	}
+
+	// Override: service is hardcoded to "cloudantnosqldb" in create/update,
+	// so it must be Computed-only here rather than Required as in the base schema.
+	cloudantResourceInstanceSchema["service"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: "The service type of the instance",
 		Computed:    true,
 	}
 
-	riSchema["legacy_credentials"] = &schema.Schema{
+	cloudantResourceInstanceSchema["legacy_credentials"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-		Description: "Use both legacy credentials and IAM for authentication",
+		Description: "Only available for IBM Cloudant Gen 1. Use both legacy credentials and IAM for authentication.",
 		ForceNew:    true,
 	}
 
-	riSchema["environment_crn"] = &schema.Schema{
+	cloudantResourceInstanceSchema["environment_crn"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
-		Description: "CRN of the IBM Cloudant Dedicated Hardware plan instance",
+		Description: "Only available for IBM Cloudant Gen 1. CRN of the IBM Cloudant Dedicated Hardware plan instance.",
 		ForceNew:    true,
 	}
 
-	riSchema["include_data_events"] = &schema.Schema{
+	cloudantResourceInstanceSchema["include_data_events"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-		Description: "Include data event types in events sent to IBM Cloud Activity Tracker with LogDNA for the IBM Cloudant instance. By default only emitted events are of \"management\" type.",
+		Description: "Include data event types in events sent to IBM Cloud Activity Tracker Event Routing for the IBM Cloudant instance. By default only emitted events are of \"management\" type. For Gen 1 instances this is applied via the Activity Tracker API; for Gen 2 instances it is set via the broker parameter `dataservices.cloudant.configuration.audit.data_events`.",
 	}
 
-	riSchema["capacity"] = &schema.Schema{
+	cloudantResourceInstanceSchema["capacity"] = &schema.Schema{
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      1,
@@ -64,30 +79,27 @@ func ResourceIBMCloudant() *schema.Resource {
 		ValidateFunc: validation.IntAtLeast(1),
 	}
 
-	riSchema["throughput"] = &schema.Schema{
+	cloudantResourceInstanceSchema["throughput"] = &schema.Schema{
 		Type:        schema.TypeMap,
 		Computed:    true,
-		Description: "Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes.",
+		Description: "Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes. This is only available for IBM Cloudant Gen 1.",
 		Elem: &schema.Schema{
 			Type: schema.TypeInt,
 		},
 	}
 
-	riSchema["enable_cors"] = &schema.Schema{
+	cloudantResourceInstanceSchema["enable_cors"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     true,
 		Description: "Boolean value to turn CORS on and off.",
 	}
 
-	riSchema["cors_config"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			// suppress missing cors_config, we set defaults during update
-			return k == "cors_config.#" && new == "0"
-		},
-		Description: "Configuration for CORS.",
+	cloudantResourceInstanceSchema["cors_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		Optional:         true,
+		DiffSuppressFunc: suppressMissingCorsConfig,
+		Description:      "Configuration for CORS.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"allow_credentials": {
@@ -111,12 +123,24 @@ func ResourceIBMCloudant() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Create:   resourceIBMCloudantCreate,
-		Read:     resourceIBMCloudantRead,
-		Update:   resourceIBMCloudantUpdate,
-		Delete:   resourcecontroller.ResourceIBMResourceInstanceDelete,
-		Exists:   resourcecontroller.ResourceIBMResourceInstanceExists,
-		Importer: &schema.ResourceImporter{},
+		Create: resourceIBMCloudantCreate,
+		Read:   resourceIBMCloudantRead,
+		Update: resourceIBMCloudantUpdate,
+		Delete: resourcecontroller.ResourceIBMResourceInstanceDelete,
+		Exists: resourcecontroller.ResourceIBMResourceInstanceExists,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				if err := resourceIBMCloudantRead(d, meta); err != nil {
+					return nil, err
+				}
+				if _, ok := d.GetOk("legacy_credentials"); !ok {
+					if err := d.Set("legacy_credentials", false); err != nil {
+						return nil, err
+					}
+				}
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -125,171 +149,77 @@ func ResourceIBMCloudant() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 				return flex.ResourceTagsCustomizeDiff(diff)
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+				if err := validateCloudantInstanceCapacity(diff); err != nil {
+					return err
+				}
+				if err := validateCloudantInstanceCors(diff); err != nil {
+					return err
+				}
+				return nil
+			},
+			// For Gen 2 plans, propagate capacity/CORS changes into parameters_json
+			// at plan time so that HasChange("parameters_json") is true during Update
+			// and the RC layer actually sends the new parameters to the broker.
+			// Also needs to mark the extensions as updating so they become part of
+			// the plan delta (see https://github.com/hashicorp/terraform/issues/36462)
+			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+				if !isCloudantGen2PlanFrom(diff) {
+					return nil
+				}
+				if !diff.HasChange("capacity") && !diff.HasChange("enable_cors") && !diff.HasChange("cors_config") && !diff.HasChange("include_data_events") {
+					return nil
+				}
+				if err := diff.SetNewComputed("extensions"); err != nil {
+					return err
+				}
+				paramsJSON, err := cloudantGen2ParamsAsJSON(map[string]interface{}{}, diff)
+				if err != nil {
+					return err
+				}
+				return diff.SetNew("parameters_json", paramsJSON)
 			},
 		),
 
-		Schema: riSchema,
+		Schema: cloudantResourceInstanceSchema,
 	}
 }
 
 func resourceIBMCloudantCreate(d *schema.ResourceData, meta interface{}) error {
 	d.Set("service", "cloudantnosqldb")
 
-	err := validateCloudantInstanceCapacity(d)
-	if err != nil {
+	if err := cloudantToResourceInstance(d); err != nil {
+		return err
+	}
+	if err := resourcecontroller.ResourceIBMResourceInstanceCreate(d, meta); err != nil {
 		return err
 	}
 
-	err = validateCloudantInstanceCors(d)
-	if err != nil {
-		return err
-	}
+	if !isCloudantGen2PlanFrom(d) {
 
-	params := make(map[string]interface{})
+		client, tfErr := GetCloudantClientFromResource(d, meta, "ibm_cloudant", "create")
+		if tfErr != nil {
+			return tfErr
+		}
 
-	if legacyCredentials, ok := d.GetOkExists("legacy_credentials"); ok {
-		params["legacyCredentials"] = fmt.Sprintf("%t", legacyCredentials)
-	}
-
-	if environmentCRN, ok := d.GetOk("environment_crn"); ok {
-		params["environment_crn"] = environmentCRN
-	}
-
-	// copy values from "parameters" to params, unless they are already defined
-	parameters, ok := d.GetOk("parameters")
-	if ok {
-		temp := parameters.(map[string]interface{})
-		for k, v := range temp {
-			if override, ok := params[k]; ok && override != v {
-				log.Printf("[WARN] Overriding %q in 'parameters' to %s", k, override)
-				continue
+		// if matches an instance creation default skip request
+		if d.Get("include_data_events").(bool) {
+			if err := updateCloudantActivityTrackerEvents(client, d); err != nil {
+				return flex.FmtErrorf("[ERROR] Error updating activity tracker events: %s", err)
 			}
-			params[k] = v
 		}
-	}
 
-	if len(params) > 0 {
-		d.Set("parameters", params)
-	}
-
-	err = resourcecontroller.ResourceIBMResourceInstanceCreate(d, meta)
-	if err != nil {
-		return err
-	}
-
-	// return original parameters on state
-	d.Set("parameters", parameters)
-
-	client, err := getCloudantClient(d, meta)
-	if err != nil {
-		return err
-	}
-
-	// if matches an instance creation default skip request
-	if d.Get("include_data_events").(bool) {
-		err := updateCloudantActivityTrackerEvents(client, d)
-		if err != nil {
-			return flex.FmtErrorf("[ERROR] Error updating activity tracker events: %s", err)
+		// if matches an instance creation default skip request
+		if d.Get("capacity").(int) > 1 {
+			if err := updateCloudantInstanceCapacity(client, d); err != nil {
+				return flex.FmtErrorf("[ERROR] Error retrieving capacity throughput information: %s", err)
+			}
 		}
-	}
 
-	// if matches an instance creation default skip request
-	if d.Get("capacity").(int) > 1 {
-		err := updateCloudantInstanceCapacity(client, d)
-		if err != nil {
-			return flex.FmtErrorf("[ERROR] Error retrieving capacity throughput information: %s", err)
-		}
-	}
-
-	err = updateCloudantInstanceCors(client, d)
-	if err != nil {
-		return flex.FmtErrorf("[ERROR] Error updating CORS settings: %s", err)
-	}
-
-	return resourceIBMCloudantRead(d, meta)
-}
-
-func resourceIBMCloudantRead(d *schema.ResourceData, meta interface{}) error {
-	err := resourcecontroller.ResourceIBMResourceInstanceRead(d, meta)
-	if err != nil {
-		return err
-	}
-
-	err = setCloudantLegacyCredentials(d, meta)
-	if err != nil {
-		return err
-	}
-
-	err = setCloudantResourceControllerURL(d, meta)
-	if err != nil {
-		return err
-	}
-
-	client, err := getCloudantClient(d, meta)
-	if err != nil {
-		return err
-	}
-
-	err = setCloudantActivityTrackerEvents(client, d)
-	if err != nil {
-		return err
-	}
-
-	err = setCloudantInstanceCapacity(client, d)
-	if err != nil {
-		return err
-	}
-
-	err = setCloudantInstanceCors(client, d)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func resourceIBMCloudantUpdate(d *schema.ResourceData, meta interface{}) error {
-	d.Set("service", "cloudantnosqldb")
-
-	err := validateCloudantInstanceCapacity(d)
-	if err != nil {
-		return err
-	}
-
-	err = validateCloudantInstanceCors(d)
-	if err != nil {
-		return err
-	}
-
-	err = resourcecontroller.ResourceIBMResourceInstanceUpdate(d, meta)
-	if err != nil {
-		return err
-	}
-
-	client, err := getCloudantClient(d, meta)
-	if err != nil {
-		return err
-	}
-
-	if d.HasChange("include_data_events") {
-		err := updateCloudantActivityTrackerEvents(client, d)
-		if err != nil {
-			return flex.FmtErrorf("[ERROR] Error updating activity tracker events: %s", err)
-		}
-	}
-
-	if d.HasChange("capacity") {
-		err := updateCloudantInstanceCapacity(client, d)
-		if err != nil {
-			return flex.FmtErrorf("[ERROR] Error retrieving capacity throughput information: %s", err)
-		}
-	}
-
-	if d.HasChange("enable_cors") {
-		err := updateCloudantInstanceCors(client, d)
-		if err != nil {
+		if err := updateCloudantInstanceCors(client, d); err != nil {
 			return flex.FmtErrorf("[ERROR] Error updating CORS settings: %s", err)
 		}
 	}
@@ -297,42 +227,80 @@ func resourceIBMCloudantUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceIBMCloudantRead(d, meta)
 }
 
-func setCloudantLegacyCredentials(d *schema.ResourceData, meta interface{}) error {
-	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
-	if err != nil {
+func resourceIBMCloudantRead(d *schema.ResourceData, meta interface{}) error {
+	if err := resourcecontroller.ResourceIBMResourceInstanceRead(d, meta); err != nil {
 		return err
 	}
 
-	instanceID := d.Id()
-	resourceInstanceGet := rc.GetResourceInstanceOptions{
-		ID: &instanceID,
-	}
-
-	instance, response, err := rsConClient.GetResourceInstance(&resourceInstanceGet)
-	if err != nil {
-		log.Printf("[DEBUG] Error retrieving resource instance: %s\n%s", err, response)
+	if err := setCloudantResourceControllerURL(d, meta); err != nil {
 		return err
 	}
 
-	parameters := instance.Parameters
+	resourceInstanceToCloudant(d)
 
-	if legacyCredentials, ok := parameters["legacyCredentials"]; ok {
-		switch v := legacyCredentials.(type) {
-		case bool:
-			d.Set("legacy_credentials", v)
-		case string:
-			d.Set("legacy_credentials", v == "true")
-		default:
-			d.Set("legacy_credentials", false)
+	if !isCloudantGen2PlanFrom(d) {
+
+		// Gen 1: API calls to fix up Cloudant-specific values.
+
+		client, tfErr := GetCloudantClientFromResource(d, meta, "ibm_cloudant", "read")
+		if tfErr != nil {
+			return tfErr
+		}
+
+		if err := setCloudantActivityTrackerEvents(client, d); err != nil {
+			return err
+		}
+		if err := setCloudantInstanceCapacity(client, d); err != nil {
+			return err
+		}
+		if err := setCloudantInstanceCors(client, d); err != nil {
+			return err
 		}
 	}
 
-	if environmentCRN, ok := parameters["environment_crn"]; ok {
-		v := environmentCRN.(string)
-		d.Set("environment_crn", v)
+	return nil
+}
+
+func resourceIBMCloudantUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Set("service", "cloudantnosqldb")
+	isGen2 := isCloudantGen2PlanFrom(d)
+
+	if err := cloudantToResourceInstance(d); err != nil {
+		return err
+	}
+	if err := resourcecontroller.ResourceIBMResourceInstanceUpdate(d, meta); err != nil {
+		return err
 	}
 
-	return nil
+	if !isGen2 {
+		client, tfErr := GetCloudantClientFromResource(d, meta, "ibm_cloudant", "update")
+		if tfErr != nil {
+			return tfErr
+		}
+
+		if d.HasChange("include_data_events") {
+			err := updateCloudantActivityTrackerEvents(client, d)
+			if err != nil {
+				return flex.FmtErrorf("[ERROR] Error updating activity tracker events: %s", err)
+			}
+		}
+
+		if d.HasChange("capacity") {
+			err := updateCloudantInstanceCapacity(client, d)
+			if err != nil {
+				return flex.FmtErrorf("[ERROR] Error retrieving capacity throughput information: %s", err)
+			}
+		}
+
+		if d.HasChange("enable_cors") || d.HasChange("cors_config") {
+			err := updateCloudantInstanceCors(client, d)
+			if err != nil {
+				return flex.FmtErrorf("[ERROR] Error updating CORS settings: %s", err)
+			}
+		}
+	}
+
+	return resourceIBMCloudantRead(d, meta)
 }
 
 func setCloudantResourceControllerURL(d *schema.ResourceData, meta interface{}) error {
@@ -346,82 +314,20 @@ func setCloudantResourceControllerURL(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func getCloudantClient(d *schema.ResourceData, meta interface{}) (*cloudantv1.CloudantV1, error) {
-
-	session, err := meta.(conns.ClientSession).BluemixSession()
-	if err != nil {
-		return nil, err
+func validateCloudantGen2UnsupportedFields(diff *schema.ResourceDiff) error {
+	if !isCloudantGen2PlanFrom(diff) {
+		return nil
 	}
 
-	var endpoint string
-	extensions := d.Get("extensions").(map[string]interface{})
-	if v, ok := extensions["endpoints.public"]; ok {
-		endpoint = "https://" + v.(string)
+	if diff.Get("legacy_credentials").(bool) {
+		return flex.FmtErrorf("[ERROR] Setting legacy_credentials is not supported for Gen 2 Cloudant instances")
 	}
 
-	switch session.Config.Visibility {
-	case "private":
-		_, ok := extensions["endpoints.private"]
-		if !ok {
-			return nil, flex.FmtErrorf("[ERROR] Missing endpoints.private in extensions")
-		}
-		endpoint = "https://" + extensions["endpoints.private"].(string)
-	case "public-and-private":
-		if v, ok := extensions["endpoints.private"]; ok {
-			endpoint = "https://" + v.(string)
-		}
+	if _, ok := diff.GetOk("environment_crn"); ok {
+		return flex.FmtErrorf("[ERROR] Setting environment_crn is not supported for Gen 2 Cloudant instances")
 	}
 
-	endpoint = conns.EnvFallBack([]string{"IBMCLOUD_CLOUDANT_ENDPOINT"}, endpoint)
-	if endpoint == "" {
-		return nil, flex.FmtErrorf("[ERROR] Missing endpoints.public in extensions")
-	}
-
-	return GetCloudantClientForUrl(endpoint, meta)
-}
-
-func GetCloudantClientForUrl(endpoint string, meta interface{}) (*cloudantv1.CloudantV1, error) {
-	session, err := meta.(conns.ClientSession).BluemixSession()
-	if err != nil {
-		return nil, err
-	}
-
-	var authenticator core.Authenticator
-	token := session.Config.IAMAccessToken
-
-	if token != "" {
-		token = strings.Replace(token, "Bearer ", "", -1)
-		authenticator = &core.BearerTokenAuthenticator{
-			BearerToken: token,
-		}
-	} else {
-		apiKey := session.Config.BluemixAPIKey
-		region := session.Config.Region
-		visibility := session.Config.Visibility
-		iamURL := iamidentity.DefaultServiceURL
-		if visibility == "private" || visibility == "public-and-private" {
-			if region == "us-south" || region == "us-east" {
-				iamURL = conns.ContructEndpoint(fmt.Sprintf("private.%s.iam", region), "cloud.ibm.com")
-			} else {
-				iamURL = conns.ContructEndpoint("private.iam", "cloud.ibm.com")
-			}
-		}
-		authenticator = &core.IamAuthenticator{
-			ApiKey: apiKey,
-			URL:    conns.EnvFallBack([]string{"IBMCLOUD_IAM_API_ENDPOINT"}, iamURL) + "/identity/token",
-		}
-	}
-
-	client, err := cloudantv1.NewCloudantV1(&cloudantv1.CloudantV1Options{
-		Authenticator: authenticator,
-		URL:           endpoint,
-	})
-	if err != nil {
-		return nil, flex.FmtErrorf("[ERROR] Error occured while configuring Cloudant service: %q", err)
-	}
-	client.Service.SetUserAgent("cloudant-terraform/" + version.Version)
-
-	return client, nil
+	return nil
 }
 
 func setCloudantActivityTrackerEvents(client *cloudantv1.CloudantV1, d *schema.ResourceData) error {
@@ -466,9 +372,13 @@ func updateCloudantActivityTrackerEvents(client *cloudantv1.CloudantV1, d *schem
 	return err
 }
 
-func validateCloudantInstanceCapacity(d *schema.ResourceData) error {
-	plan := d.Get("plan").(string)
-	capacity := d.Get("capacity").(int)
+func validateCloudantInstanceCapacity(diff *schema.ResourceDiff) error {
+	if err := validateCloudantGen2UnsupportedFields(diff); err != nil {
+		return err
+	}
+
+	plan := diff.Get("plan").(string)
+	capacity := diff.Get("capacity").(int)
 	if capacity > 1 && plan == "lite" {
 		return flex.FmtErrorf("[ERROR] Setting capacity is not supported for your instance's plan")
 	}
@@ -510,6 +420,7 @@ func readCloudantInstanceCapacity(client *cloudantv1.CloudantV1) (*cloudantv1.Ca
 	capacityThroughputInformation, response, err := client.GetCapacityThroughputInformation(opts)
 	if err != nil {
 		log.Printf("[DEBUG] Error getting capacity throughput information: %s\n%s", err, response)
+		return nil, err
 	}
 	return capacityThroughputInformation, nil
 }
@@ -528,9 +439,9 @@ func updateCloudantInstanceCapacity(client *cloudantv1.CloudantV1, d *schema.Res
 	return nil
 }
 
-func validateCloudantInstanceCors(d *schema.ResourceData) error {
-	enableCors := d.Get("enable_cors").(bool)
-	corsConfigRaw := d.Get("cors_config").([]interface{})
+func validateCloudantInstanceCors(diff *schema.ResourceDiff) error {
+	enableCors := diff.Get("enable_cors").(bool)
+	corsConfigRaw := diff.Get("cors_config").([]interface{})
 	if !enableCors && len(corsConfigRaw) > 0 {
 		corsConfig := corsConfigRaw[0].(map[string]interface{})
 		allowCredentials := corsConfig["allow_credentials"].(bool)

--- a/ibm/service/cloudant/resource_ibm_cloudant_database.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant_database.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021, 2022 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudant
@@ -12,9 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
-
-	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 )
 
@@ -58,15 +55,8 @@ func ResourceIBMCloudantDatabase() *schema.Resource {
 
 func resourceIBMCloudantDatabaseCreate(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	instanceCRN := d.Get("instance_crn").(string)
-	cUrl, err := GetCloudantInstanceUrl(instanceCRN, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "create", "get-instance-url")
-		return tfErr.GetDiag()
-	}
-
-	cloudantClient, err := GetCloudantClientForUrl(cUrl, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "create", "get-client")
+	cloudantClient, tfErr := GetCloudantClientFromCrn(instanceCRN, meta, "ibm_cloudant_database", "create")
+	if tfErr != nil {
 		return tfErr.GetDiag()
 	}
 
@@ -99,15 +89,8 @@ func resourceIBMCloudantDatabaseRead(context context.Context, d *schema.Resource
 	}
 
 	instanceCRN, dbName := strings.Join(parts[:len(parts)-1], "/"), parts[len(parts)-1]
-	cUrl, err := GetCloudantInstanceUrl(instanceCRN, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "read", "get-instance-url")
-		return tfErr.GetDiag()
-	}
-
-	cloudantClient, err := GetCloudantClientForUrl(cUrl, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "read", "get-client")
+	cloudantClient, tfErr := GetCloudantClientFromCrn(instanceCRN, meta, "ibm_cloudant_database", "read")
+	if tfErr != nil {
 		return tfErr.GetDiag()
 	}
 
@@ -120,7 +103,11 @@ func resourceIBMCloudantDatabaseRead(context context.Context, d *schema.Resource
 			return nil
 		}
 		log.Printf("[DEBUG] GetDatabaseInformationWithContext failed %s\n%s", err, response)
-		tfErr := flex.DiscriminatedTerraformErrorf(err, response.String(), "ibm_cloudant_database", "read", "get-database-information")
+		summary := err.Error()
+		if response != nil {
+			summary = response.String()
+		}
+		tfErr := flex.DiscriminatedTerraformErrorf(err, summary, "ibm_cloudant_database", "read", "get-database-information")
 		return tfErr.GetDiag()
 	}
 
@@ -152,15 +139,8 @@ func resourceIBMCloudantDatabaseDelete(context context.Context, d *schema.Resour
 	}
 
 	instanceCRN, dbName := strings.Join(parts[:len(parts)-1], "/"), parts[len(parts)-1]
-	cUrl, err := GetCloudantInstanceUrl(instanceCRN, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "delete", "get-instance-url")
-		return tfErr.GetDiag()
-	}
-
-	cloudantClient, err := GetCloudantClientForUrl(cUrl, meta)
-	if err != nil {
-		tfErr := flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_cloudant_database", "delete", "get-client")
+	cloudantClient, tfErr := GetCloudantClientFromCrn(instanceCRN, meta, "ibm_cloudant_database", "delete")
+	if tfErr != nil {
 		return tfErr.GetDiag()
 	}
 
@@ -176,31 +156,4 @@ func resourceIBMCloudantDatabaseDelete(context context.Context, d *schema.Resour
 	d.SetId("")
 
 	return nil
-}
-
-func GetCloudantInstanceUrl(instanceCRN string, meta interface{}) (string, error) {
-	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
-	if err != nil {
-		return "", err
-	}
-
-	resourceInstanceGet := rc.GetResourceInstanceOptions{
-		ID: flex.PtrToString(instanceCRN),
-	}
-
-	instance, resp, err := rsConClient.GetResourceInstance(&resourceInstanceGet)
-	if err != nil {
-		return "", fmt.Errorf("Error retrieving resource instance: %s with resp code: %s", err, resp)
-	}
-
-	if instance.Extensions != nil {
-		instanceExtensionMap := flex.Flatten(instance.Extensions)
-		if instanceExtensionMap != nil {
-			cloudantInstanceUrl := "https://" + instanceExtensionMap["endpoints.public"]
-			cloudantInstanceUrl = conns.EnvFallBack([]string{"IBMCLOUD_CLOUDANT_API_ENDPOINT"}, cloudantInstanceUrl)
-			return cloudantInstanceUrl, nil
-		}
-	}
-
-	return "", fmt.Errorf("Unable to get URL for cloudant instance")
 }

--- a/ibm/service/cloudant/resource_ibm_cloudant_database_test.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant_database_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2021, 2022 All Rights Reserved.
+// Copyright IBM Corp. 2021, 2026 All Rights Reserved.
 // Licensed under the Mozilla Public License v2.0
 
 package cloudant_test
@@ -140,14 +140,9 @@ func testAccCheckIBMCloudantDatabaseExists(n string, obj cloudantv1.DatabaseInfo
 		}
 
 		instanceCRN := rs.Primary.Attributes["instance_crn"]
-		cUrl, err := cloudant.GetCloudantInstanceUrl(instanceCRN, acc.TestAccProvider.Meta())
-		if err != nil {
-			return err
-		}
-
-		cloudantClient, err := cloudant.GetCloudantClientForUrl(cUrl, acc.TestAccProvider.Meta())
-		if err != nil {
-			return err
+		cloudantClient, tfErr := cloudant.GetCloudantClientFromCrn(instanceCRN, acc.TestAccProvider.Meta(), "ibm_cloudant_database", "test")
+		if tfErr != nil {
+			return fmt.Errorf("Error getting Cloudant client: %s", tfErr)
 		}
 
 		dbName := rs.Primary.Attributes["db"]
@@ -170,21 +165,16 @@ func testAccCheckIBMCloudantDatabaseDestroy(s *terraform.State) error {
 		}
 
 		instanceCRN := rs.Primary.Attributes["instance_crn"]
-		cUrl, err := cloudant.GetCloudantInstanceUrl(instanceCRN, acc.TestAccProvider.Meta())
-		if err != nil {
-			return err
-		}
-
-		cloudantClient, err := cloudant.GetCloudantClientForUrl(cUrl, acc.TestAccProvider.Meta())
-		if err != nil {
-			return err
+		cloudantClient, tfErr := cloudant.GetCloudantClientFromCrn(instanceCRN, acc.TestAccProvider.Meta(), "ibm_cloudant_database", "test")
+		if tfErr != nil {
+			return fmt.Errorf("Error getting Cloudant client: %s", tfErr)
 		}
 
 		dbName := rs.Primary.Attributes["db"]
 		getDatabaseInformationOptions := cloudantClient.NewGetDatabaseInformationOptions(dbName)
 
 		// Try to find the key
-		_, _, err = cloudantClient.GetDatabaseInformation(getDatabaseInformationOptions)
+		_, _, err := cloudantClient.GetDatabaseInformation(getDatabaseInformationOptions)
 		if err == nil {
 			return fmt.Errorf("cloudant_database still exists: %s", rs.Primary.ID)
 		}

--- a/website/docs/d/cloudant.html.markdown
+++ b/website/docs/d/cloudant.html.markdown
@@ -40,7 +40,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `capacity` (Number) A number of blocks of throughput units.
 
-Capacity changes are reflected immediately, but are applied asynchronously over time by the service. Large capacity jumps are not fully available for some time after modification, but typically complete within 12 hours. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter.
+  Capacity changes on Gen 1 are reflected immediately but applied asynchronously; large jumps may take up to 12 hours to become fully effective. For more information, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration).
 * `cors_config` (List of Object) Configuration for CORS.
 
   Nested scheme for `cors_config`:
@@ -52,14 +52,14 @@ Capacity changes are reflected immediately, but are applied asynchronously over 
 * `features` (List of String) List of enabled optional features.
 * `features_flags` (List of String) List of feature flags.
 * `guid` (String) The `GUID` of the resource instance.
-* `include_data_events` (Boolean) Include `data` event types in events sent to IBM Cloud Activity Tracker with LogDNA for the IBM Cloudant instance. By default emitted events are only of the  `management` type.
+* `include_data_events` (Boolean) Include `data` event types in events sent to IBM Cloud Activity Tracker Event Routing for the IBM Cloudant instance. By default emitted events are only of the `management` type.
 * `plan` (String) The plan type of the instance.
 * `resource_controller_url` (String) The URL of the IBM Cloud dashboard that can be used to explore and view details about the resource.
 * `resource_crn` (String) The CRN of the resource.
 * `resource_group_name` (String) The resource group name in which resource is provisioned.
 * `resource_name` (String) The name of the resource.
 * `resource_status` (String) The status of the resource.
-* `service` (String) The service type of the instance.
+* `service` (String) The service type of the instance. Always `cloudantnosqldb`.
 * `status` (String) The resource instance status.
-* `throughput` (Map of Number) Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes.
+* `throughput` (Map of Number) **Gen 1 only.** Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes. Not populated for Gen 2 instances.
 * `version` (String) The vendor version.

--- a/website/docs/d/cloudant_database.html.markdown
+++ b/website/docs/d/cloudant_database.html.markdown
@@ -23,17 +23,17 @@ data "ibm_cloudant_database" "cloudant_database" {
 
 The following arguments are supported:
 
-* `db` - (Required, string) Path parameter to specify the database name.
-* `instance_crn` - (Required, string) Path parameter to specify the cloudant instance CRN.
+* `db` - (Required, string) The database name.
+* `instance_crn` - (Required, string) The CRN of the Cloudant instance.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `cluster` - Schema for database cluster information. Nested `cluster` blocks have the following structure:
+* `cluster` - Database cluster information. Nested `cluster` blocks have the following structure:
 	* `read_quorum` - Read quorum. The number of consistent copies of a document that need to be read before a successful reply.
-	* `replicas` - Schema for the number of replicas of a database in a cluster.
-	* `shards` - Schema for the number of shards in a database. Each shard is a partition of the hash value range.
+	* `replicas` - The number of replicas of a database in a cluster.
+	* `shards` - The number of shards in a database. Each shard is a partition of the hash value range.
 	* `write_quorum` - Write quorum. The number of copies of a document that need to be written before a successful reply.
 
 * `committed_update_seq` - An opaque string that describes the committed state of the database.
@@ -41,8 +41,6 @@ In addition to all arguments above, the following attributes are exported:
 * `compact_running` - True if the database compaction routine is operating on this database.
 
 * `compacted_seq` - An opaque string that describes the compaction state of the database.
-
-* `db_name` - The name of the database.
 
 * `disk_format_version` - The version of the physical format used for the data when it is stored on disk.
 
@@ -54,15 +52,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique identifier of the cloudant_database.
 
-* `props` - Schema for database properties. Nested `props` blocks have the following structure:
+* `props` - Database properties. Nested `props` blocks have the following structure:
 	* `partitioned` - The value is `true` for a partitioned database.
 
-* `sizes` - Schema for size information of content. Nested `sizes` blocks have the following structure:
-	* `active` - The active size of the content, in bytes.
-	* `external` - The total uncompressed size of the content, in bytes.
-	* `file` - The total size of the content as stored on disk, in bytes.
+* `sizes` - Database size information. Nested `sizes` blocks have the following structure:
+	* `active` - The active size of the data in the database, in bytes.
+	* `external` - The total uncompressed size of the data in the database, in bytes.
+	* `file` - The total size of the database as stored on disk, in bytes.
 
 * `update_seq` - An opaque string that describes the state of the database. Do not rely on this string for counting the number of updates.
 
 * `uuid` - The UUID of the database.
-

--- a/website/docs/r/cloudant.html.markdown
+++ b/website/docs/r/cloudant.html.markdown
@@ -13,6 +13,8 @@ For more information, about Cloudant, see the official [Getting started with IBM
 
 ## Example usage
 
+### Gen 1
+
 ```terraform
 resource "ibm_cloudant" "cloudant" {
   name     = "cloudant-service-name"
@@ -37,6 +39,25 @@ resource "ibm_cloudant" "cloudant" {
 }
 ```
 
+### Gen 2
+
+```terraform
+resource "ibm_cloudant" "cloudant_gen2" {
+  name     = "cloudant-gen2-name"
+  location = "us-south"
+  plan     = "standard-gen2"
+
+  include_data_events = true
+  capacity            = 1
+  enable_cors         = true
+
+  cors_config {
+    allow_credentials = false
+    origins           = ["https://example.com"]
+  }
+}
+```
+
 ## Timeouts
 
 ibm_cloudant provides the following [Timeouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts)
@@ -50,26 +71,26 @@ configuration options:
 
 Review the argument reference that you can specify for your resource:
 
-* `capacity` - (Optional, Number) A number of blocks of throughput units. The default value is `1`. Capacity modification is not supported for `lite` plan.
+* `capacity` - (Optional, Number) A number of blocks of throughput units.The default value is `1`. Capacity modification is not supported for the `lite` plan.
 
-Capacity changes are reflected immediately, but are applied asynchronously over time by the service. Large capacity jumps are not fully available for some time after modification, but typically complete within 12 hours. For more information, about throughput capacity, see [`blocks`](https://cloud.ibm.com/apidocs/cloudant#putcapacitythroughputconfiguration) parameter.
-* `cors_config` - (Optional, Block List) Configuration for CORS.
+  Capacity changes are applied asynchronously. For Gen 1 plans the new blocks value is reflected immediately, but the capacity change may take some time. For Gen 2 the capacity change will be reflected when the change is complete.
+  For more information, see [Gen 1 `blocks`](https://cloud.ibm.com/docs/apis/cloudant/cloudant-gen1#putcapacitythroughputconfiguration) or [Gen 2 capacity units](https://cloud.ibm.com/docs/cloudant-gen2?topic=cloudant-gen2-usage-and-charges#provisioned-throughput-capacity-units).
+* `cors_config` - (Optional, Block List) Configuration for CORS. Requires `enable_cors` to be `true`.
 
   Nested scheme for `cors_config`:
     * Constraints: The minimum length is **1** item.
     * `allow_credentials` - (Optional, Boolean) Boolean value to allow authentication credentials. If set to **true**, browser requests must be done by setting `XmlHttpRequest.withCredentials = true` on the request object. The default value is `true`.
     * `origins` - (Required, List of String) An array of strings that contain allowed origin domains. You have to specify the full URL including the protocol. It is recommended that only the HTTPS protocol is used. Subdomains count as separate domains, so you have to specify all subdomains used.
-    * `enable_cors` - (Optional, Boolean) Boolean value to enable CORS. The supported values are **true** and **false**. The default value is `true`. If it is set to `false`, then customizing `cors_config` is not allowed.
-* `environment_crn` - (Optional, Forces new resource, String) CRN of the IBM Cloudant Dedicated Hardware plan instance.
-* `id` - (Optional, String) The unique identifier of the new Cloudant resource.
-* `include_data_events` - (Optional, Boolean) Include `data` event types in events sent to IBM Cloud Activity Tracker with LogDNA for the IBM Cloudant instance. The default value is **false** and emitted events are only of the `management` type.
-* `legacy_credentials` - (Optional, Forces new resource, Boolean) Use both legacy credentials and IAM for authentication. The default value is **false**.
+* `enable_cors` - (Optional, Boolean) Boolean value to enable CORS. The default value is `true`. If it is set to `false`, then customizing `cors_config` is not allowed.
+* `environment_crn` - (Optional, Forces new resource, String) **Gen 1 dedicated hardware plan only.** CRN of the IBM Cloudant Dedicated Hardware plan instance.
+* `include_data_events` - (Optional, Boolean) Include `data` event types in events sent to IBM Cloud Activity Tracker Event Routing for the IBM Cloudant instance. The default value is **false** and emitted events are only of the `management` type. For Gen 1 instances this is applied via the Activity Tracker API. For Gen 2 instances this maps to the broker parameter `dataservices.cloudant.configuration.audit.data_events`.
+* `legacy_credentials` - (Optional, Forces new resource, Boolean) **Gen 1 only.** Use both legacy credentials and IAM for authentication. The default value is **false**.
 * `location` - (Required, Forces new resource, String) Target location or environment to create the resource instance.
 * `name` - (Required, String) A name for the resource instance.
-* `parameters` - (Optional, Forces new resource, Map) Arbitrary parameters to pass. Must be a JSON object.
-* `plan` - (Required, String) The plan type of the service.
+* `parameters` - (Optional, Forces new resource, Map) Arbitrary parameters to pass. Must be a JSON object. Typed schema attributes always take precedence over any conflicting values supplied here.
+* `plan` - (Required, String) The plan type of the service. Plan transitions between Gen 1 and Gen 2, or between dedicated and non-dedicated plans, are not supported.
 * `resource_group_id` - (Optional, Forces new resource, String) The resource group ID.
-* `service_endpoints` - (Optional, String) Types of the service endpoints. Possible values are 'public', 'private', 'public-and-private'.
+* `service_endpoints` - (Optional, String) Types of the service endpoints. Possible values are `public`, `private`, `public-and-private`.
 * `tags` - (Optional, Set of String) Tags associated with the instance.
 
 ## Attribute reference
@@ -104,12 +125,12 @@ In addition to all arguments above, you can access the following attribute refer
 * `restored_by` - (String) The subject who restored the instance back from reclamation.
 * `scheduled_reclaim_at` - (String) The date when the instance was scheduled for reclamation.
 * `scheduled_reclaim_by` - (String) The subject who initiated the instance reclamation.
-* `service` - (String) The service type of the instance.
+* `service` - (String) The service type of the instance. Always `cloudantnosqldb`.
 * `state` - (String) The current state of the instance.
 * `status` - (String) Status of the resource instance.
 * `sub_type` - (String) The sub-type of an instance. For example, **cfaas**.
 * `target_crn` - (String) The full deployment CRN as defined in the global catalog.
-* `throughput` - (Map of Number) Schema for detailed information about throughput capacity with breakdown by specific throughput requests classes.
+* `throughput` - (Map of Number) **Gen 1 only.** Detailed information about throughput capacity with breakdown by specific throughput requests classes. Not populated for Gen 2 instances.
 * `type` - (String) The type of the instance. For example, **service_instance**.
 * `update_at` - (String) The date when the instance was last updated.
 * `update_by` - (String) The subject who updated the instance.

--- a/website/docs/r/cloudant_database.html.markdown
+++ b/website/docs/r/cloudant_database.html.markdown
@@ -23,11 +23,11 @@ resource "ibm_cloudant_database" "cloudant_database" {
 
 The following arguments are supported:
 
-* `db` - (Required, Forces new resource, string) Path parameter to specify the database name.
-* `instance_crn` - (Required, string) Path parameter to specify the cloudant instance CRN.
-* `partitioned` - (Optional, Forces new resource, bool) Query parameter to specify whether to enable database partitions when creating a database.
+* `db` - (Required, Forces new resource, string) The database name.
+* `instance_crn` - (Required, Forces new resource, string) The CRN of the Cloudant instance.
+* `partitioned` - (Optional, Forces new resource, bool) Whether to enable database partitions when creating a database.
   * Constraints: The default value is `false`.
-* `shards` - (Optional, Forces new resource, int) The number of shards in the database. Each shard is a partition of the hash value range. Default set by server.
+* `shards` - (Optional, Forces new resource, int) The number of shards in the database. Each shard is a partition of the hash value range. You are encouraged to talk to support about appropriate values before changing this.
   * Constraints: The minimum value is `1`.
 
 ## Attribute Reference
@@ -44,8 +44,8 @@ The `ID` property can be formed from `instance_crn`, and `db` in the following f
 ```
 <instance_crn>/<db>
 ```
-* `db`: A string. Path parameter to specify the database name.
-* `instance_crn`: A string. Path parameter to specify the cloudant instance CRN.
+* `db`: A string. The database name.
+* `instance_crn`: A string. The CRN of the Cloudant instance.
 
 ```
 $ terraform import ibm_cloudant_database.cloudant_database <instance_crn>/<db>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Add IBM Cloudant Gen 2 plan support
Also Closes #6905 

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`) - not modified
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make testacc TEST=./ibm/service/cloudant/ TESTARGS='-run=TestAccIBMCloudant'                                                                                  (cloudant-gen2-support)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cloudant/ -v -run=TestAccIBMCloudant -timeout 700m 
[WARN] Set the environment variable IBM_RECLAMATION_ID for testing reclamation, reclamation_delete tests will fail if this is not set
...
[WARN] Set the environment variable IBM_IS_ADMIN_CONFIG for testing ibm_container_cluster_config datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMCloudantDatabaseDataSourceBasic
--- PASS: TestAccIBMCloudantDatabaseDataSourceBasic (101.00s)
=== RUN   TestAccIBMCloudantDataSource_basic
--- PASS: TestAccIBMCloudantDataSource_basic (89.07s)
=== RUN   TestAccIBMCloudantDatabaseBasic
--- PASS: TestAccIBMCloudantDatabaseBasic (111.14s)
=== RUN   TestAccIBMCloudantDatabaseAllArgs
--- PASS: TestAccIBMCloudantDatabaseAllArgs (97.92s)
=== RUN   TestAccIBMCloudant_basic
--- PASS: TestAccIBMCloudant_basic (130.00s)
=== RUN   TestAccIBMCloudant_import
--- PASS: TestAccIBMCloudant_import (112.75s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudant	643.655s
```

Extends the ibm_cloudant and ibm_cloudant_database resources to support IBM Cloudant Gen 2 plan instances (e.g. standard-gen2), alongside several bug fixes and a utility refactor that underpins both.

* `refactor: ibm_cloudant utils`
    * Extracts all Cloudant-specific helper logic into a new `cloudant_utils.go`, including client construction, endpoint resolution, and parameter marshalling.
    * Introduces `isCloudantGen2Plan` / `isCloudantGen2PlanFrom`: any plan name not in the known Gen 1 set is treated as Gen 2.
    * Adds `selectCloudantEndpoint` to handle both Gen 1 (endpoints.public / endpoints.private) and Gen 2 (dataservices.connection.public_endpoint_url / dataservices.connection.vpe_url) extension formats, respecting the provider visibility setting (private, public-and-private, public).
    * Replaces the two-step `GetCloudantInstanceUrl` + `GetCloudantClientForUrl` calls with a single `GetCloudantClientFromCrn` (used by `ibm_cloudant_database`) and`GetCloudantClientFromResource` (used by `ibm_cloudant`).
    * Adds `cloudantToResourceInstance` / `resourceInstanceToCloudant` to translate between Cloudant-level attributes and Resource Controller parameters.
    * Adds `cloudant_utils_test.go` covering endpoint selection, extension parsing, parameter encoding, and Gen 1/2 detection across all visibility modes.
* `feat: Gen 2 support for ibm_cloudant`
    * Gen 2 provisioning: for Gen 2 plans, `capacity`, `enable_cors`, `cors_config`, and `include_data_events` are encoded as a structured JSON object and written to `parameters_json`, which the Resource Controller layer forwards to the broker — bypassing the Cloudant management API calls that are only valid for Gen 1.
    * `parameters_json` schema fix: the attribute was excluded from docs but not from schema. It is now Computed-only, and is used internally to carry nested broker parameters.
    * Fix: Gen 1 always sends `legacyCredentials`: previously, omitting `legacy_credentials` in config would leave the field unset, causing the created instance to have legacy credentials while Terraform reported it did not. Now `legacyCredentials` is always explicitly sent. Added an importer to ensure the value is `false` if unset
    * Fix: surface validation errors at plan time: capacity and CORS validation, plus Gen 2 unsupported-field checks (`legacy_credentials`, `environment_crn`), are now wired into `CustomizeDiff` so they fail fast during terraform plan rather than only at apply.
    * Fix: nil pointer dereference in `ibm_cloudant_database` read when response is `nil`.
    * Updated attribute descriptions to call out Gen 1 only applicability for `legacy_credentials`, `environment_crn`, and `throughput`.
* `feat: Gen 2 support for ibm_cloudant_database`
    * Removes the now-redundant `GetCloudantInstanceUrl` function from `resource_ibm_cloudant_database.go`; all CRUD operations use the consolidated `GetCloudantClientFromCrn` helper.
    * Gen 2 databases are created/read/deleted via the same Cloudant SDK path as Gen 1 — no additional changes needed beyond correct endpoint resolution handled in the utils layer.
* Examples & docs
    * Adds two new Terraform example configurations under `examples/ibm-cloudant/standard-gen2-plan` and `examples/ibm-cloudant/standard-gen2-plan-with-database`.
    * Updates `website/docs/r/cloudant.html.markdown` with a Gen 2 usage example and per-attribute Gen 1/Gen 2 notes.
    * Updates `website/docs/r/cloudant_database.html.markdown` and the corresponding data source docs.
