### PR TITLE
chore(secretsmanager): Update Secrets Manager Vault Enterprise provider 28.07.26

### DIFF
--- a/ibm/service/secretsmanager/utils.go
+++ b/ibm/service/secretsmanager/utils.go
@@ -274,3 +274,4 @@ func secretVersionMetadataAsPatchFunction(secretVersionMetadataPatch *secretsman
 	}
 	return
 }
+// Generated: 28.07.26 build 14570


### PR DESCRIPTION
## Description

Updates Secrets Manager Vault Enterprise Terraform provider resources generated from the broker API spec.

**Note:** This PR only includes service-specific files. The shared files `config.go` and `provider.go` are not modified (generated with `initialize=false`).

**Changed files (1):**
- ibm/service/secretsmanager/utils.go


**Source:** static/api-docs.yaml

## Checklist
- [ ] Generated with `initialize=false`
- [ ] Only secretsmanager service files included
- [ ] Tests passing