### PR TITLE
chore(secretsmanager): Update Secrets Manager Vault Enterprise provider 28.07.26

### DIFF
--- a/ibm/service/secretsmanager/utils.go
+++ b/ibm/service/secretsmanager/utils.go
@@ -274,3 +274,4 @@ func secretVersionMetadataAsPatchFunction(secretVersionMetadataPatch *secretsman
 	}
 	return
 }
+// Generated: 28.07.26 build 14571


### PR DESCRIPTION
## Description

Updates Secrets Manager Vault Enterprise Terraform provider resources.

**Changed files (1):**
- ibm/service/secretsmanager/utils.go
