### PR TITLE
fix(dns): added support for new enum combination in GLB monitoring expected codes

### DIFF
--- a/ibm/service/dnsservices/resource_ibm_private_dns_glb_monitor.go
+++ b/ibm/service/dnsservices/resource_ibm_private_dns_glb_monitor.go
@@ -161,11 +161,16 @@ func ResourceIBMPrivateDNSGLBMonitor() *schema.Resource {
 			},
 
 			pdnsGlbMonitorExpectedCodes: {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: validate.InvokeValidator(ibmDNSGlbMonitor, pdnsGlbMonitorExpectedCodes),
-				Description:  "The expected HTTP response code or code range of the health check. This parameter is only valid for HTTP and HTTPS",
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{
+					"200", "201", "202", "203", "204", "205", "206", "207", "208", "226",
+					"2xx", "3xx", "4xx", "5xx",
+					"2xx,3xx", "2xx,4xx",
+					"2xx,3xx,4xx",
+				}),
+				Description: "The expected HTTP response code or code range of the health check. This parameter is only valid for HTTP and HTTPS",
 			},
 
 			pdnsGlbMonitorExpectedBody: {
@@ -192,7 +197,6 @@ func ResourceIBMPrivateDNSGLBMonitor() *schema.Resource {
 func ResourceIBMPrivateDNSGLBMonitorValidator() *validate.ResourceValidator {
 	monitorCheckTypes := "HTTP, HTTPS, TCP"
 	methods := "GET, HEAD"
-	expectedcode := "200,201,202,203,204,205,206,207,208,226,2xx,3xx,4xx,5xx"
 
 	validateSchema := make([]validate.ValidateSchema, 0)
 	validateSchema = append(validateSchema,
@@ -209,13 +213,6 @@ func ResourceIBMPrivateDNSGLBMonitorValidator() *validate.ResourceValidator {
 			Type:                       validate.TypeString,
 			Required:                   true,
 			AllowedValues:              methods})
-	validateSchema = append(validateSchema,
-		validate.ValidateSchema{
-			Identifier:                 pdnsGlbMonitorExpectedCodes,
-			ValidateFunctionIdentifier: validate.ValidateAllowedStringValue,
-			Type:                       validate.TypeString,
-			Required:                   true,
-			AllowedValues:              expectedcode})
 	dnsMonitorValidator := validate.ResourceValidator{ResourceName: ibmDNSGlbMonitor, Schema: validateSchema}
 	return &dnsMonitorValidator
 }

--- a/website/docs/r/dns_glb_monitor.html.markdown
+++ b/website/docs/r/dns_glb_monitor.html.markdown
@@ -41,7 +41,7 @@ Review the argument reference that you can specify for your resource.
 - `allow_insecure` - (Optional, String) Do not validate the certificate when monitor use HTTPS. This parameter is currently only valid for HTTPS monitors.
 - `description` - (Optional, String)  Descriptive text of the Load Balancer monitor.
 - `expected_body` - (Optional, String) A case-insensitive sub-string to look in the response body. If the string is not found, the origin will be marked as unhealthy. This parameter is only valid for HTTP and HTTPS monitors.
-- `expected_codes` - (Optional, String) The expected HTTP response code or code range of the health check. This parameter is only valid for HTTP and HTTPS monitors. Allowable values are `200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 2xx, 3xx, 4xx, 5xx`.
+- `expected_codes` - (Optional, String) The expected HTTP response code or code range of the health check. This parameter is only valid for HTTP and HTTPS monitors. Allowable values are `200`, `201`, `202`, `203`, `204`, `205`, `206`, `207`, `208`, `226`, `2xx`, `3xx`, `4xx`, `5xx`, `2xx,3xx`, `2xx,4xx`, `2xx,3xx,4xx`.
 - `headers` - (Optional, Set) The HTTP request headers to send in the health check. It is recommended you set a host header by default. The `User-Agent` header cannot be overridden. This parameter is only valid for HTTP and HTTPS monitors.
 
   Nested scheme for `headers`:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/dnsservices TESTARGS='-run=TestAccIBMPrivateDNSGlbMonitor' | grep -v '^\[WARN\]\|^\[INFO\]'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/dnsservices -v -run=TestAccIBMPrivateDNSGlbMonitor -timeout 700m 
=== RUN   TestAccIBMPrivateDNSGlbMonitorsDataSource_basic
--- PASS: TestAccIBMPrivateDNSGlbMonitorsDataSource_basic (135.34s)
=== RUN   TestAccIBMPrivateDNSGlbMonitor_Basic
--- PASS: TestAccIBMPrivateDNSGlbMonitor_Basic (168.36s)
=== RUN   TestAccIBMPrivateDNSGlbMonitorImport
--- PASS: TestAccIBMPrivateDNSGlbMonitorImport (114.44s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/dnsservices     419.956s
```
