### PR TITLE
Feat: added enterprise-sharding-gen2 plan support for MongoDB databases

### DIFF
--- a/ibm/service/database/helpers.go
+++ b/ibm/service/database/helpers.go
@@ -283,6 +283,15 @@ var databaseServicePrefixes = map[string]string{
 	"databases-for-enterprisedb":   "enterprisedb",
 }
 
+// mongodbPlanTypeOverrides maps MongoDB plan names to their API-level dataservices key.
+// The Gen2 API uses plan-specific keys ("mongodbee", "mongodbees") instead of the
+// generic "mongodb" key used for standard plans.
+var mongodbPlanTypeOverrides = map[string]string{
+	"enterprise":               "mongodbee",
+	"enterprise-sharding":      "mongodbees",
+	"enterprise-sharding-gen2": "mongodbees",
+}
+
 // getDatabaseTypeFromResourceID maps the resource ID or service name to the database type key.
 // Used in extensions for Gen2 and in parameters structure.
 // Returns an empty string if the resource ID doesn't match any known database service.
@@ -293,6 +302,19 @@ func getDatabaseTypeFromResourceID(resourceID string) string {
 		}
 	}
 	return ""
+}
+
+// getDatabaseTypeForPlan maps the service name and plan to the correct API-level dataservices key.
+// For most services this is the same as getDatabaseTypeFromResourceID, but MongoDB has
+// plan-specific keys ("mongodbee", "mongodbees") that the Gen2 API requires.
+func getDatabaseTypeForPlan(serviceName, plan string) string {
+	dbType := getDatabaseTypeFromResourceID(serviceName)
+	if dbType == "mongodb" {
+		if override, ok := mongodbPlanTypeOverrides[plan]; ok {
+			return override
+		}
+	}
+	return dbType
 }
 
 // expandPlatformOptionsFromRCExtension extracts platform options from instance extensions for Gen2.

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -279,6 +279,8 @@ func TestIsGen2Plan(t *testing.T) {
 		{"databases-for-postgresql-gen2", true},
 		{"databases-for-postgresql-gen2-dev", true},
 		{"standard-gen2", true},
+		{"enterprise-sharding-gen2", true},
+		{"enterprise-sharding", false},
 		{"standard", false},
 		{"", false},
 	}

--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -948,7 +948,7 @@ func ResourceIBMICDValidator() *validate.ResourceValidator {
 			Identifier:                 "plan",
 			ValidateFunctionIdentifier: validate.ValidateAllowedICDPlanValue,
 			Type:                       validate.TypeString,
-			AllowedValues:              "standard, standard-gen2, enterprise, enterprise-sharding, platinum",
+			AllowedValues:              "standard, standard-gen2, enterprise, enterprise-sharding, enterprise-sharding-gen2, platinum",
 			Required:                   true})
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -61,10 +61,11 @@ const (
 // DBConfig represents database-specific configuration for Gen2 parameters.
 // Replaces map[string]interface{} for type safety and compile-time validation.
 type DBConfig struct {
-	Version    string `json:"version,omitempty"`
-	Members    int    `json:"members"`
-	StorageGB  int    `json:"storage_gb,omitempty"`
-	HostFlavor string `json:"host_flavor,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Members     int    `json:"members"`
+	StorageGB   int    `json:"storage_gb,omitempty"`
+	HostFlavor  string `json:"host_flavor,omitempty"`
+	OmitMembers bool   `json:"-"` // when true, members is not sent in the API payload
 }
 
 // instanceConfigContext encapsulates shared context for instance configuration steps.
@@ -349,14 +350,17 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 		}
 	}
 
-	// Get the database type for the dataservices key
-	dbType := getDatabaseTypeFromResourceID(serviceName)
+	// Get the plan-aware database type for the dataservices key.
+	// MongoDB enterprise plans use distinct keys ("mongodbee", "mongodbees") rather than "mongodb".
+	plan := d.Get("plan").(string)
+	dbType := getDatabaseTypeForPlan(serviceName, plan)
 	if dbType == "" {
 		return nil, fmt.Errorf("unable to determine database type from service name: %s", serviceName)
 	}
 
-	// Build database configuration using typed struct
-	dbConfig, err := g.buildDBConfig(d, catalogCRN, meta)
+	// Build database configuration using typed struct.
+	// Pass dbType so fields unsupported by specific brokers (e.g. "members" for mongodbees) can be omitted.
+	dbConfig, err := g.buildDBConfig(d, catalogCRN, meta, dbType)
 	if err != nil {
 		return nil, err
 	}
@@ -387,8 +391,12 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 // Extracts and consolidates member group logic, reducing nested if statements.
 // Gen2 supports: members, disk, and host_flavor from groups.
 // Note: memory and cpu are NOT supported independently in Gen2 - they are controlled by host_flavor.
-func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, catalogCRN string, meta interface{}) (map[string]interface{}, error) {
+// dbType is the API-level key (e.g. "mongodbees") used to suppress fields the broker does not accept.
+func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, catalogCRN string, meta interface{}, dbType string) (map[string]interface{}, error) {
 	config := DBConfig{}
+
+	// mongodbees (enterprise-sharding) broker rejects a "members" field in the payload.
+	config.OmitMembers = dbType == "mongodbees"
 
 	// Version
 	if version, ok := d.GetOk("version"); ok {
@@ -398,7 +406,8 @@ func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, c
 	// Get member group configuration
 	memberGroup := g.getMemberGroup(d)
 
-	// Members count - use from group if specified, otherwise get default from catalog
+	// Members count - use from group if specified, otherwise get default from catalog.
+	// Still resolved so it is available for state tracking, but not sent for mongodbees.
 	members, err := g.getMembersCount(memberGroup, catalogCRN, meta)
 	if err != nil {
 		return nil, err
@@ -426,13 +435,16 @@ func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, c
 
 // dbConfigToMap converts DBConfig struct to map[string]interface{} for API compatibility.
 // Only includes non-zero values to avoid sending unnecessary fields.
+// members is omitted when OmitMembers is set (e.g. mongodbees whose broker rejects the field).
 func (g *resourceIBMDatabaseGen2Backend) dbConfigToMap(config DBConfig) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	if config.Version != "" {
 		result["version"] = config.Version
 	}
-	result["members"] = config.Members
+	if !config.OmitMembers {
+		result["members"] = config.Members
+	}
 	if config.StorageGB > 0 {
 		result["storage_gb"] = config.StorageGB
 	}

--- a/ibm/service/database/resource_ibm_database_gen2_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_test.go
@@ -173,7 +173,7 @@ func TestGen2BuildDBConfigUsesPerMemberDiskAllocation(t *testing.T) {
 
 	backend := newResourceIBMDatabaseGen2Backend().(*resourceIBMDatabaseGen2Backend)
 
-	config, err := backend.buildDBConfig(d, "", nil)
+	config, err := backend.buildDBConfig(d, "", nil, "postgresql")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, config["members"])
 	assert.Equal(t, 20, config["storage_gb"])

--- a/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
@@ -113,6 +113,80 @@ func TestAccIBMDatabaseInstanceMongoShardingHscale(t *testing.T) {
 	})
 }
 
+// TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic provisions a Gen2 MongoDB
+// enterprise-sharding instance using the enterprise-sharding-gen2 plan. Gen2 plans
+// use dedicated host flavors and only support private service endpoints.
+//
+// Run against a real account with:
+// go test -timeout 240m -run TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic ./ibm/service/database/...
+func TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic(t *testing.T) {
+	t.Parallel()
+	databaseResourceGroup := "default"
+	var databaseInstanceOne string
+	rnd := fmt.Sprintf("tf-mongoShardingGen2-%d", acctest.RandIntRange(10, 100))
+	testName := rnd
+	name := "ibm_database." + testName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGroup, testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
+					resource.TestCheckResourceAttr(name, "name", testName),
+					resource.TestCheckResourceAttr(name, "service", "databases-for-mongodb"),
+					resource.TestCheckResourceAttr(name, "plan", "enterprise-sharding-gen2"),
+					resource.TestCheckResourceAttr(name, "location", acc.Region()),
+					resource.TestCheckResourceAttr(name, "service_endpoints", "private"),
+					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGroup string, name string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		name = "%[1]s"
+	}
+
+	resource "ibm_database" "%[2]s" {
+		resource_group_id            = data.ibm_resource_group.test_acc.id
+		name                         = "%[2]s"
+		service                      = "databases-for-mongodb"
+		plan                         = "enterprise-sharding-gen2"
+		location                     = "%[3]s"
+		service_endpoints            = "private"
+
+		group {
+			group_id = "member"
+
+			host_flavor {
+				id = "bx3d.4x20"
+			}
+
+			members {
+				allocation_count = 3
+			}
+
+			disk {
+				allocation_mb = 20480
+			}
+		}
+
+		timeouts {
+			create = "480m"
+			update = "480m"
+			delete = "15m"
+		}
+	}
+				`, databaseResourceGroup, name, acc.Region())
+}
+
 func testAccCheckIBMDatabaseInstanceMongoDBShardingBasic(databaseResourceGroup string, name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {

--- a/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
@@ -123,25 +123,24 @@ func TestAccIBMDatabaseInstanceMongoShardingHscale(t *testing.T) {
 // go test -timeout 240m -run TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic ./ibm/service/database/...
 func TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic(t *testing.T) {
 	t.Parallel()
-	databaseResourceGroup := "default"
 	var databaseInstanceOne string
 	rnd := fmt.Sprintf("tf-mongoShardingGen2-%d", acctest.RandIntRange(10, 100))
 	testName := rnd
 	name := "ibm_database." + testName
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		PreCheck:     func() { acc.TestAccPreCheckEnterprise(t) },
 		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckIBMDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGroup, testName),
+				Config: testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(testName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIBMDatabaseInstanceExists(name, &databaseInstanceOne),
 					resource.TestCheckResourceAttr(name, "name", testName),
 					resource.TestCheckResourceAttr(name, "service", "databases-for-mongodb"),
 					resource.TestCheckResourceAttr(name, "plan", "enterprise-sharding-gen2"),
-					resource.TestCheckResourceAttr(name, "location", acc.Region()),
+					resource.TestCheckResourceAttr(name, "location", "ca-mon"),
 					resource.TestCheckResourceAttr(name, "service_endpoints", "private"),
 					resource.TestCheckResourceAttr(name, "groups.0.count", "3"),
 				),
@@ -150,18 +149,18 @@ func TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGroup string, name string) string {
+func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(name string) string {
 	return fmt.Sprintf(`
 	data "ibm_resource_group" "test_acc" {
-		name = "%[1]s"
+		is_default = true
 	}
 
-	resource "ibm_database" "%[2]s" {
+	resource "ibm_database" "%[1]s" {
 		resource_group_id = data.ibm_resource_group.test_acc.id
-		name              = "%[2]s"
+		name              = "%[1]s"
 		service           = "databases-for-mongodb"
 		plan              = "enterprise-sharding-gen2"
-		location          = "%[3]s"
+		location          = "ca-mon"
 		service_endpoints = "private"
 
 		# host_flavor must NOT be set: enterprise-sharding-gen2 is multitenant
@@ -180,7 +179,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGro
 			delete = "15m"
 		}
 	}
-			`, databaseResourceGroup, name, acc.Region())
+			`, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceMongoDBShardingBasic(databaseResourceGroup string, name string) string {

--- a/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
+++ b/ibm/service/database/resource_ibm_database_mongodb_sharding_test.go
@@ -114,8 +114,10 @@ func TestAccIBMDatabaseInstanceMongoShardingHscale(t *testing.T) {
 }
 
 // TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic provisions a Gen2 MongoDB
-// enterprise-sharding instance using the enterprise-sharding-gen2 plan. Gen2 plans
-// use dedicated host flavors and only support private service endpoints.
+// enterprise-sharding instance using the enterprise-sharding-gen2 plan. This plan
+// is multitenant (no dedicated host flavors) and only supports private service endpoints.
+// The shard member count is fixed at 3 by the plan — members and host_flavor must not
+// be specified in the group block. Minimum disk is 30 GB (30720 MB) per member.
 //
 // Run against a real account with:
 // go test -timeout 240m -run TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic ./ibm/service/database/...
@@ -155,26 +157,20 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGro
 	}
 
 	resource "ibm_database" "%[2]s" {
-		resource_group_id            = data.ibm_resource_group.test_acc.id
-		name                         = "%[2]s"
-		service                      = "databases-for-mongodb"
-		plan                         = "enterprise-sharding-gen2"
-		location                     = "%[3]s"
-		service_endpoints            = "private"
+		resource_group_id = data.ibm_resource_group.test_acc.id
+		name              = "%[2]s"
+		service           = "databases-for-mongodb"
+		plan              = "enterprise-sharding-gen2"
+		location          = "%[3]s"
+		service_endpoints = "private"
 
+		# host_flavor must NOT be set: enterprise-sharding-gen2 is multitenant
+		# members  must NOT be set: shard count is fixed at 3 by the plan; broker rejects the field
 		group {
 			group_id = "member"
 
-			host_flavor {
-				id = "bx3d.4x20"
-			}
-
-			members {
-				allocation_count = 3
-			}
-
 			disk {
-				allocation_mb = 20480
+				allocation_mb = 30720 # minimum 30 GB; step size 3 GB
 			}
 		}
 
@@ -184,7 +180,7 @@ func testAccCheckIBMDatabaseInstanceMongoDBShardingGen2Basic(databaseResourceGro
 			delete = "15m"
 		}
 	}
-				`, databaseResourceGroup, name, acc.Region())
+			`, databaseResourceGroup, name, acc.Region())
 }
 
 func testAccCheckIBMDatabaseInstanceMongoDBShardingBasic(databaseResourceGroup string, name string) string {

--- a/ibm/service/database/validators_test.go
+++ b/ibm/service/database/validators_test.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
@@ -11,6 +12,43 @@ import (
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
+
+// TestResourceIBMICDValidatorPlanAllowedValues locks in the set of plan values
+// accepted by the ibm_database "plan" attribute. The plan validator does an exact
+// string match against this list, so every supported plan (including Gen2 plans
+// such as enterprise-sharding-gen2) must be present here or provisioning fails at
+// plan/validate time.
+func TestResourceIBMICDValidatorPlanAllowedValues(t *testing.T) {
+	validator := ResourceIBMICDValidator()
+
+	var planAllowedValues string
+	found := false
+	for _, s := range validator.Schema {
+		if s.Identifier == "plan" {
+			planAllowedValues = s.AllowedValues
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected a validate schema for the \"plan\" attribute")
+
+	allowed := make(map[string]bool)
+	for _, v := range strings.Split(planAllowedValues, ",") {
+		allowed[strings.TrimSpace(v)] = true
+	}
+
+	expectedPlans := []string{
+		"standard",
+		"standard-gen2",
+		"enterprise",
+		"enterprise-sharding",
+		"enterprise-sharding-gen2",
+		"platinum",
+	}
+	for _, plan := range expectedPlans {
+		require.Truef(t, allowed[plan], "expected plan %q to be an allowed value, got %q", plan, planAllowedValues)
+	}
+}
 
 func TestIsVersionUpgradeAllowed(t *testing.T) {
 	testcases := []struct {

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -817,10 +817,10 @@ Review the argument reference that you can specify for your resource.
 
   **Gen2:** Accepted but ignored (Classic-only feature).
 - `plan` - (Required, Forces new resource, String) The name of the service plan that you choose for your instance. The plan determines whether your instance uses Classic or Gen2 infrastructure:
-  - **Classic plans**: `standard`, `enterprise`, `platinum`
-  - **Gen2 plans**: `standard-gen2`, `enterprise-gen2`, `platinum-gen2`
+  - **Classic plans**: `standard`, `enterprise`, `enterprise-sharding`, `platinum`
+  - **Gen2 plans**: `standard-gen2`, `enterprise-gen2`, `enterprise-sharding-gen2`, `platinum-gen2`
 
-  Plans ending with `-gen2` use Gen2 infrastructure. `enterprise` is supported only for elasticsearch (`databases-for-elasticsearch`) and mongodb (`databases-for-mongodb`). `platinum` is supported for elasticsearch (`databases-for-elasticsearch`).
+  Plans ending with `-gen2` use Gen2 infrastructure. `enterprise` is supported only for elasticsearch (`databases-for-elasticsearch`) and mongodb (`databases-for-mongodb`). `enterprise-sharding` and `enterprise-sharding-gen2` are supported only for mongodb (`databases-for-mongodb`). `platinum` is supported for elasticsearch (`databases-for-elasticsearch`).
 - `point_in_time_recovery_deployment_id` - (Optional, String) The ID of the source deployment that you want to recover back to.
 
   **Gen2:** Plan fails if set. Point-in-time recovery is not yet implemented for Gen2 instances.

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -469,6 +469,60 @@ output "analytics_connection" {
 
 ```
 
+### Sample MongoDB Enterprise Sharding Gen2 database instance
+
+* Uses the `enterprise-sharding-gen2` plan — a Gen2 plan backed by the IBM Cloud Resource Controller API, not the Classic ICD API.
+* **Do not set `host_flavor`** — this plan is multitenant. The Global Catalog carries no host-flavor options for `enterprise-sharding-gen2`. Any value causes the broker to return `error_invalid_host_flavor`.
+* **Do not set `members` inside the `group` block** — the shard count is fixed at `3` by the plan. Sending a `members` field causes the broker to return `unknown field 'members'`.
+* The minimum `disk` allocation is **30 GB** (`30720 MB`) per member. Values below this are rejected by the broker.
+* `service_endpoints` must be set to `"private"`.
+* Use `ibm_resource_key` for credentials. The `adminpassword`, `users`, and `allowlist` attributes are not supported on Gen2 plans.
+* Provisioning takes longer than standard instances — extend the `create` timeout to at least `120m`.
+
+```terraform
+data "ibm_resource_group" "group" {
+  name = "Default"
+}
+
+resource "ibm_database" "mongodb_enterprise_sharding_gen2" {
+  resource_group_id = data.ibm_resource_group.group.id
+  name              = "my-mongodb-enterprise-sharding-gen2"
+  service           = "databases-for-mongodb"
+  plan              = "enterprise-sharding-gen2"
+  location          = "ca-mon"
+  service_endpoints = "private"
+
+  # Do NOT include host_flavor — plan is multitenant, no dedicated-host options exist
+  # Do NOT include members  — fixed at 3 by the plan; broker rejects the field
+  group {
+    group_id = "member"
+
+    disk {
+      allocation_mb = 30720  # minimum 30 GB; step size 3 GB
+    }
+  }
+
+  tags = ["env:production"]
+
+  timeouts {
+    create = "120m"
+    update = "120m"
+    delete = "15m"
+  }
+}
+
+# Gen2 credentials are managed via ibm_resource_key
+resource "ibm_resource_key" "mongodb_credentials" {
+  name                 = "mongodb-credentials"
+  resource_instance_id = ibm_database.mongodb_enterprise_sharding_gen2.id
+}
+
+output "mongodb_connection" {
+  value     = ibm_resource_key.mongodb_credentials.credentials
+  sensitive = true
+}
+```
+
 ### Sample EDB instance
 EDB takes more time than expected. It is always advisible to extend timeouts using timeouts block
 
@@ -821,6 +875,13 @@ Review the argument reference that you can specify for your resource.
   - **Gen2 plans**: `standard-gen2`, `enterprise-gen2`, `enterprise-sharding-gen2`, `platinum-gen2`
 
   Plans ending with `-gen2` use Gen2 infrastructure. `enterprise` is supported only for elasticsearch (`databases-for-elasticsearch`) and mongodb (`databases-for-mongodb`). `enterprise-sharding` and `enterprise-sharding-gen2` are supported only for mongodb (`databases-for-mongodb`). `platinum` is supported for elasticsearch (`databases-for-elasticsearch`).
+
+  **`enterprise-sharding-gen2` specific rules:**
+  - `host_flavor` must **not** be set — this plan is multitenant (no dedicated-host flavors available).
+  - `members` must **not** be set inside the `group` block — the shard count is fixed at `3` by the plan; the broker rejects the field.
+  - `disk.allocation_mb` minimum is `30720` (30 GB); step size is 3 GB.
+  - `service_endpoints` must be `"private"`.
+  - `adminpassword`, `users`, and `allowlist` are not supported — use `ibm_resource_key` for credentials.
 - `point_in_time_recovery_deployment_id` - (Optional, String) The ID of the source deployment that you want to recover back to.
 
   **Gen2:** Plan fails if set. Point-in-time recovery is not yet implemented for Gen2 instances.


### PR DESCRIPTION

**added enterprise-sharding-gen2 plan support for MongoDB databases**
<img width="1325" height="965" alt="Screenshot 2026-07-28 at 4 10 19 PM" src="https://github.com/user-attachments/assets/1e52f776-a05f-4c3f-a40f-0ec734b4394a" />
<img width="1728" height="586" alt="Screenshot 2026-07-29 at 11 02 18 AM" src="https://github.com/user-attachments/assets/18b2f993-2839-414b-8696-18838a08c2c3" />
<img width="1728" height="476" alt="Screenshot 2026-07-29 at 11 02 33 AM" src="https://github.com/user-attachments/assets/695a5a8d-b334-42bf-8af9-e0f5ee721d03" />


Output from acceptance testing:

```
$ make testacc TEST=./ibm/service/database TESTARGS='-run=TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic'

=== RUN   TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic
=== PAUSE TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic
=== CONT  TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic
--- PASS: TestAccIBMMongoDBShardingGen2DatabaseInstanceBasic (1616.11s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1618.292s
```
