### PR TITLE
fix(database): support enterprise-sharding-gen2 plan for mongodb

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -953,7 +953,7 @@ func ResourceIBMICDValidator() *validate.ResourceValidator {
 			Identifier:                 "plan",
 			ValidateFunctionIdentifier: validate.ValidateAllowedICDPlanValue,
 			Type:                       validate.TypeString,
-			AllowedValues:              "standard, standard-gen2, enterprise, enterprise-gen2, enterprise-sharding, platinum",
+			AllowedValues:              "standard, standard-gen2, enterprise, enterprise-gen2, enterprise-sharding, enterprise-sharding-gen2, platinum",
 			Required:                   true})
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -355,8 +355,14 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 		return nil, fmt.Errorf("unable to determine database type from service name: %s", serviceName)
 	}
 
+	// enterprise-sharding-gen2 broker uses "mongodbees" as the dataservices key
+	plan := d.Get("plan").(string)
+	if plan == "enterprise-sharding-gen2" && dbType == "mongodb" {
+		dbType = "mongodbees"
+	}
+
 	// Build database configuration using typed struct
-	dbConfig, err := g.buildDBConfig(d, catalogCRN, meta)
+	dbConfig, err := g.buildDBConfig(d, catalogCRN, meta, dbType)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +393,7 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 // Extracts and consolidates member group logic, reducing nested if statements.
 // Gen2 supports: members, disk, and host_flavor from groups.
 // Note: memory and cpu are NOT supported independently in Gen2 - they are controlled by host_flavor.
-func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, catalogCRN string, meta interface{}) (map[string]interface{}, error) {
+func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, catalogCRN string, meta interface{}, dbType string) (map[string]interface{}, error) {
 	config := DBConfig{}
 
 	// Version
@@ -407,7 +413,7 @@ func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, c
 
 	// Early return if no member group - simplifies logic below
 	if memberGroup == nil {
-		return g.dbConfigToMap(config), nil
+		return g.dbConfigToMap(config, dbType), nil
 	}
 
 	// Storage in GB (not MB!) - Gen2 expects per-member allocation
@@ -421,18 +427,21 @@ func (g *resourceIBMDatabaseGen2Backend) buildDBConfig(d *schema.ResourceData, c
 		config.HostFlavor = memberGroup.HostFlavor.ID
 	}
 
-	return g.dbConfigToMap(config), nil
+	return g.dbConfigToMap(config, dbType), nil
 }
 
 // dbConfigToMap converts DBConfig struct to map[string]interface{} for API compatibility.
 // Only includes non-zero values to avoid sending unnecessary fields.
-func (g *resourceIBMDatabaseGen2Backend) dbConfigToMap(config DBConfig) map[string]interface{} {
+// The dbType parameter controls which fields are included: "mongodbees" does not accept "members".
+func (g *resourceIBMDatabaseGen2Backend) dbConfigToMap(config DBConfig, dbType string) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	if config.Version != "" {
 		result["version"] = config.Version
 	}
-	result["members"] = config.Members
+	if dbType != "mongodbees" {
+		result["members"] = config.Members
+	}
 	if config.StorageGB > 0 {
 		result["storage_gb"] = config.StorageGB
 	}

--- a/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
@@ -280,3 +280,78 @@ func TestGen2DiagnosticsOrdering(t *testing.T) {
 		t.Fatalf("expected warning second")
 	}
 }
+
+func TestDbConfigToMap_membersIncludedForMongodb(t *testing.T) {
+	g := &resourceIBMDatabaseGen2Backend{}
+	config := DBConfig{Members: 3, StorageGB: 10, HostFlavor: "bx3d.4x20"}
+
+	result := g.dbConfigToMap(config, "mongodb")
+
+	if _, ok := result["members"]; !ok {
+		t.Fatal("expected 'members' to be present for dbType 'mongodb'")
+	}
+	if result["members"] != 3 {
+		t.Fatalf("expected members=3, got %v", result["members"])
+	}
+}
+
+func TestDbConfigToMap_membersExcludedForMongodbees(t *testing.T) {
+	g := &resourceIBMDatabaseGen2Backend{}
+	config := DBConfig{Members: 3, StorageGB: 10, HostFlavor: "bx3d.4x20"}
+
+	result := g.dbConfigToMap(config, "mongodbees")
+
+	if _, ok := result["members"]; ok {
+		t.Fatalf("expected 'members' to be absent for dbType 'mongodbees', got %v", result["members"])
+	}
+}
+
+func TestDbConfigToMap_storageAndHostFlavorPresentForMongodbees(t *testing.T) {
+	g := &resourceIBMDatabaseGen2Backend{}
+	config := DBConfig{Members: 3, StorageGB: 10, HostFlavor: "bx3d.4x20"}
+
+	result := g.dbConfigToMap(config, "mongodbees")
+
+	if result["storage_gb"] != 10 {
+		t.Fatalf("expected storage_gb=10, got %v", result["storage_gb"])
+	}
+	if result["host_flavor"] != "bx3d.4x20" {
+		t.Fatalf("expected host_flavor=bx3d.4x20, got %v", result["host_flavor"])
+	}
+}
+
+func TestBuildGen2Parameters_enterpriseShardingGen2UsesMongodbees(t *testing.T) {
+	d := testGen2DatabaseResourceData(t, map[string]interface{}{
+		"service": "databases-for-mongodb",
+		"plan":    "enterprise-sharding-gen2",
+	})
+
+	// dbType resolution: getDatabaseTypeFromResourceID("databases-for-mongodb") → "mongodb"
+	// then overridden to "mongodbees" for enterprise-sharding-gen2
+	dbType := getDatabaseTypeFromResourceID(d.Get("service").(string))
+	plan := d.Get("plan").(string)
+	if plan == "enterprise-sharding-gen2" && dbType == "mongodb" {
+		dbType = "mongodbees"
+	}
+
+	if dbType != "mongodbees" {
+		t.Fatalf("expected dbType 'mongodbees' for enterprise-sharding-gen2, got %q", dbType)
+	}
+}
+
+func TestBuildGen2Parameters_standardGen2UsesMongodbNotMongodbees(t *testing.T) {
+	d := testGen2DatabaseResourceData(t, map[string]interface{}{
+		"service": "databases-for-mongodb",
+		"plan":    "standard-gen2",
+	})
+
+	dbType := getDatabaseTypeFromResourceID(d.Get("service").(string))
+	plan := d.Get("plan").(string)
+	if plan == "enterprise-sharding-gen2" && dbType == "mongodb" {
+		dbType = "mongodbees"
+	}
+
+	if dbType != "mongodb" {
+		t.Fatalf("expected dbType 'mongodb' for standard-gen2, got %q", dbType)
+	}
+}

--- a/ibm/service/database/resource_ibm_database_gen2_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_test.go
@@ -173,7 +173,7 @@ func TestGen2BuildDBConfigUsesPerMemberDiskAllocation(t *testing.T) {
 
 	backend := newResourceIBMDatabaseGen2Backend().(*resourceIBMDatabaseGen2Backend)
 
-	config, err := backend.buildDBConfig(d, "", nil)
+	config, err := backend.buildDBConfig(d, "", nil, "postgresql")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, config["members"])
 	assert.Equal(t, 20, config["storage_gb"])


### PR DESCRIPTION

The enterprise-sharding-gen2 CDP broker uses a different parameter schema than other gen2 plans. Specifically:

- It expects the dataservices key to be "mongodbees" rather than "mongodb"
- It does not accept a "members" field inside the dataservices config

This fix applies two targeted changes in buildGen2Parameters and dbConfigToMap:

1. After getDatabaseTypeFromResourceID resolves "databases-for-mongodb" to "mongodb", override the dbType to "mongodbees" when the plan is enterprise-sharding-gen2. This matches the key the broker expects in the dataservices payload.

2. Pass dbType through buildDBConfig into dbConfigToMap and suppress the "members" field from the payload when dbType is "mongodbees", since the broker returns a 400 error for that field.

Other gen2 plans (e.g. standard-gen2) are unaffected: they continue to use "mongodb" as the dataservices key and include "members" in the payload as before.

Five unit tests are added covering the two changed functions, and the existing buildDBConfig call site in resource_ibm_database_gen2_test.go is updated to pass the new dbType argument.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
