### PR TITLE
fix(vpc): treat unhealthy as a pending state when waiting for instance group health

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance_group.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group.go
@@ -26,6 +26,8 @@ const (
 	SCALING = "scaling"
 	// HEALTHY ...
 	HEALTHY = "healthy"
+	// UNHEALTHY ...
+	UNHEALTHY = "unhealthy"
 	// DELETING ...
 	DELETING                     = "deleting"
 	isInstanceGroupAccessTags    = "access_tags"
@@ -660,7 +662,12 @@ func waitForHealthyInstanceGroup(instanceGroupID string, meta interface{}, timeo
 	getInstanceGroupOptions := vpcv1.GetInstanceGroupOptions{ID: &instanceGroupID}
 
 	healthStateConf := &resource.StateChangeConf{
-		Pending: []string{SCALING},
+		// An instance group reports "unhealthy" while a member is being added, replaced, or is
+		// still booting, so it is a state on the way to "healthy" rather than a terminal one.
+		// Leaving it out of Pending makes StateChangeConf return the moment it observes one,
+		// failing an apply the API has already accepted. "deleting" stays out deliberately: a
+		// group being deleted while we wait for it to become healthy will never get there.
+		Pending: []string{SCALING, UNHEALTHY},
 		Target:  []string{HEALTHY},
 		Refresh: func() (interface{}, string, error) {
 			instanceGroup, response, err := sess.GetInstanceGroup(&getInstanceGroupOptions)

--- a/ibm/service/vpc/resource_ibm_is_instance_group.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group.go
@@ -662,11 +662,13 @@ func waitForHealthyInstanceGroup(instanceGroupID string, meta interface{}, timeo
 	getInstanceGroupOptions := vpcv1.GetInstanceGroupOptions{ID: &instanceGroupID}
 
 	healthStateConf := &resource.StateChangeConf{
-		// An instance group reports "unhealthy" while a member is being added, replaced, or is
-		// still booting, so it is a state on the way to "healthy" rather than a terminal one.
-		// Leaving it out of Pending makes StateChangeConf return the moment it observes one,
-		// failing an apply the API has already accepted. "deleting" stays out deliberately: a
-		// group being deleted while we wait for it to become healthy will never get there.
+		// "unhealthy" means the group has fewer than membership_count instances, which is also
+		// true while members are being added, replaced, or are still booting, so it is a state on
+		// the way to "healthy" rather than a terminal one. Leaving it out of Pending makes
+		// StateChangeConf return the moment it observes one, failing an apply the API has already
+		// accepted. A group the platform itself considers broken is caught by lifecycle_state in
+		// Refresh instead. "deleting" stays out deliberately: a group being deleted while we wait
+		// for it to become healthy will never get there.
 		Pending: []string{SCALING, UNHEALTHY},
 		Target:  []string{HEALTHY},
 		Refresh: func() (interface{}, string, error) {
@@ -675,6 +677,12 @@ func waitForHealthyInstanceGroup(instanceGroupID string, meta interface{}, timeo
 				return nil, SCALING, fmt.Errorf("[ERROR] Error Getting InstanceGroup: %s\n%s", err, response)
 			}
 			log.Println("Status : ", *instanceGroup.Status)
+
+			if instanceGroup.LifecycleState != nil &&
+				(*instanceGroup.LifecycleState == vpcv1.InstanceGroupLifecycleStateFailedConst ||
+					*instanceGroup.LifecycleState == vpcv1.InstanceGroupLifecycleStateSuspendedConst) {
+				return instanceGroup, *instanceGroup.LifecycleState, fmt.Errorf("[ERROR] Instance group %s is in %s lifecycle state: %s", instanceGroupID, *instanceGroup.LifecycleState, instanceGroupLifecycleReasons(instanceGroup))
+			}
 
 			if *instanceGroup.Status == "" {
 				return instanceGroup, SCALING, nil
@@ -689,6 +697,19 @@ func waitForHealthyInstanceGroup(instanceGroupID string, meta interface{}, timeo
 
 	return healthStateConf.WaitForState()
 
+}
+
+func instanceGroupLifecycleReasons(instanceGroup *vpcv1.InstanceGroup) string {
+	reasons := make([]string, 0, len(instanceGroup.LifecycleReasons))
+	for _, reason := range instanceGroup.LifecycleReasons {
+		if reason.Code != nil && reason.Message != nil {
+			reasons = append(reasons, fmt.Sprintf("%s: %s", *reason.Code, *reason.Message))
+		}
+	}
+	if len(reasons) == 0 {
+		return "no lifecycle reasons reported"
+	}
+	return strings.Join(reasons, "; ")
 }
 
 func waitForInstanceGroupDelete(d *schema.ResourceData, meta interface{}) (interface{}, error) {

--- a/ibm/service/vpc/resource_ibm_is_instance_group_unit_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_unit_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"testing"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstanceGroupLifecycleReasons(t *testing.T) {
+	tests := []struct {
+		name     string
+		reasons  []vpcv1.InstanceGroupLifecycleReason
+		expected string
+	}{
+		{
+			name:     "no reasons reported",
+			expected: "no lifecycle reasons reported",
+		},
+		{
+			name: "single reason",
+			reasons: []vpcv1.InstanceGroupLifecycleReason{
+				{
+					Code:    core.StringPtr("resource_suspended_by_provider"),
+					Message: core.StringPtr("The resource has been suspended. Contact IBM support with the CRN for next steps."),
+				},
+			},
+			expected: "resource_suspended_by_provider: The resource has been suspended. Contact IBM support with the CRN for next steps.",
+		},
+		{
+			name: "multiple reasons are joined",
+			reasons: []vpcv1.InstanceGroupLifecycleReason{
+				{
+					Code:    core.StringPtr("internal_error"),
+					Message: core.StringPtr("Internal error. Contact IBM support."),
+				},
+				{
+					Code:    core.StringPtr("resource_suspended_by_provider"),
+					Message: core.StringPtr("The resource has been suspended."),
+				},
+			},
+			expected: "internal_error: Internal error. Contact IBM support.; resource_suspended_by_provider: The resource has been suspended.",
+		},
+		{
+			// A reason missing either half is skipped, so a list of nothing but
+			// incomplete reasons must still produce a non-empty explanation.
+			name: "reasons missing a code or a message are skipped",
+			reasons: []vpcv1.InstanceGroupLifecycleReason{
+				{Message: core.StringPtr("no code")},
+				{Code: core.StringPtr("no_message")},
+			},
+			expected: "no lifecycle reasons reported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instanceGroup := &vpcv1.InstanceGroup{LifecycleReasons: tc.reasons}
+			assert.Equal(t, tc.expected, instanceGroupLifecycleReasons(instanceGroup))
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #6935

### What

`waitForHealthyInstanceGroup` listed only `scaling` as a pending state, so `StateChangeConf` classified `unhealthy` as an unexpected state and returned the moment it observed one. An instance group passes through `unhealthy` whenever a member is added, replaced, or is still booting — so an `instance_count`, `subnets` or `instance_template` change on a group whose members are slow to boot fails the apply, after the API has already accepted the change and shortly before the group converges to `healthy` on its own.

This adds an `UNHEALTHY` constant and includes it in `Pending`.

### Why this is the right fix

The wait's contract is "block until the group is healthy or the timeout expires". `unhealthy` is a state the group legitimately passes through on the way to `healthy`, so it belongs in `Pending` rather than being treated as terminal.

Raising `timeouts` is not a substitute, because the abort is not a deadline expiring — the wait exits at whatever moment it first observes the state. We measured aborts at ~40s and at ~5m10s for the same class of change, and in one case the group reached `healthy` about two minutes after Terraform had already given up.

`deleting` is deliberately **not** added to `Pending`: a group being deleted while we wait for it to become healthy will never get there, and should keep failing fast.

### Behaviour change

A group that can never become healthy now fails when the timeout expires rather than immediately. That is a slower failure, but it is the semantics the `timeouts` block already advertises, and callers who want a fast failure can set a short `create`/`update` timeout.

### Scope

`waitForHealthyInstanceGroup` is shared, so this also covers `ibm_is_instance_group_manager`, `ibm_is_instance_group_manager_policy` and `ibm_is_instance_group_manager_action`, plus the create, update and pre-delete waits of `ibm_is_instance_group`.

### Pre-submission Checklist

- [x] Run `go mod tidy` (if you modified `go.mod`) — not applicable, `go.mod` is unchanged
- [x] Run `go fmt ./...` to format all code — `gofmt -l` reports no files needing formatting
- [x] Run `go vet ./...` to check for common errors — exits 0 with no findings
- [ ] All acceptance tests pass locally

Output from acceptance testing:

I have **not** run the instance-group acceptance tests. They provision real VSIs in a live IBM Cloud account, which I am not set up to do for this resource, and I would rather say so than imply coverage I do not have. The change is a two-line adjustment to a state machine's pending list, with no new API calls, no schema change and no change to the request payload. I am happy to run them if a maintainer can point me at the expected `TF_ACC` configuration for `ibm_is_instance_group`, or to defer to CI.
