### PR TITLE
added tag support for private path services gateway

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_private_path_service_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_private_path_service_gateway.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -65,6 +66,22 @@ func ResourceIBMIsPrivatePathServiceGateway() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "ndicates whether this private path service gateway has zonal affinity.",
+			},
+			"tags": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_private_path_service_gateway", "tags")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of user tags for this private path service gateway.",
+			},
+			"access_tags": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validate.InvokeValidator("ibm_is_private_path_service_gateway", "accesstag")},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access management tags for this private path service gateway.",
 			},
 			"created_at": &schema.Schema{
 				Type:        schema.TypeString,
@@ -190,6 +207,24 @@ func ResourceIBMIsPrivatePathServiceGatewayValidator() *validate.ResourceValidat
 			MinValueLength:             1,
 			MaxValueLength:             128,
 		},
+		validate.ValidateSchema{
+			Identifier:                 "tags",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^[A-Za-z0-9:_ .-]+$`,
+			MinValueLength:             1,
+			MaxValueLength:             128,
+		},
+		validate.ValidateSchema{
+			Identifier:                 "accesstag",
+			ValidateFunctionIdentifier: validate.ValidateRegexpLen,
+			Type:                       validate.TypeString,
+			Optional:                   true,
+			Regexp:                     `^([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-]):([A-Za-z0-9_.-]|[A-Za-z0-9_.-][A-Za-z0-9_ .-]*[A-Za-z0-9_.-])$`,
+			MinValueLength:             1,
+			MaxValueLength:             128,
+		},
 	)
 
 	resourceValidator := validate.ResourceValidator{ResourceName: "ibm_is_private_path_service_gateway", Schema: validateSchema}
@@ -251,6 +286,26 @@ func resourceIBMIsPrivatePathServiceGatewayCreate(context context.Context, d *sc
 	if err != nil {
 		return flex.TerraformErrorf(err, fmt.Sprintf("isWaitForPPSGAvailable failed: %s", err.Error()), "ibm_is_private_path_service_gateway", "create").GetDiag()
 
+	}
+
+	if privatePathServiceGateway.CRN != nil {
+		v := os.Getenv("IC_ENV_TAGS")
+		if _, ok := d.GetOk("tags"); ok || v != "" {
+			oldList, newList := d.GetChange("tags")
+			err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *privatePathServiceGateway.CRN, "", isUserTagType)
+			if err != nil {
+				log.Printf(
+					"[ERROR] Error on create of resource private path service gateway (%s) tags: %s", d.Id(), err)
+			}
+		}
+		if _, ok := d.GetOk("access_tags"); ok {
+			oldList, newList := d.GetChange("access_tags")
+			err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *privatePathServiceGateway.CRN, "", isAccessTagType)
+			if err != nil {
+				log.Printf(
+					"[ERROR] Error on create of resource private path service gateway (%s) access tags: %s", d.Id(), err)
+			}
+		}
 	}
 
 	return resourceIBMIsPrivatePathServiceGatewayUpdate(context, d, meta)
@@ -331,6 +386,24 @@ func resourceIBMIsPrivatePathServiceGatewayRead(context context.Context, d *sche
 	if err = d.Set("private_path_service_gateway", privatePathServiceGateway.ID); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting private_path_service_gateway: %s", err), "ibm_is_private_path_service_gateway", "read", "set-private_path_service_gateway").GetDiag()
 	}
+	if privatePathServiceGateway.CRN != nil {
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, *privatePathServiceGateway.CRN, "", isUserTagType)
+		if err != nil {
+			log.Printf(
+				"[ERROR] Error on get of resource private path service gateway (%s) tags: %s", d.Id(), err)
+		}
+		if err = d.Set("tags", tags); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting tags: %s", err), "ibm_is_private_path_service_gateway", "read", "set-tags").GetDiag()
+		}
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *privatePathServiceGateway.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"[ERROR] Error on get of resource private path service gateway (%s) access tags: %s", d.Id(), err)
+		}
+		if err = d.Set("access_tags", accesstags); err != nil {
+			return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting access_tags: %s", err), "ibm_is_private_path_service_gateway", "read", "set-access_tags").GetDiag()
+		}
+	}
 
 	return nil
 }
@@ -348,6 +421,35 @@ func resourceIBMIsPrivatePathServiceGatewayUpdate(context context.Context, d *sc
 	hasChange := false
 
 	patchVals := &vpcv1.PrivatePathServiceGatewayPatch{}
+
+	if (d.HasChange("tags") || d.HasChange("access_tags")) && !d.IsNewResource() {
+		getPrivatePathServiceGatewayOptions := &vpcv1.GetPrivatePathServiceGatewayOptions{}
+		getPrivatePathServiceGatewayOptions.SetID(d.Id())
+		privatePathServiceGateway, response, err := vpcClient.GetPrivatePathServiceGatewayWithContext(context, getPrivatePathServiceGatewayOptions)
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error getting private path service gateway: %s\n%s", err.Error(), response), "ibm_is_private_path_service_gateway", "update")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		if privatePathServiceGateway.CRN != nil {
+			if d.HasChange("tags") {
+				oldList, newList := d.GetChange("tags")
+				err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *privatePathServiceGateway.CRN, "", isUserTagType)
+				if err != nil {
+					log.Printf(
+						"[ERROR] Error on update of resource private path service gateway (%s) tags: %s", d.Id(), err)
+				}
+			}
+			if d.HasChange("access_tags") {
+				oldList, newList := d.GetChange("access_tags")
+				err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, *privatePathServiceGateway.CRN, "", isAccessTagType)
+				if err != nil {
+					log.Printf(
+						"[ERROR] Error on update of resource private path service gateway (%s) access tags: %s", d.Id(), err)
+				}
+			}
+		}
+	}
 
 	if d.HasChange("default_access_policy") && !d.IsNewResource() {
 		newAccessPolicy := d.Get("default_access_policy").(string)

--- a/ibm/service/vpc/resource_ibm_is_private_path_service_gateway_test.go
+++ b/ibm/service/vpc/resource_ibm_is_private_path_service_gateway_test.go
@@ -54,6 +54,94 @@ func TestAccIBMIsPrivatePathServiceGatewayBasic(t *testing.T) {
 	})
 }
 
+func TestAccIBMIsPrivatePathServiceGatewayUserTags(t *testing.T) {
+	var conf vpcv1.PrivatePathServiceGateway
+	accessPolicy := "deny"
+	vpcname := fmt.Sprintf("tflb-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tflb-subnet-name-%d", acctest.RandIntRange(10, 100))
+	lbname := fmt.Sprintf("tf-test-lb%dd", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-test-ppsg%d", acctest.RandIntRange(10, 100))
+	userTag := "env:prod"
+	userTagUpdated := "env:dev"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsPrivatePathServiceGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsPrivatePathServiceGatewayConfigUserTags(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, accessPolicy, name, userTag),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsPrivatePathServiceGatewayExists("ibm_is_private_path_service_gateway.is_private_path_service_gateway", conf),
+					resource.TestCheckResourceAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "name", name),
+					resource.TestCheckResourceAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "tags.*", userTag),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsPrivatePathServiceGatewayConfigUserTags(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, accessPolicy, name, userTagUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "tags.*", userTagUpdated),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "ibm_is_private_path_service_gateway.is_private_path_service_gateway",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIBMIsPrivatePathServiceGatewayAccessTags(t *testing.T) {
+	var conf vpcv1.PrivatePathServiceGateway
+	accessPolicy := "deny"
+	vpcname := fmt.Sprintf("tflb-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tflb-subnet-name-%d", acctest.RandIntRange(10, 100))
+	lbname := fmt.Sprintf("tf-test-lb%dd", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-test-ppsg%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMIsPrivatePathServiceGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsPrivatePathServiceGatewayConfigAccessTags(vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, lbname, accessPolicy, name, "test:access"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMIsPrivatePathServiceGatewayExists("ibm_is_private_path_service_gateway.is_private_path_service_gateway", conf),
+					resource.TestCheckResourceAttr("ibm_is_private_path_service_gateway.is_private_path_service_gateway", "access_tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsPrivatePathServiceGatewayConfigUserTags(vpcname, subnetname, zone, cidr, lbname, accessPolicy, name, userTag string) string {
+	return testAccCheckIBMISPPNLB(vpcname, subnetname, zone, cidr, lbname) + fmt.Sprintf(`
+		resource "ibm_is_private_path_service_gateway" "is_private_path_service_gateway" {
+			default_access_policy = "%s"
+			name = "%s"
+			load_balancer = ibm_is_lb.testacc_LB.id
+			zonal_affinity = true
+			service_endpoints = ["mytestfqdn.internal"]
+			tags = ["%s"]
+		}
+	`, accessPolicy, name, userTag)
+}
+
+func testAccCheckIBMIsPrivatePathServiceGatewayConfigAccessTags(vpcname, subnetname, zone, cidr, lbname, accessPolicy, name, accessTags string) string {
+	return testAccCheckIBMISPPNLB(vpcname, subnetname, zone, cidr, lbname) + fmt.Sprintf(`
+		resource "ibm_is_private_path_service_gateway" "is_private_path_service_gateway" {
+			default_access_policy = "%s"
+			name = "%s"
+			load_balancer = ibm_is_lb.testacc_LB.id
+			zonal_affinity = true
+			service_endpoints = ["mytestfqdn.internal"]
+			access_tags = ["%s"]
+		}
+	`, accessPolicy, name, accessTags)
+}
+
 func testAccCheckIBMIsPrivatePathServiceGatewayConfigBasic(vpcname, subnetname, zone, cidr, lbname, accessPolicy, name string) string {
 	return testAccCheckIBMISPPNLB(vpcname, subnetname, zone, cidr, lbname) + fmt.Sprintf(`
 		resource "ibm_is_private_path_service_gateway" "is_private_path_service_gateway" {

--- a/website/docs/r/is_private_path_service_gateway.html.markdown
+++ b/website/docs/r/is_private_path_service_gateway.html.markdown
@@ -19,6 +19,8 @@ resource "ibm_is_private_path_service_gateway" "example" {
   load_balancer = ibm_is_lb.testacc_LB.id
   zonal_affinity = true
   service_endpoints = ["myexamplefqdn"]
+  tags = ["env:prod"]
+  access_tags = ["project:myapp"]
 }
 ```
 
@@ -30,7 +32,9 @@ Review the argument reference that you can specify for your resource.
 - `load_balancer` - (Required, String) The ID of the load balancer for this private path service gateway. This load balancer must be in the same VPC as the private path service gateway and must have is_private_path set to true.
 - `service_endpoints` - (Required, List of Strings) The fully qualified domain names for this private path service gateway.
 - `name` - (Optional, String) The name for this private path service gateway. The name must not be used by another private path service gateway in the VPC. 
+- `access_tags` - (Optional, List of Strings) A list of access management tags to attach to the private path service gateway. Tags must be in the format `key:value`. **Note** you can attach only those access tags that already exists.
 - `resource_group` - (Optional, String) ID of the resource group to use.
+- `tags` - (Optional, List of Strings) A list of user tags to attach to the private path service gateway.
 - `zonal_affinity` - (Optional, String) Indicates whether this private path service gateway has zonal affinity.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6947

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsPrivatePathServiceGatewayUserTags
--- PASS: TestAccIBMIsPrivatePathServiceGatewayUserTags (203.53s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     205.738s

=== RUN   TestAccIBMIsPrivatePathServiceGatewayAccessTags
--- PASS: TestAccIBMIsPrivatePathServiceGatewayAccessTags (153.31s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     155.356s
```
