### PR TITLE
Add acceptance tests for IBM Cloudant Gen 2

### DIFF
--- a/ibm/service/cloudant/data_source_ibm_cloudant_database_gen2_test.go
+++ b/ibm/service/cloudant/data_source_ibm_cloudant_database_gen2_test.go
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMCloudantGen2DatabaseDataSourceBasic(t *testing.T) {
+	serviceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(8))
+	db := fmt.Sprintf("tf_db_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCloudantGen2DatabaseDataSourceConfigBasic(serviceName, db),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "id"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "db"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "cluster.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "compact_running"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "disk_format_version"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "doc_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "doc_del_count"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "props.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "sizes.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_cloudant_database.cloudant_database", "update_seq"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMCloudantGen2DatabaseDataSourceConfigBasic(serviceName, db string) string {
+	return fmt.Sprintf(`
+
+			resource "ibm_cloudant" "cloudant_instance" {
+				name     = "%s"
+				plan     = "standard-gen2"
+				location = "%s"
+
+				timeouts {
+					create = "15m"
+					update = "15m"
+					delete = "15m"
+				}
+			}
+
+			resource "ibm_cloudant_database" "cloudant_database" {
+				instance_crn = ibm_cloudant.cloudant_instance.crn
+				db = "%s"
+			}
+
+			data "ibm_cloudant_database" "cloudant_database" {
+				db = ibm_cloudant_database.cloudant_database.db
+				instance_crn = ibm_cloudant_database.cloudant_database.instance_crn
+			}
+	`, serviceName, acc.Region(), db)
+}

--- a/ibm/service/cloudant/data_source_ibm_cloudant_gen2_test.go
+++ b/ibm/service/cloudant/data_source_ibm_cloudant_gen2_test.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMCloudantGen2DataSource_basic(t *testing.T) {
+	dataSourceName := "data.ibm_cloudant.instance"
+	serviceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCloudantGen2DataSourceConfig(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", serviceName),
+					resource.TestCheckResourceAttr(dataSourceName, "service", "cloudantnosqldb"),
+					resource.TestMatchResourceAttr(dataSourceName, flex.ResourceControllerURL, regexp.MustCompile("services/cloudantnosqldb/crn%3A.+")),
+					resource.TestCheckResourceAttr(dataSourceName, "include_data_events", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "capacity", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "enable_cors", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "cors_config.0.allow_credentials", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "features.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "features_flags.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMCloudantGen2DataSourceConfig(serviceName string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_cloudant" "instance" {
+	  name     = "%s"
+	  plan     = "standard-gen2"
+	  location = "%s"
+
+	  timeouts {
+	    create = "15m"
+	    update = "15m"
+	    delete = "15m"
+	  }
+	}
+
+	data "ibm_cloudant" "instance" {
+	  name = ibm_cloudant.instance.name
+	}
+
+	`, serviceName, acc.Region())
+}

--- a/ibm/service/cloudant/resource_ibm_cloudant_database_gen2_test.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant_database_gen2_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/IBM/cloudant-go-sdk/cloudantv1"
+)
+
+func TestAccIBMCloudantGen2DatabaseBasic(t *testing.T) {
+	var conf cloudantv1.DatabaseInformation
+	instanceName := fmt.Sprintf("tf_instance_%d", acctest.RandIntRange(10, 100))
+	db := fmt.Sprintf("tf_db_%d", acctest.RandIntRange(10, 100))
+	dbUpdate := fmt.Sprintf("tf_db_%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCloudantDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCloudantGen2DatabaseConfigBasic(instanceName, db),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCloudantDatabaseExists("ibm_cloudant_database.cloudant_database", conf),
+					resource.TestCheckResourceAttr("ibm_cloudant_database.cloudant_database", "db", db),
+				),
+			},
+			{
+				Config: testAccCheckIBMCloudantGen2DatabaseConfigBasic(instanceName, dbUpdate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ibm_cloudant_database.cloudant_database", "db", dbUpdate),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMCloudantGen2DatabaseConfigBasic(instanceName, db string) string {
+	return fmt.Sprintf(`
+
+		resource "ibm_cloudant" "cloudant_instance" {
+			name     = "%s"
+			plan     = "standard-gen2"
+			location = "%s"
+
+			timeouts {
+				create = "15m"
+				update = "15m"
+				delete = "15m"
+			}
+		}
+
+		resource "ibm_cloudant_database" "cloudant_database" {
+			instance_crn = ibm_cloudant.cloudant_instance.crn
+			db           = "%s"
+		}
+	`, instanceName, acc.Region(), db)
+}

--- a/ibm/service/cloudant/resource_ibm_cloudant_gen2_test.go
+++ b/ibm/service/cloudant/resource_ibm_cloudant_gen2_test.go
@@ -1,0 +1,150 @@
+// Copyright IBM Corp. 2026 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package cloudant_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMCloudantGen2_basic(t *testing.T) {
+	resourceName := "ibm_cloudant.instance"
+	serviceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(8))
+	updateName := fmt.Sprintf("terraform-test-%s", acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCloudantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCloudantGen2ResourceConfig(serviceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCloudantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", serviceName),
+					resource.TestCheckResourceAttr(resourceName, "service", "cloudantnosqldb"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(resourceName, "include_data_events", "true"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_cors", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.allow_credentials", "false"),
+				),
+			},
+			{
+				Config: testAccCheckIBMCloudantGen2ResourceUpdateConfig(updateName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "service", "cloudantnosqldb"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(resourceName, "include_data_events", "false"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "enable_cors", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMCloudantGen2_import(t *testing.T) {
+	resourceName := "ibm_cloudant.instance"
+	serviceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMCloudantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMCloudantGen2ResourceConfigMinimal(serviceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIBMCloudantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", serviceName),
+					resource.TestCheckResourceAttr(resourceName, "service", "cloudantnosqldb"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "standard-gen2"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_cors", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.allow_credentials", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
+			},
+		},
+	})
+}
+
+func testAccCheckIBMCloudantGen2ResourceConfig(serviceName string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_cloudant" "instance" {
+		name                = "%s"
+		plan                = "standard-gen2"
+		location            = "%s"
+
+		include_data_events = true
+		capacity            = 1
+		enable_cors         = true
+
+		cors_config {
+			allow_credentials = false
+			origins           = ["https://example.com"]
+		}
+
+		timeouts {
+		  create = "15m"
+		  update = "15m"
+		  delete = "15m"
+		}
+	  }
+
+	`, serviceName, acc.Region())
+}
+
+func testAccCheckIBMCloudantGen2ResourceUpdateConfig(serviceName string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_cloudant" "instance" {
+		name                = "%s"
+		plan                = "standard-gen2"
+		location            = "%s"
+
+		include_data_events = false
+		capacity            = 2
+		enable_cors         = false
+
+		timeouts {
+		  create = "15m"
+		  update = "15m"
+		  delete = "15m"
+		}
+	  }
+
+	`, serviceName, acc.Region())
+}
+
+func testAccCheckIBMCloudantGen2ResourceConfigMinimal(serviceName string) string {
+	return fmt.Sprintf(`
+
+	resource "ibm_cloudant" "instance" {
+		name     = "%s"
+		plan     = "standard-gen2"
+		location = "%s"
+
+		timeouts {
+		  create = "15m"
+		  update = "15m"
+		  delete = "15m"
+		}
+	  }
+
+	`, serviceName, acc.Region())
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Add acceptance tests for IBM Cloudant Gen 2

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [x] Run `go mod tidy` (if you modified `go.mod`) - not modified
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [x] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TEST=./ibm/service/cloudant/ TESTARGS='-run=TestAccIBMCloudant'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ibm/service/cloudant/ -v -run=TestAccIBMCloudant -timeout 700m 
[WARN] Set the environment variable IBM_RECLAMATION_ID for testing reclamation, reclamation_delete tests will fail if this is not set
...
[WARN] Set the environment variable IBM_IS_ADMIN_CONFIG for testing ibm_container_cluster_config datasource else tests will fail if this is not set correctly
=== RUN   TestAccIBMCloudantGen2DatabaseDataSourceBasic
--- PASS: TestAccIBMCloudantGen2DatabaseDataSourceBasic (70.72s)
=== RUN   TestAccIBMCloudantDatabaseDataSourceBasic
--- PASS: TestAccIBMCloudantDatabaseDataSourceBasic (91.57s)
=== RUN   TestAccIBMCloudantGen2DataSource_basic
--- PASS: TestAccIBMCloudantGen2DataSource_basic (72.52s)
=== RUN   TestAccIBMCloudantDataSource_basic
--- PASS: TestAccIBMCloudantDataSource_basic (92.42s)
=== RUN   TestAccIBMCloudantGen2DatabaseBasic
--- PASS: TestAccIBMCloudantGen2DatabaseBasic (68.88s)
=== RUN   TestAccIBMCloudantDatabaseBasic
--- PASS: TestAccIBMCloudantDatabaseBasic (96.91s)
=== RUN   TestAccIBMCloudantDatabaseAllArgs
--- PASS: TestAccIBMCloudantDatabaseAllArgs (100.46s)
=== RUN   TestAccIBMCloudantGen2_basic
--- PASS: TestAccIBMCloudantGen2_basic (109.27s)
=== RUN   TestAccIBMCloudantGen2_import
--- PASS: TestAccIBMCloudantGen2_import (59.06s)
=== RUN   TestAccIBMCloudant_basic
--- PASS: TestAccIBMCloudant_basic (135.57s)
=== RUN   TestAccIBMCloudant_import
--- PASS: TestAccIBMCloudant_import (96.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/cloudant        995.896s
```

Add acceptance tests for IBM Cloudant Gen 2 instances, databases, and data sources under `/ibm/service/cloudant`.

Tests were executed with `IC_REGION=eu-de`.