### PR TITLE
fix: use placeholder constants for passwords in tests and docs

### DIFF
--- a/ibm/service/database/data_source_ibm_database_connection_gen2_unit_test.go
+++ b/ibm/service/database/data_source_ibm_database_connection_gen2_unit_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+// testPasswordValue is a non-secret placeholder used in unit test fixtures.
+const testPasswordValue = "test-fixture-password"
+
 
 // TestTransformGen2ConnectionToSchema_PostgreSQL tests PostgreSQL connection transformation
 func TestTransformGen2ConnectionToSchema_PostgreSQL(t *testing.T) {
@@ -17,7 +20,7 @@ func TestTransformGen2ConnectionToSchema_PostgreSQL(t *testing.T) {
 		"database": "postgres",
 		"path":     "/postgres",
 		"composed": []interface{}{
-			"postgres://user:pass@host.example.com:5432/postgres?sslmode=verify-full",
+			"postgres://user:example-value@host.example.com:5432/postgres?sslmode=verify-full",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -28,7 +31,7 @@ func TestTransformGen2ConnectionToSchema_PostgreSQL(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 		"certificate": map[string]interface{}{
 			"name":               "ca-certificate",
@@ -63,7 +66,7 @@ func TestTransformGen2ConnectionToSchema_PostgreSQL(t *testing.T) {
 	assert.Len(t, auth, 1)
 	assert.Equal(t, "direct", auth[0]["method"])
 	assert.Equal(t, "user", auth[0]["username"])
-	assert.Equal(t, "pass", auth[0]["password"])
+	assert.Equal(t, testPasswordValue, auth[0]["password"])
 
 	// Verify certificate transformation
 	cert := result["certificate"].([]map[string]interface{})
@@ -84,7 +87,7 @@ func TestTransformGen2ConnectionToSchema_MongoDB(t *testing.T) {
 		"database": "admin",
 		"path":     "/admin",
 		"composed": []interface{}{
-			"mongodb://user:pass@host1.example.com:27017,host2.example.com:27017/admin?authSource=admin&replicaSet=replset",
+			"mongodb://user:example-value@host1.example.com:27017,host2.example.com:27017/admin?authSource=admin&replicaSet=replset",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -99,7 +102,7 @@ func TestTransformGen2ConnectionToSchema_MongoDB(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 		"query_options": map[string]interface{}{
 			"authSource": "admin",
@@ -136,7 +139,7 @@ func TestTransformGen2ConnectionToSchema_Redis(t *testing.T) {
 		"type":   "uri",
 		"scheme": "rediss",
 		"composed": []interface{}{
-			"rediss://:password@host.example.com:6379/0",
+			"rediss://:example-value@host.example.com:6379/0",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -146,7 +149,7 @@ func TestTransformGen2ConnectionToSchema_Redis(t *testing.T) {
 		},
 		"authentication": map[string]interface{}{
 			"method":   "direct",
-			"password": "password",
+			"password": testPasswordValue,
 		},
 		"query_options": map[string]interface{}{
 			"ssl": true,
@@ -170,7 +173,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_AMQPS(t *testing.T) {
 		"type":   "uri",
 		"scheme": "amqps",
 		"composed": []interface{}{
-			"amqps://user:pass@host.example.com:5671",
+			"amqps://user:example-value@host.example.com:5671",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -181,7 +184,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_AMQPS(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 	}
 
@@ -198,7 +201,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_MQTTS(t *testing.T) {
 		"type":   "uri",
 		"scheme": "mqtts",
 		"composed": []interface{}{
-			"mqtts://user:pass@host.example.com:8883",
+			"mqtts://user:example-value@host.example.com:8883",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -209,7 +212,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_MQTTS(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 	}
 
@@ -226,7 +229,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_StompSSL(t *testing.T) {
 		"type":   "uri",
 		"scheme": "stomp+ssl",
 		"composed": []interface{}{
-			"stomp+ssl://user:pass@host.example.com:61614",
+			"stomp+ssl://user:example-value@host.example.com:61614",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -237,7 +240,7 @@ func TestTransformGen2ConnectionToSchema_RabbitMQ_StompSSL(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 	}
 
@@ -255,7 +258,7 @@ func TestTransformGen2ConnectionToSchema_MySQL(t *testing.T) {
 		"scheme":   "mysql",
 		"database": "ibmclouddb",
 		"composed": []interface{}{
-			"mysql://user:pass@host.example.com:3306/ibmclouddb?ssl-mode=REQUIRED",
+			"mysql://user:example-value@host.example.com:3306/ibmclouddb?ssl-mode=REQUIRED",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -266,7 +269,7 @@ func TestTransformGen2ConnectionToSchema_MySQL(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 		"query_options": map[string]interface{}{
 			"ssl-mode": "REQUIRED",
@@ -287,7 +290,7 @@ func TestTransformGen2ConnectionToSchema_Elasticsearch_HTTPS(t *testing.T) {
 		"type":   "uri",
 		"scheme": "https",
 		"composed": []interface{}{
-			"https://user:pass@host.example.com:9200",
+			"https://user:example-value@host.example.com:9200",
 		},
 		"hosts": []interface{}{
 			map[string]interface{}{
@@ -298,7 +301,7 @@ func TestTransformGen2ConnectionToSchema_Elasticsearch_HTTPS(t *testing.T) {
 		"authentication": map[string]interface{}{
 			"method":   "direct",
 			"username": "user",
-			"password": "pass",
+			"password": testPasswordValue,
 		},
 	}
 
@@ -450,15 +453,15 @@ func TestTransformGen2CliToSchema(t *testing.T) {
 			"port=5432",
 			"dbname=postgres",
 			"user=user",
-			"password=pass",
+			"password=example-value",
 			"sslmode=verify-full",
 		},
 		"composed": []interface{}{
-			"PGUSER=user PGPASSWORD=pass PGSSLMODE=verify-full psql 'host=host.example.com port=5432 dbname=postgres'",
+			"PGUSER=user PGPASSWORD=example-value PGSSLMODE=verify-full psql 'host=host.example.com port=5432 dbname=postgres'",
 		},
 		"environment": map[string]interface{}{
 			"PGUSER":        "user",
-			"PGPASSWORD":    "pass",
+			"PGPASSWORD":    testPasswordValue,
 			"PGSSLMODE":     "verify-full",
 			"PGSSLROOTCERT": "system",
 		},
@@ -481,7 +484,7 @@ func TestTransformGen2CliToSchema(t *testing.T) {
 	// Verify environment variables
 	env := result["environment"].(map[string]interface{})
 	assert.Equal(t, "user", env["PGUSER"])
-	assert.Equal(t, "pass", env["PGPASSWORD"])
+	assert.Equal(t, testPasswordValue, env["PGPASSWORD"])
 	assert.Equal(t, "verify-full", env["PGSSLMODE"])
 	assert.Equal(t, "system", env["PGSSLROOTCERT"])
 
@@ -498,10 +501,10 @@ func TestTransformGen2CliToSchema_MongoDB(t *testing.T) {
 		"type": "cli",
 		"bin":  "mongosh",
 		"arguments": []interface{}{
-			"mongodb://user:pass@host.example.com:27017/admin?authSource=admin&replicaSet=replset",
+			"mongodb://user:example-value@host.example.com:27017/admin?authSource=admin&replicaSet=replset",
 		},
 		"composed": []interface{}{
-			"mongosh 'mongodb://user:pass@host.example.com:27017/admin?authSource=admin&replicaSet=replset'",
+			"mongosh 'mongodb://user:example-value@host.example.com:27017/admin?authSource=admin&replicaSet=replset'",
 		},
 		"environment": map[string]interface{}{},
 	}
@@ -523,14 +526,14 @@ func TestTransformGen2CliToSchema_Redis(t *testing.T) {
 		"arguments": []interface{}{
 			"-h", "host.example.com",
 			"-p", "6379",
-			"-a", "password",
+			"-a", "example-value",
 			"--tls",
 		},
 		"composed": []interface{}{
-			"redis-cli -h host.example.com -p 6379 -a password --tls",
+			"redis-cli -h host.example.com -p 6379 -a example-value --tls",
 		},
 		"environment": map[string]interface{}{
-			"REDISCLI_AUTH": "password",
+			"REDISCLI_AUTH": testPasswordValue,
 		},
 	}
 
@@ -542,7 +545,7 @@ func TestTransformGen2CliToSchema_Redis(t *testing.T) {
 
 	// Verify environment
 	env := result["environment"].(map[string]interface{})
-	assert.Equal(t, "password", env["REDISCLI_AUTH"])
+	assert.Equal(t, testPasswordValue, env["REDISCLI_AUTH"])
 }
 
 // TestTransformGen2ConnectionToSchema_EmptyInput tests handling of empty input

--- a/ibm/service/database/data_source_ibm_database_connection_gen2_unit_test.go
+++ b/ibm/service/database/data_source_ibm_database_connection_gen2_unit_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
 // testPasswordValue is a non-secret placeholder used in unit test fixtures.
 const testPasswordValue = "test-fixture-password"
-
 
 // TestTransformGen2ConnectionToSchema_PostgreSQL tests PostgreSQL connection transformation
 func TestTransformGen2ConnectionToSchema_PostgreSQL(t *testing.T) {

--- a/ibm/service/database/helpers_test.go
+++ b/ibm/service/database/helpers_test.go
@@ -291,6 +291,8 @@ func TestIsGen2Plan(t *testing.T) {
 
 // TestClearGen2UnsupportedAttributes tests the clearGen2UnsupportedAttributes function
 func TestClearGen2UnsupportedAttributes(t *testing.T) {
+	adminPasswordValue := "example-admin-value"
+
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
 		"adminuser": {
 			Type:     schema.TypeString,
@@ -343,7 +345,7 @@ func TestClearGen2UnsupportedAttributes(t *testing.T) {
 		},
 	}, map[string]interface{}{
 		"adminuser":            "admin",
-		"adminpassword":        "password123",
+		"adminpassword":        adminPasswordValue,
 		"auto_scaling":         []interface{}{map[string]interface{}{"enabled": true}},
 		"allowlist":            []interface{}{map[string]interface{}{"address": "1.2.3.4"}},
 		"users":                []interface{}{map[string]interface{}{"name": "user1"}},

--- a/ibm/service/database/resource_ibm_database_classic_test.go
+++ b/ibm/service/database/resource_ibm_database_classic_test.go
@@ -298,6 +298,9 @@ func TestClassicBackendCreateWithTags(t *testing.T) {
 
 // TestClassicBackendCreateWithAdminPassword tests admin password configuration
 func TestClassicBackendCreateWithAdminPassword(t *testing.T) {
+	adminPasswordValue := "example-admin-value"
+	specialPasswordValue := "example-special-value-1"
+
 	tests := []struct {
 		name          string
 		password      string
@@ -306,12 +309,12 @@ func TestClassicBackendCreateWithAdminPassword(t *testing.T) {
 	}{
 		{
 			name:          "valid_admin_password",
-			password:      "SecurePassword123!",
+			password:      adminPasswordValue,
 			expectedError: false,
 		},
 		{
 			name:          "password_with_special_chars",
-			password:      "P@ssw0rd!#$%",
+			password:      specialPasswordValue,
 			expectedError: false,
 		},
 	}
@@ -438,6 +441,11 @@ func TestClassicBackendCreateWithAutoScaling(t *testing.T) {
 
 // TestClassicBackendCreateWithUsers tests user creation
 func TestClassicBackendCreateWithUsers(t *testing.T) {
+	userPasswordValue1 := "example-user-value-1"
+	userPasswordValue2 := "example-user-value-2"
+	opsPasswordValue := "example-ops-value"
+	redisPasswordValue := "example-redis-value"
+
 	tests := []struct {
 		name          string
 		users         []map[string]interface{}
@@ -449,7 +457,7 @@ func TestClassicBackendCreateWithUsers(t *testing.T) {
 			users: []map[string]interface{}{
 				{
 					"name":     "testuser",
-					"password": "SecurePass123!",
+					"password": userPasswordValue1,
 				},
 			},
 			expectedError: false,
@@ -459,11 +467,11 @@ func TestClassicBackendCreateWithUsers(t *testing.T) {
 			users: []map[string]interface{}{
 				{
 					"name":     "user1",
-					"password": "SecurePass123!",
+					"password": userPasswordValue1,
 				},
 				{
 					"name":     "user2",
-					"password": "AnotherPass456!",
+					"password": userPasswordValue2,
 				},
 			},
 			expectedError: false,
@@ -473,7 +481,7 @@ func TestClassicBackendCreateWithUsers(t *testing.T) {
 			users: []map[string]interface{}{
 				{
 					"name":     "opsmanager",
-					"password": "OpsPass123!@#",
+					"password": opsPasswordValue,
 					"type":     "ops_manager",
 				},
 			},
@@ -484,7 +492,7 @@ func TestClassicBackendCreateWithUsers(t *testing.T) {
 			users: []map[string]interface{}{
 				{
 					"name":     "redisuser",
-					"password": "RedisPass123!",
+					"password": redisPasswordValue,
 					"role":     "+@read -@write",
 				},
 			},
@@ -635,6 +643,9 @@ func TestClassicBackendRead(t *testing.T) {
 
 // TestClassicBackendUpdate tests the Update method
 func TestClassicBackendUpdate(t *testing.T) {
+	updatedAdminPasswordValue := "example-updated-admin-value"
+	updatedUserPasswordValue := "example-updated-user-value"
+
 	tests := []struct {
 		name          string
 		changes       map[string]interface{}
@@ -669,7 +680,7 @@ func TestClassicBackendUpdate(t *testing.T) {
 		{
 			name: "update_admin_password",
 			changes: map[string]interface{}{
-				"adminpassword": "NewSecurePass123!",
+				"adminpassword": updatedAdminPasswordValue,
 			},
 			expectedError: false,
 		},
@@ -702,7 +713,7 @@ func TestClassicBackendUpdate(t *testing.T) {
 				"users": []map[string]interface{}{
 					{
 						"name":     "newuser",
-						"password": "NewUserPass123!",
+						"password": updatedUserPasswordValue,
 					},
 				},
 			},

--- a/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_attrs_test.go
@@ -70,10 +70,11 @@ func requireNoErrors(t *testing.T, diags diag.Diagnostics) {
 
 func TestGen2UnsupportedAttrsValidation(t *testing.T) {
 	g := &resourceIBMDatabaseGen2Backend{}
+	adminPasswordValue := "example-admin-value"
 
 	t.Run("unsupported attr present returns error", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"adminpassword": "very-secure-password-123",
+			"adminpassword": adminPasswordValue,
 		})
 
 		err := g.ValidateUnsupportedAttrsData(d)
@@ -84,7 +85,7 @@ func TestGen2UnsupportedAttrsValidation(t *testing.T) {
 
 	t.Run("multiple unsupported attrs present are all listed", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"adminpassword":             "very-secure-password-123",
+			"adminpassword":             adminPasswordValue,
 			"backup_encryption_key_crn": "crn:v1:bluemix:public:kms:us-south:a/account-id:instance-id:key:key-id",
 			"remote_leader_id":          "crn:v1:bluemix:public:databases-for-postgresql:us-south:a/account-id:instance-id::",
 		})
@@ -110,7 +111,7 @@ func TestGen2UnsupportedAttrsValidation(t *testing.T) {
 
 	t.Run("ignored and unsupported attrs returns error for unsupported attrs only", func(t *testing.T) {
 		d := testGen2DatabaseResourceData(t, map[string]interface{}{
-			"adminpassword": "very-secure-password-123",
+			"adminpassword": adminPasswordValue,
 			"configuration": `{"max_connections": 100}`,
 		})
 
@@ -193,9 +194,10 @@ func TestGen2IgnoredAttrsWarnings(t *testing.T) {
 
 func TestGen2IgnoredAttrsWarningsAreIndependentFromUnsupportedAttrs(t *testing.T) {
 	g := &resourceIBMDatabaseGen2Backend{}
+	adminPasswordValue := "example-admin-value"
 
 	d := testGen2DatabaseResourceData(t, map[string]interface{}{
-		"adminpassword":               "very-secure-password-123",
+		"adminpassword":               adminPasswordValue,
 		"configuration":               `{"max_connections": 100}`,
 		"version_upgrade_skip_backup": true,
 	})

--- a/ibm/service/database/resource_ibm_database_gen2_test.go
+++ b/ibm/service/database/resource_ibm_database_gen2_test.go
@@ -298,6 +298,9 @@ func TestGen2BackendCreateWithTags(t *testing.T) {
 
 // TestGen2BackendCreateWithAdminPassword tests admin password configuration
 func TestGen2BackendCreateWithAdminPassword(t *testing.T) {
+	adminPasswordValue := "example-admin-value"
+	specialPasswordValue := "example-special-value-1"
+
 	tests := []struct {
 		name          string
 		password      string
@@ -306,12 +309,12 @@ func TestGen2BackendCreateWithAdminPassword(t *testing.T) {
 	}{
 		{
 			name:          "valid_admin_password",
-			password:      "SecurePassword123!",
+			password:      adminPasswordValue,
 			expectedError: false,
 		},
 		{
 			name:          "password_with_special_chars",
-			password:      "P@ssw0rd!#$%",
+			password:      specialPasswordValue,
 			expectedError: false,
 		},
 	}
@@ -325,6 +328,8 @@ func TestGen2BackendCreateWithAdminPassword(t *testing.T) {
 
 // TestGen2BackendUnsupportedFeatures tests that Gen2 properly rejects unsupported features
 func TestGen2BackendUnsupportedFeatures(t *testing.T) {
+	userPasswordValue := "example-user-value-1"
+
 	tests := []struct {
 		name         string
 		attribute    string
@@ -345,7 +350,7 @@ func TestGen2BackendUnsupportedFeatures(t *testing.T) {
 			value: []map[string]interface{}{
 				{
 					"name":     "testuser",
-					"password": "SecurePass123!",
+					"password": userPasswordValue,
 				},
 			},
 			expectedWarn: true,
@@ -377,6 +382,8 @@ func TestGen2BackendUnsupportedFeatures(t *testing.T) {
 
 // TestGen2BackendWarnUnsupported tests the WarnUnsupported method
 func TestGen2BackendWarnUnsupported(t *testing.T) {
+	passwordValue := "example-value"
+
 	tests := []struct {
 		name              string
 		resourceData      map[string]interface{}
@@ -401,7 +408,7 @@ func TestGen2BackendWarnUnsupported(t *testing.T) {
 				"name":     "test-db",
 				"location": "us-south",
 				"users": []map[string]interface{}{
-					{"name": "test", "password": "pass"},
+					{"name": "test", "password": passwordValue},
 				},
 			},
 			expectedDiagCount: 1,
@@ -415,7 +422,7 @@ func TestGen2BackendWarnUnsupported(t *testing.T) {
 				"name":     "test-db",
 				"location": "us-south",
 				"users": []map[string]interface{}{
-					{"name": "test", "password": "pass"},
+					{"name": "test", "password": passwordValue},
 				},
 				"auto_scaling": map[string]interface{}{
 					"disk": map[string]interface{}{"capacity_enabled": true},
@@ -441,6 +448,8 @@ func TestGen2BackendWarnUnsupported(t *testing.T) {
 
 // TestGen2BackendValidateUnsupportedAttrsDiff tests validation during plan
 func TestGen2BackendValidateUnsupportedAttrsDiff(t *testing.T) {
+	passwordValue := "example-value"
+
 	tests := []struct {
 		name          string
 		changes       map[string]interface{}
@@ -460,7 +469,7 @@ func TestGen2BackendValidateUnsupportedAttrsDiff(t *testing.T) {
 			name: "unsupported_users_attr",
 			changes: map[string]interface{}{
 				"users": []map[string]interface{}{
-					{"name": "test", "password": "pass"},
+					{"name": "test", "password": passwordValue},
 				},
 			},
 			expectedError: true,
@@ -533,6 +542,9 @@ func TestGen2BackendRead(t *testing.T) {
 
 // TestGen2BackendUpdate tests the Update method
 func TestGen2BackendUpdate(t *testing.T) {
+	updatedAdminPasswordValue := "example-updated-admin-value"
+	updatedUserPasswordValue := "example-updated-user-value"
+
 	tests := []struct {
 		name          string
 		changes       map[string]interface{}
@@ -567,7 +579,7 @@ func TestGen2BackendUpdate(t *testing.T) {
 		{
 			name: "update_admin_password",
 			changes: map[string]interface{}{
-				"adminpassword": "NewSecurePass123!",
+				"adminpassword": updatedAdminPasswordValue,
 			},
 			expectedError: false,
 		},
@@ -609,7 +621,7 @@ func TestGen2BackendUpdate(t *testing.T) {
 				"users": []map[string]interface{}{
 					{
 						"name":     "newuser",
-						"password": "NewUserPass123!",
+						"password": updatedUserPasswordValue,
 					},
 				},
 			},
@@ -1552,6 +1564,9 @@ func TestGen2KeyProtectInstance(t *testing.T) {
 
 // TestGen2AdminPasswordIgnored tests that adminpassword is silently ignored in Gen2
 func TestGen2AdminPasswordIgnored(t *testing.T) {
+	adminPasswordValue := "example-admin-value"
+	updatedAdminPasswordValue := "example-updated-admin-value"
+
 	tests := []struct {
 		name             string
 		adminPassword    string
@@ -1560,19 +1575,19 @@ func TestGen2AdminPasswordIgnored(t *testing.T) {
 	}{
 		{
 			name:             "admin_password_create_ignored",
-			adminPassword:    "SecurePassword123!",
+			adminPassword:    adminPasswordValue,
 			operation:        "CREATE",
 			expectedBehavior: "Accepted but silently ignored - not validated, not sent to API, not configured",
 		},
 		{
 			name:             "admin_password_update_ignored",
-			adminPassword:    "NewPassword456!",
+			adminPassword:    updatedAdminPasswordValue,
 			operation:        "UPDATE",
 			expectedBehavior: "Accepted but silently ignored - not validated, not sent to API, not configured",
 		},
 		{
 			name:             "admin_password_read_not_returned",
-			adminPassword:    "SecurePassword123!",
+			adminPassword:    adminPasswordValue,
 			operation:        "READ",
 			expectedBehavior: "Not returned from API",
 		},

--- a/website/docs/r/kms_cryptounits.html.markdown
+++ b/website/docs/r/kms_cryptounits.html.markdown
@@ -19,6 +19,12 @@ After creating a Key Protect Dedicated resource, you need to initialize the inst
 ## Example usage to provision Key Protect service and key management
 
 ```terraform
+variable "kms_key_passphrase" {
+  description = "Passphrase for the KMS key share files."
+  type        = string
+  sensitive   = true
+}
+
 resource "ibm_resource_instance" "key_protect_instance" {
   name              = "test-tf-st"
   resource_group_id = data.ibm_resource_group.resource_group.id
@@ -45,11 +51,11 @@ resource "ibm_kms_cryptounits" "st-dedicated" {
   master_key  {
     keysharefile {
       filepath = "tf-mbk-1.key"
-      passphrase    = "abcd12"
+      passphrase    = var.kms_key_passphrase
     }
     keysharefile {
       filepath = "tf-mbk-2.key"
-      passphrase    = "abcd12"
+      passphrase    = var.kms_key_passphrase
     }
     keyname = "mbkkey"
     exists  = true
@@ -84,11 +90,11 @@ resource "ibm_kms_cryptounits" "st-dedicated" {
   master_key  {
     keysharefile {
       filepath = "tf-mbk-1.key"
-      passphrase    = "abcd12"
+      passphrase    = var.kms_key_passphrase
     }
     keysharefile {
       filepath = "tf-mbk-2.key"
-      passphrase    = "abcd12"
+      passphrase    = var.kms_key_passphrase
     }
     keyname = "mbkkey"
     exists  = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
