### PR TITLE
Increased provisioning timout

### DIFF
--- a/examples/ibm-pag/README.MD
+++ b/examples/ibm-pag/README.MD
@@ -96,9 +96,9 @@ resource "ibm_pag_instance" "pag" {
     }
   )
   timeouts {
-    create = "15m"
-    update = "15m"
-    delete = "15m"
+    create = "95m"
+    update = "1h"
+    delete = "1h"
   }
 }
 

--- a/examples/ibm-pag/main.tf
+++ b/examples/ibm-pag/main.tf
@@ -69,9 +69,9 @@ resource "ibm_pag_instance" "pag" {
     }
   )
   timeouts {
-    create = "15m"
-    update = "15m"
-    delete = "15m"
+    create = "95m"
+    update = "1h"
+    delete = "1h"
   }
 }
 

--- a/ibm/service/pag/resource_ibm_pag_instance.go
+++ b/ibm/service/pag/resource_ibm_pag_instance.go
@@ -32,9 +32,9 @@ func ResourceIBMPag() *schema.Resource {
 		Importer: &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(95 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		CustomizeDiff: customdiff.Sequence(

--- a/ibm/service/pag/resource_ibm_pag_instance_test.go
+++ b/ibm/service/pag/resource_ibm_pag_instance_test.go
@@ -185,9 +185,9 @@ func testAccCheckIBMResourceInstanceBasic(cos_instance_name string, cos_bucket_n
 		  }
 		)
 		timeouts {
-		  create = "30m"
-		  update = "30m"
-		  delete = "30m"
+		  create = "95m"
+		  update = "1h"
+		  delete = "1h"
 		}
 	  }
 	  

--- a/website/docs/r/pag_instance.html.markdown
+++ b/website/docs/r/pag_instance.html.markdown
@@ -83,7 +83,7 @@ resource "ibm_pag_instance" "pag" {
     }
   )
   timeouts {
-    create = "1h"
+    create = "95m"
     update = "1h"
     delete = "1h"
   }


### PR DESCRIPTION
Increased provisioning timeout to 95m from 1h , Since we introduce some new checks which is causing overall provisioning timeout to shout more than 1h .

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
