### PR TITLE
User-configurable storage IOPS

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -877,6 +877,13 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 					},
 				},
 			},
+			"iops": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "IOPS (Input/Output Operations Per Second) for the database instance. Valid range: 3000–64000. Only applicable for Gen2 plans.",
+				ValidateFunc: validation.IntBetween(3000, 64000),
+			},
+
 			flex.DeletionProtection: {
 				Type:        schema.TypeBool,
 				Optional:    true,

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -381,6 +381,11 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 		dataservices["restore_backup_id"] = backupID.(string)
 	}
 
+	// Support IOPS configuration when it is provided, (applicable only to Gen2 plans)
+	if iops, ok := d.GetOk("iops"); ok {
+		dataservices["iops"] = iops.(int)
+	}
+
 	// Build final parameters structure
 	parameters := map[string]interface{}{
 		"dataservices": dataservices,
@@ -891,8 +896,9 @@ func (g *resourceIBMDatabaseGen2Backend) checkUnsupportedChanges(d *schema.Resou
 
 // applyGroupScalingWithDiagnostics applies group scaling and returns diagnostics.
 // Wraps applyGroupScaling to provide consistent diagnostic handling.
+// Also triggers when iops changes, since IOPS is part of the dataservices parameters.
 func (g *resourceIBMDatabaseGen2Backend) applyGroupScalingWithDiagnostics(ctx context.Context, d *schema.ResourceData, rsConClient *rc.ResourceControllerV2, instanceID string, meta interface{}) diag.Diagnostics {
-	if !d.HasChange("group") {
+	if !d.HasChange("group") && !d.HasChange("iops") {
 		return nil
 	}
 


### PR DESCRIPTION
## Issue
https://github.ibm.com/cdp/issues/issues/3701

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
