### PR TITLE
fix: correct subcategory from 'IBM Backup Recovery API' to 'IBM Backup Recovery' in docs

### DIFF
--- a/website/docs/d/backup_recoveries.html.markdown
+++ b/website/docs/d/backup_recoveries.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recoveries"
 description: |-
   Get information about List of Recoveries.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recoveries

--- a/website/docs/d/backup_recovery_connector_agent_config.html.markdown
+++ b/website/docs/d/backup_recovery_connector_agent_config.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_agent_config"
 description: |-
   Get information about Connector agent config
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_agent_config

--- a/website/docs/d/backup_recovery_connector_agents.html.markdown
+++ b/website/docs/d/backup_recovery_connector_agents.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_agents"
 description: |-
   Get information about backup_recovery_connector_agents
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_agents

--- a/website/docs/d/backup_recovery_connector_get_users.html.markdown
+++ b/website/docs/d/backup_recovery_connector_get_users.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_get_users"
 description: |-
   Get information about backup_recovery_connector_get_users
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_get_users

--- a/website/docs/d/backup_recovery_connector_logs.html.markdown
+++ b/website/docs/d/backup_recovery_connector_logs.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_logs"
 description: |-
   Get information about Data-Source Connector Logs
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_logs

--- a/website/docs/d/backup_recovery_connector_status.html.markdown
+++ b/website/docs/d/backup_recovery_connector_status.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_status"
 description: |-
   Get information about Data-Source Connector Status
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_status

--- a/website/docs/d/backup_recovery_registration_info.html.markdown
+++ b/website/docs/d/backup_recovery_registration_info.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_registration_info"
 description: |-
   Get information about backup_recovery_registration_info
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_registration_info

--- a/website/docs/r/backup_recovery_connector_access_token.html.markdown
+++ b/website/docs/r/backup_recovery_connector_access_token.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_access_token"
 description: |-
   Manages backup_recovery_connector_access_token.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_access_token

--- a/website/docs/r/backup_recovery_connector_agent_registration.html.markdown
+++ b/website/docs/r/backup_recovery_connector_agent_registration.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_agent_registration"
 description: |-
   Manages Connector agent registration request.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_agent_registration

--- a/website/docs/r/backup_recovery_connector_registration.html.markdown
+++ b/website/docs/r/backup_recovery_connector_registration.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_registration"
 description: |-
   Manages Data-Source Connector Registration Request.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_registration

--- a/website/docs/r/backup_recovery_connector_update_user.html.markdown
+++ b/website/docs/r/backup_recovery_connector_update_user.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_connector_update_user"
 description: |-
   Manages backup_recovery_connector_update_user.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_connector_update_user

--- a/website/docs/r/backup_recovery_protection_source_refresh.html.markdown
+++ b/website/docs/r/backup_recovery_protection_source_refresh.html.markdown
@@ -3,7 +3,7 @@ layout: "ibm"
 page_title: "IBM : ibm_backup_recovery_protection_source_refresh"
 description: |-
   Manages backup_recovery_protection_source_refresh.
-subcategory: "IBM Backup Recovery API"
+subcategory: "IBM Backup Recovery"
 ---
 
 # ibm_backup_recovery_protection_source_refresh


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #BAAS-8358

### Summary

This fixes the subcategory in **12 documentation files** so they all appear under the correct **IBM Backup Recovery** section on the Terraform registry.

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [x] Run `go fmt ./...` to format all code
- [x] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Documentation-only change — no acceptance tests to run.