### PR TITLE
feat(vpc): add minimum_provisioned_size to ibm_is_image

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_image.go
+++ b/ibm/service/vpc/data_source_ibm_is_image.go
@@ -51,6 +51,11 @@ func DataSourceIBMISImage() *schema.Resource {
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{"public", "private"}),
 				Description:  "Whether the image is publicly visible or private to the account",
 			},
+			"minimum_provisioned_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The minimum size (in gigabytes) of a volume onto which this image may be provisioned.",
+			},
 			"resource_group": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -576,6 +581,9 @@ func imageGetById(context context.Context, d *schema.ResourceData, meta interfac
 	}
 	if err = d.Set("name", image.Name); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting name: %s", err), "(Data) ibm_is_image", "read", "set-name").GetDiag()
+	}
+	if err = d.Set("minimum_provisioned_size", flex.IntValue(image.MinimumProvisionedSize)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting minimum_provisioned_size: %s", err), "(Data) ibm_is_image", "read", "set-minimum_provisioned_size").GetDiag()
 	}
 	if err = d.Set("user_data_format", image.UserDataFormat); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting user_data_format: %s", err), "(Data) ibm_is_image", "read", "set-user_data_format").GetDiag()

--- a/ibm/service/vpc/data_source_ibm_is_image.go
+++ b/ibm/service/vpc/data_source_ibm_is_image.go
@@ -400,6 +400,9 @@ func imageGetByName(context context.Context, d *schema.ResourceData, meta interf
 	if err = d.Set("user_data_format", image.UserDataFormat); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting user_data_format: %s", err), "(Data) ibm_is_image", "read", "set-user_data_format").GetDiag()
 	}
+	if err = d.Set("minimum_provisioned_size", flex.IntValue(image.MinimumProvisionedSize)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting minimum_provisioned_size: %s", err), "(Data) ibm_is_image", "read", "set-minimum_provisioned_size").GetDiag()
+	}
 	if err = d.Set("status", image.Status); err != nil {
 		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting status: %s", err), "(Data) ibm_is_image", "read", "set-status").GetDiag()
 	}

--- a/ibm/service/vpc/data_source_ibm_is_image_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_image_test.go
@@ -210,6 +210,22 @@ func TestAccIBMISImageDataSource_With_VisibiltyPrivate(t *testing.T) {
 	})
 }
 
+func TestAccIBMISImageDataSourceMinimumProvisionedSize(t *testing.T) {
+	resName := "data.ibm_is_image.example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISImageDataSourceWithMinimumProvisionedSize(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "minimum_provisioned_size"),
+				),
+			},
+		},
+	})
+}
 func TestAccIBMISImageDataSourceRemoteAccountId(t *testing.T) {
 	resName := "data.ibm_is_image.example"
 
@@ -319,6 +335,12 @@ func testAccCheckIBMISCatalogImageDataSourceRemoteAccountId() string {
 	}`)
 }
 
+func testAccCheckIBMISImageDataSourceWithMinimumProvisionedSize() string {
+	return fmt.Sprintf(`
+		data "ibm_is_image" "example" {
+  		name = "ibm-ubuntu-18-04-1-minimal-amd64-1"
+	}`)
+}
 func testAccCheckIBMISImageDataSourceWithRemoteAccountId() string {
 	return fmt.Sprintf(`
 		data "ibm_is_image" "example" {

--- a/ibm/service/vpc/data_source_ibm_is_images.go
+++ b/ibm/service/vpc/data_source_ibm_is_images.go
@@ -118,6 +118,11 @@ func DataSourceIBMISImages() *schema.Resource {
 							Computed:    true,
 							Description: "Whether the image is publicly visible or private to the account",
 						},
+						"minimum_provisioned_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The minimum size (in gigabytes) of a volume onto which this image may be provisioned.",
+						},
 						"operating_system": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -541,6 +546,9 @@ func imageList(context context.Context, d *schema.ResourceData, meta interface{}
 		}
 		if image.SourceVolume != nil {
 			l["source_volume"] = *image.SourceVolume.ID
+		}
+		if image.MinimumProvisionedSize != nil {
+			l["minimum_provisioned_size"] = flex.IntValue(image.MinimumProvisionedSize)
 		}
 		if image.CatalogOffering != nil {
 			catalogOfferingList := []map[string]interface{}{}

--- a/ibm/service/vpc/data_source_ibm_is_images_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_images_test.go
@@ -31,7 +31,30 @@ func TestAccIBMISImagesDataSource_basic(t *testing.T) {
 		},
 	})
 }
-func TestAccIBMISImagesDataSource_Zones(t *testing.T) {
+
+func TestAccIBMISImagesDataSource_MinimumProvisionedSize(t *testing.T) {
+	resName := "data.ibm_is_images.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISImagesDataSourceNameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resName, "images.0.name"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.status"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.architecture"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.zones.#"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.zones.0.name"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.zones.0.href"),
+					resource.TestCheckResourceAttrSet(resName, "images.0.minimum_provisioned_size"),
+				),
+			},
+		},
+	})
+}
+func TestAccIBMISImagesDataSource_(t *testing.T) {
 	resName := "data.ibm_is_images.test1"
 
 	resource.Test(t, resource.TestCase{

--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -159,7 +159,11 @@ func ResourceIBMISImage() *schema.Resource {
 				Computed:     true,
 				Description:  "Image Operating system",
 			},
-
+			"minimum_provisioned_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The minimum size (in gigabytes) of a volume onto which this image may be provisioned.",
+			},
 			isImageEncryption: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -891,6 +895,9 @@ func imgGet(context context.Context, d *schema.ResourceData, meta interface{}, i
 	if err = d.Set("created_at", flex.DateTimeToString(image.CreatedAt)); err != nil {
 		err = fmt.Errorf("Error setting created_at: %s", err)
 		return flex.DiscriminatedTerraformErrorf(err, err.Error(), "ibm_is_image", "read", "set-created_at").GetDiag()
+	}
+	if err = d.Set("minimum_provisioned_size", flex.IntValue(image.MinimumProvisionedSize)); err != nil {
+		return flex.DiscriminatedTerraformErrorf(err, fmt.Sprintf("Error setting minimum_provisioned_size: %s", err), "ibm_is_image", "read", "set-minimum_provisioned_size").GetDiag()
 	}
 	if !core.IsNil(image.DeprecationAt) {
 		if err = d.Set("deprecation_at", flex.DateTimeToString(image.DeprecationAt)); err != nil {

--- a/ibm/service/vpc/resource_ibm_is_image_test.go
+++ b/ibm/service/vpc/resource_ibm_is_image_test.go
@@ -41,6 +41,29 @@ func TestAccIBMISImage_basic(t *testing.T) {
 	})
 }
 
+func TestAccIBMISImage_MinimumProvisionedSize(t *testing.T) {
+	var image string
+	name := fmt.Sprintf("tfimg-name-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckImage(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISImageConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISImageExists("ibm_is_image.isExampleImage", image),
+					resource.TestCheckResourceAttr(
+						"ibm_is_image.isExampleImage", "name", name),
+					resource.TestCheckResourceAttrSet("ibm_is_image.isExampleImage", "user_data_format"),
+					resource.TestCheckResourceAttrSet("ibm_is_image.isExampleImage", "minimum_provisioned_size"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISImage_accessTags(t *testing.T) {
 	var image string
 	name := fmt.Sprintf("tfimg-access-tags-%d", acctest.RandIntRange(10, 100))

--- a/website/docs/d/is_image.html.markdown
+++ b/website/docs/d/is_image.html.markdown
@@ -68,6 +68,7 @@ In addition to all argument reference list, you can access the following attribu
 - `encryption` - (String) The type of encryption used of the image.
 - `encryption_key`-  (String) The CRN of the Key Protect or Hyper Protect Crypto Service root key for this resource.
 - `id` - (String) The unique identifier of the image.
+- `minimum_provisioned_size` - (Integer) The minimum size (in gigabytes) of a volume onto which this image may be provisioned. This property may be absent if the image has a status of pending or failed..
 - `obsolescence_at` - (String) The obsolescence date and time (UTC) for this image. If absent, no obsolescence date and time has been set.
 - `os` - (String) The name of the operating system.
 - `operating_system` - (List) The operating system details. 

--- a/website/docs/d/is_image.html.markdown
+++ b/website/docs/d/is_image.html.markdown
@@ -68,7 +68,7 @@ In addition to all argument reference list, you can access the following attribu
 - `encryption` - (String) The type of encryption used of the image.
 - `encryption_key`-  (String) The CRN of the Key Protect or Hyper Protect Crypto Service root key for this resource.
 - `id` - (String) The unique identifier of the image.
-- `minimum_provisioned_size` - (Integer) The minimum size (in gigabytes) of a volume onto which this image may be provisioned. This property may be absent if the image has a status of pending or failed..
+- `minimum_provisioned_size` - (Integer) The minimum size (in gigabytes) of a volume onto which this image may be provisioned. This property may be absent if the image has a status of pending or failed.
 - `obsolescence_at` - (String) The obsolescence date and time (UTC) for this image. If absent, no obsolescence date and time has been set.
 - `os` - (String) The name of the operating system.
 - `operating_system` - (List) The operating system details. 

--- a/website/docs/d/is_images.html.markdown
+++ b/website/docs/d/is_images.html.markdown
@@ -102,6 +102,7 @@ You can access the following attribute references after your data source is crea
   - `encryption` - (String) The type of encryption used on the image.
   - `encryption_key` - (String) The CRN of the Key Protect Root Key or Hyper Protect Crypto Service Root Key for this resource.
   - `id` - (String) The unique identifier for this image.
+  - `minimum_provisioned_size` - (Integer) The minimum size (in gigabytes) of a volume onto which this image may be provisioned. This property may be absent if the image has a status of pending or failed.
   - `name` - (String) The name for this image.
   - `os` - (String) The name of the Operating System.
   - `operating_system` - (List) The operating system details.

--- a/website/docs/r/is_image.html.markdown
+++ b/website/docs/r/is_image.html.markdown
@@ -194,6 +194,7 @@ In addition to all argument reference list, you can access the following attribu
 - `file` - (String) The file.
 - `format` - (String) The format of an image.
 - `id` - (String) The unique identifier of the image.
+- `minimum_provisioned_size` - (Integer) The minimum size (in gigabytes) of a volume onto which this image may be provisioned. This property may be absent if the image has a status of pending or failed.
 - `resourceGroup` - (String) The resource group to which the image belongs to.
 - `status`- (String) The status of an image such as `corrupt`, or `available`.
 - `user_data_format` - (String) The user data format for this image.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6970

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISImageDataSourceMinimumProvisionedSize
--- PASS: TestAccIBMISImageDataSourceMinimumProvisionedSize (17.48s)

=== RUN   TestAccIBMISImagesDataSource_MinimumProvisionedSize
--- PASS: TestAccIBMISImagesDataSource_MinimumProvisionedSize (15.94s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     17.759s

=== RUN   TestAccIBMISImage_MinimumProvisionedSize
--- PASS: TestAccIBMISImage_MinimumProvisionedSize (257.85s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     259.680s
```
