### PR TITLE
added cluster name support in container cluster

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_cluster.go
@@ -37,6 +37,10 @@ func DataSourceIBMContainerCluster() *schema.Resource {
 					"ibm_container_cluster",
 					"name"),
 			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"wait_till": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -478,6 +482,7 @@ func dataSourceIBMContainerClusterRead(d *schema.ResourceData, meta interface{})
 	filteredAlbs := flex.FlattenAlbs(albs, filterType)
 
 	d.Set("state", clusterFields.State)
+	d.Set("cluster_name", clusterFields.Name)
 	d.Set("worker_count", clusterFields.WorkerCount)
 	d.Set("workers", workers)
 	d.Set("region", clusterFields.Region)

--- a/website/docs/d/container_vpc_cluster.html.markdown
+++ b/website/docs/d/container_vpc_cluster.html.markdown
@@ -45,6 +45,7 @@ In addition to all argument reference list, you can access the following attribu
 	- `name` - (String) The name of the Ingress ALB.
 	- `state` - (String) The state of the ALB. Supported values are `enabled` or `disabled`. 
 	- `resize` -  (Bool)  Indicate whether resizing should be done. 
+- `cluster_name` - (String) The name of the cluster.
 - `crn` - (String) The CRN of the cluster.
 - `health` - (String) The health of the cluster master.
 - `id` - (String) The unique identifier of the cluster.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
