### PR TITLE
added cluster name support in vpc container cluster

### DIFF
--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -59,6 +59,11 @@ func DataSourceIBMContainerVPCCluster() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 			},
+			"cluster_name": {
+				Description: "Number of cluster",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"workers": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
+++ b/ibm/service/kubernetes/data_source_ibm_container_vpc_cluster.go
@@ -507,6 +507,7 @@ func dataSourceIBMContainerClusterVPCRead(d *schema.ResourceData, meta interface
 		log.Printf("Error in GetApiKeyInfo, %s", err)
 		//return err
 	}
+	d.Set("cluster_name", cls.Name)
 	if &apikeyConfig != nil {
 		if &apikeyConfig.Name != nil {
 			d.Set("api_key_id", apikeyConfig.ID)

--- a/website/docs/d/container_cluster.html.markdown
+++ b/website/docs/d/container_cluster.html.markdown
@@ -64,6 +64,7 @@ In addition to all argument reference list, you can access the following attribu
   - `resize` -  (Bool)  Indicate whether resizing should be done. 
   - `state` - (String) The state of the ALB. Supported values are `enabled` or `disabled`. 
 - `bounded_services` - List of strings - A list of IBM Cloud services that are bounded to the cluster.
+- `cluster_name` - (String) The name of the cluster.
 - `crn` - (String) The CRN of the cluster.
 - `id` - (String) The unique identifier of the cluster.
 - `image_security_enforcement` - (Bool) Indicates if image security enforcement policies are enabled in a cluster.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
