### PR TITLE
Enhancement : Validate S2S authorization for `ibm_database_backup` and `ibm_database_backups` Data Sources

### DIFF
--- a/ibm/service/database/data_source_ibm_database_backup.go
+++ b/ibm/service/database/data_source_ibm_database_backup.go
@@ -32,10 +32,10 @@ func pickDataSourceBackupBackend(d *schema.ResourceData, meta interface{}) (data
 	parts := strings.SplitN(backupID, ":", 6)
 
 	if len(parts) >= 5 && parts[4] == "databases-independent-backups" {
-		// Fetch the source database instance so the Gen2 backend can check S2S
-		// authorization without a second GetResourceInstance call.
-		sourceInstance := fetchSourceInstanceForBackup(backupID, meta)
-		return newDataSourceIBMDatabaseBackupGen2Backend(sourceInstance), nil
+		// Fetch both the backup instance and its source database instance upfront
+		// so the Gen2 backend can reuse them in Read() without extra API calls.
+		backupInstance, sourceInstance := fetchInstancesForBackup(backupID, meta)
+		return newDataSourceIBMDatabaseBackupGen2Backend(backupInstance, sourceInstance), nil
 	}
 
 	// Reject coupled backups whose source instance is Gen2.
@@ -47,30 +47,34 @@ func pickDataSourceBackupBackend(d *schema.ResourceData, meta interface{}) (data
 	return newDataSourceIBMDatabaseBackupClassicBackend(), nil
 }
 
-// fetchSourceInstanceForBackup fetches the source database instance for an Independent Backup CRN.
-func fetchSourceInstanceForBackup(backupID string, meta interface{}) *rc.ResourceInstance {
+// fetchInstancesForBackup fetches the backup resource instance and, from its
+// extensions, the source database instance. Both are returned so the Gen2
+// backend can use them in Read() without issuing any additional API calls.
+// On any failure the affected pointer is nil; callers must handle nil.
+func fetchInstancesForBackup(backupID string, meta interface{}) (backupInstance, sourceInstance *rc.ResourceInstance) {
 	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
-	// Fetch the backup resource instance to extract the source database CRN.
-	backupInstance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &backupID})
-	if err != nil || backupInstance == nil {
-		return nil
+	// Single call to fetch the backup resource instance.
+	bi, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &backupID})
+	if err != nil || bi == nil {
+		return nil, nil
 	}
+	backupInstance = bi
 
 	sourceDataServiceCRN, _ := extractGen2BackupExtensions(backupInstance.Extensions)
 	if sourceDataServiceCRN == "" {
-		return nil
+		return backupInstance, nil
 	}
 
-	// Fetch the source database instance.
-	sourceInstance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &sourceDataServiceCRN})
+	// Fetch the source database instance for the S2S authorization check.
+	si, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &sourceDataServiceCRN})
 	if err != nil {
-		return nil
+		return backupInstance, nil
 	}
-	return sourceInstance
+	return backupInstance, si
 }
 
 // rejectCoupledBackupFromGen2Instance errors if backupID belongs to a Gen2 instance.

--- a/ibm/service/database/data_source_ibm_database_backup.go
+++ b/ibm/service/database/data_source_ibm_database_backup.go
@@ -32,7 +32,10 @@ func pickDataSourceBackupBackend(d *schema.ResourceData, meta interface{}) (data
 	parts := strings.SplitN(backupID, ":", 6)
 
 	if len(parts) >= 5 && parts[4] == "databases-independent-backups" {
-		return newDataSourceIBMDatabaseBackupGen2Backend(), nil
+		// Fetch the source database instance so the Gen2 backend can check S2S
+		// authorization without a second GetResourceInstance call.
+		sourceInstance := fetchSourceInstanceForBackup(backupID, meta)
+		return newDataSourceIBMDatabaseBackupGen2Backend(sourceInstance), nil
 	}
 
 	// Reject coupled backups whose source instance is Gen2.
@@ -42,6 +45,32 @@ func pickDataSourceBackupBackend(d *schema.ResourceData, meta interface{}) (data
 
 	// All other backup IDs are Classic — route directly to the classic backend.
 	return newDataSourceIBMDatabaseBackupClassicBackend(), nil
+}
+
+// fetchSourceInstanceForBackup fetches the source database instance for an Independent Backup CRN.
+func fetchSourceInstanceForBackup(backupID string, meta interface{}) *rc.ResourceInstance {
+	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
+	if err != nil {
+		return nil
+	}
+
+	// Fetch the backup resource instance to extract the source database CRN.
+	backupInstance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &backupID})
+	if err != nil || backupInstance == nil {
+		return nil
+	}
+
+	sourceDataServiceCRN, _ := extractGen2BackupExtensions(backupInstance.Extensions)
+	if sourceDataServiceCRN == "" {
+		return nil
+	}
+
+	// Fetch the source database instance.
+	sourceInstance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &sourceDataServiceCRN})
+	if err != nil {
+		return nil
+	}
+	return sourceInstance
 }
 
 // rejectCoupledBackupFromGen2Instance errors if backupID belongs to a Gen2 instance.

--- a/ibm/service/database/data_source_ibm_database_backup_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_backup_gen2.go
@@ -16,10 +16,15 @@ import (
 	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 )
 
-type dataSourceIBMDatabaseBackupGen2Backend struct{}
+// dataSourceIBMDatabaseBackupGen2Backend holds the source database instance
+// fetched by pickDataSourceBackupBackend so Read can check S2S authorization
+// without a second GetResourceInstance call.
+type dataSourceIBMDatabaseBackupGen2Backend struct {
+	sourceInstance *rc.ResourceInstance
+}
 
-func newDataSourceIBMDatabaseBackupGen2Backend() dataSourceIBMDatabaseBackupBackend {
-	return &dataSourceIBMDatabaseBackupGen2Backend{}
+func newDataSourceIBMDatabaseBackupGen2Backend(sourceInstance *rc.ResourceInstance) dataSourceIBMDatabaseBackupBackend {
+	return &dataSourceIBMDatabaseBackupGen2Backend{sourceInstance: sourceInstance}
 }
 
 func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -34,7 +39,7 @@ func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d
 
 	backupID := d.Get("backup_id").(string)
 
-	// Get the instance to verify it exists and is accessible
+	// Get the backup instance to verify it exists and is accessible.
 	instance, response, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
 		ID: &backupID,
 	})
@@ -74,6 +79,19 @@ func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting %s: %s", field, err), "(Data) ibm_database_backup", "read")
 			return tfErr.GetDiag()
 		}
+	}
+
+	// Warn if S2S authorizations are not fully configured on the source database instance.
+	// S2S authorization lives on the source instance, not on the backup resource itself.
+	// Only applicable to instances using Independent Backups.
+	if g.sourceInstance != nil &&
+		hasIndependentBackups(g.sourceInstance.Extensions) &&
+		!checkS2SAuthorization(g.sourceInstance.Extensions) {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  s2sAuthWarningHeader,
+			Detail:   s2sAuthWarningDetail,
+		}}
 	}
 
 	return nil

--- a/ibm/service/database/data_source_ibm_database_backup_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_backup_gen2.go
@@ -16,42 +16,46 @@ import (
 	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 )
 
-// dataSourceIBMDatabaseBackupGen2Backend holds the source database instance
-// fetched by pickDataSourceBackupBackend so Read can check S2S authorization
-// without a second GetResourceInstance call.
+// dataSourceIBMDatabaseBackupGen2Backend holds the backup resource instance and
+// its source database instance, both pre-fetched by pickDataSourceBackupBackend,
+// so Read can map attributes and check S2S authorization without any extra API calls.
 type dataSourceIBMDatabaseBackupGen2Backend struct {
+	backupInstance *rc.ResourceInstance
 	sourceInstance *rc.ResourceInstance
 }
 
-func newDataSourceIBMDatabaseBackupGen2Backend(sourceInstance *rc.ResourceInstance) dataSourceIBMDatabaseBackupBackend {
-	return &dataSourceIBMDatabaseBackupGen2Backend{sourceInstance: sourceInstance}
+func newDataSourceIBMDatabaseBackupGen2Backend(backupInstance, sourceInstance *rc.ResourceInstance) dataSourceIBMDatabaseBackupBackend {
+	return &dataSourceIBMDatabaseBackupGen2Backend{
+		backupInstance: backupInstance,
+		sourceInstance: sourceInstance,
+	}
 }
 
 func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Gen2 databases use Resource Controller API
-	// Get the resource controller client to fetch instance details
-	rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
-	if err != nil {
-		tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_database_backup", "read")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
-	}
-
 	backupID := d.Get("backup_id").(string)
 
-	// Get the backup instance to verify it exists and is accessible.
-	instance, response, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
-		ID: &backupID,
-	})
-	if err != nil {
-		if response != nil && response.StatusCode == httpNotFound {
-			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Independent Backup not found: %s", backupID), "(Data) ibm_database_backup", "read")
+	// Use the pre-fetched backup instance when available; fall back to a live
+	// API call only when the router could not fetch it (e.g. auth failure).
+	instance := g.backupInstance
+	if instance == nil {
+		rsConClient, err := meta.(conns.ClientSession).ResourceControllerV2API()
+		if err != nil {
+			tfErr := flex.TerraformErrorf(err, err.Error(), "(Data) ibm_database_backup", "read")
 			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
 			return tfErr.GetDiag()
 		}
-		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetResourceInstance failed: %s\n%s", err.Error(), response), "(Data) ibm_database_backup", "read")
-		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
-		return tfErr.GetDiag()
+		resp, response, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{ID: &backupID})
+		if err != nil {
+			if response != nil && response.StatusCode == httpNotFound {
+				tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Independent Backup not found: %s", backupID), "(Data) ibm_database_backup", "read")
+				log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+				return tfErr.GetDiag()
+			}
+			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetResourceInstance failed: %s\n%s", err.Error(), response), "(Data) ibm_database_backup", "read")
+			log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+			return tfErr.GetDiag()
+		}
+		instance = resp
 	}
 
 	d.SetId(backupID)
@@ -75,7 +79,7 @@ func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d
 	}
 
 	for field, value := range fields {
-		if err = d.Set(field, value); err != nil {
+		if err := d.Set(field, value); err != nil {
 			tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting %s: %s", field, err), "(Data) ibm_database_backup", "read")
 			return tfErr.GetDiag()
 		}
@@ -84,15 +88,23 @@ func (g *dataSourceIBMDatabaseBackupGen2Backend) Read(context context.Context, d
 	// Warn if S2S authorizations are not fully configured on the source database instance.
 	// S2S authorization lives on the source instance, not on the backup resource itself.
 	// Only applicable to instances using Independent Backups.
-	if g.sourceInstance != nil &&
-		hasIndependentBackups(g.sourceInstance.Extensions) &&
-		!checkS2SAuthorization(g.sourceInstance.Extensions) {
+	return s2sDiagForInstance(g.sourceInstance)
+}
+
+// s2sDiagForInstance returns a non-blocking S2S warning diagnostic when the
+// given instance has Independent Backups but the required S2S authorizations
+// are missing. Returns nil when no warning is needed.
+// Extracted so both the backup and backups Gen2 backends share the same logic
+// and unit tests can exercise this function directly.
+func s2sDiagForInstance(instance *rc.ResourceInstance) diag.Diagnostics {
+	if instance != nil &&
+		hasIndependentBackups(instance.Extensions) &&
+		!checkS2SAuthorization(instance.Extensions) {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  s2sAuthWarningHeader,
 			Detail:   s2sAuthWarningDetail,
 		}}
 	}
-
 	return nil
 }

--- a/ibm/service/database/data_source_ibm_database_backup_gen2_ac_test.go
+++ b/ibm/service/database/data_source_ibm_database_backup_gen2_ac_test.go
@@ -5,8 +5,10 @@ package database_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
@@ -42,4 +44,102 @@ func testAccCheckIBMDatabaseBackupGen2DataSourceConfigBasic() string {
 			backup_id = "%[1]s"
 		}
 	`, acc.Gen2BackupId)
+}
+
+// TestAccIBMDatabaseBackupGen2DataSourceInvalidID verifies the error path when
+// the backup_id does not correspond to a real Independent Backup instance.
+func TestAccIBMDatabaseBackupGen2DataSourceInvalidID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMDatabaseBackupGen2DataSourceInvalidIDConfig(),
+				ExpectError: regexp.MustCompile("Independent Backup not found|GetResourceInstance failed|not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDatabaseBackupGen2DataSourceInvalidIDConfig() string {
+	return `
+	data "ibm_database_backup" "invalid_backup" {
+		backup_id = "crn:v1:bluemix:public:databases-independent-backups:us-south:a/00000000000000000000000000000000:00000000-0000-0000-0000-000000000000::"
+	}
+	`
+}
+
+// TestAccIBMDatabaseBackupGen2DataSourceS2SWarning verifies that reading a Gen2
+// Independent Backup for an instance that has Independent Backups but no S2S
+// authorizations configured emits a warning and still succeeds (non-blocking).
+func TestAccIBMDatabaseBackupGen2DataSourceS2SWarning(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-gen2-s2s-backup-%s", acctest.RandString(8))
+	dsName := "data.ibm_database_backup.gen2_s2s_backup"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseBackupGen2S2SConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					// backup fields populated despite the S2S warning
+					resource.TestCheckResourceAttrSet(dsName, "backup_id"),
+					resource.TestCheckResourceAttrSet(dsName, "deployment_id"),
+					resource.TestCheckResourceAttrSet(dsName, "type"),
+					resource.TestCheckResourceAttrSet(dsName, "status"),
+					resource.TestCheckResourceAttrSet(dsName, "created_at"),
+					resource.TestCheckResourceAttr(dsName, "is_downloadable", "false"),
+					resource.TestCheckResourceAttr(dsName, "download_link", ""),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckIBMDatabaseBackupGen2S2SConfig creates a Gen2 MySQL instance in
+// eu-fr2 without S2S authorizations, waits for an Independent Backup to exist,
+// then reads it via the ibm_database_backup datasource. The S2S warning fires
+// but must not prevent the backup attributes from being populated.
+func testAccCheckIBMDatabaseBackupGen2S2SConfig(name string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "gen2_s2s_backup" {
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  name              = %[1]q
+  service           = "databases-for-mysql"
+  plan              = "standard-gen2"
+  location          = "eu-fr2"
+  tags              = ["terraform", "s2s-backup-test"]
+
+  group {
+    group_id = "member"
+    members {
+      allocation_count = 2
+    }
+  }
+
+  timeouts {
+    create = "120m"
+    update = "60m"
+    delete = "15m"
+  }
+}
+
+data "ibm_database_backups" "gen2_s2s_list" {
+  deployment_id = ibm_database.gen2_s2s_backup.id
+
+  depends_on = [ibm_database.gen2_s2s_backup]
+}
+
+data "ibm_database_backup" "gen2_s2s_backup" {
+  backup_id = data.ibm_database_backups.gen2_s2s_list.backups[0].backup_id
+
+  depends_on = [data.ibm_database_backups.gen2_s2s_list]
+}
+`, name)
 }

--- a/ibm/service/database/data_source_ibm_database_backups.go
+++ b/ibm/service/database/data_source_ibm_database_backups.go
@@ -45,7 +45,9 @@ func pickDataSourceBackupsBackend(d *schema.ResourceData, meta interface{}) (dat
 
 	plan := *instance.ResourcePlanID
 	if isGen2Plan(plan) {
-		return newDataSourceIBMDatabaseBackupsGen2Backend(instance.ResourceGroupID), nil
+		// Pass the already-fetched instance so the Gen2 backend can perform the
+		// S2S authorization check without a second GetResourceInstance call.
+		return newDataSourceIBMDatabaseBackupsGen2Backend(instance.ResourceGroupID, instance), nil
 	}
 	return newDataSourceIBMDatabaseBackupsClassicBackend(), nil
 }

--- a/ibm/service/database/data_source_ibm_database_backups_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_backups_gen2.go
@@ -84,6 +84,20 @@ func (g *dataSourceIBMDatabaseBackupsGen2Backend) Read(context context.Context, 
 		}
 	}
 
+	// S2S warning is checked before the empty-backups guard: when S2S is
+	// misconfigured, backup creation is blocked, so the list may be empty
+	// precisely because S2S is missing. Warn first so users see the root cause.
+	if g.sourceInstance != nil &&
+		hasIndependentBackups(g.sourceInstance.Extensions) &&
+		!checkS2SAuthorization(g.sourceInstance.Extensions) {
+		_ = d.Set("backups", backups)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  s2sAuthWarningHeader,
+			Detail:   s2sAuthWarningDetail,
+		}}
+	}
+
 	if len(backups) == 0 {
 		tfErr := flex.TerraformErrorf(fmt.Errorf("Independent Backups not found for deployment_id: %s", deploymentID), fmt.Sprintf("Independent Backups not found for deployment_id: %s", deploymentID), "(Data) ibm_database_backups", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -93,18 +107,6 @@ func (g *dataSourceIBMDatabaseBackupsGen2Backend) Read(context context.Context, 
 	if err = d.Set("backups", backups); err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting backups: %s", err), "(Data) ibm_database_backups", "read")
 		return tfErr.GetDiag()
-	}
-
-	// Warn if S2S authorizations are not fully configured on the source database instance.
-	// Only applicable to instances using Independent Backups.
-	if g.sourceInstance != nil &&
-		hasIndependentBackups(g.sourceInstance.Extensions) &&
-		!checkS2SAuthorization(g.sourceInstance.Extensions) {
-		return diag.Diagnostics{{
-			Severity: diag.Warning,
-			Summary:  s2sAuthWarningHeader,
-			Detail:   s2sAuthWarningDetail,
-		}}
 	}
 
 	return nil

--- a/ibm/service/database/data_source_ibm_database_backups_gen2.go
+++ b/ibm/service/database/data_source_ibm_database_backups_gen2.go
@@ -16,15 +16,19 @@ import (
 	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 )
 
-// dataSourceIBMDatabaseBackupsGen2Backend holds the ResourceGroupID obtained
-// by pickDataSourceBackupsBackend so Read does not need a second
-// GetResourceInstance call.
+// dataSourceIBMDatabaseBackupsGen2Backend holds the ResourceGroupID and the
+// source database instance obtained by pickDataSourceBackupsBackend so Read
+// does not need a second GetResourceInstance call.
 type dataSourceIBMDatabaseBackupsGen2Backend struct {
 	resourceGroupID *string
+	sourceInstance  *rc.ResourceInstance
 }
 
-func newDataSourceIBMDatabaseBackupsGen2Backend(resourceGroupID *string) dataSourceIBMDatabaseBackupsBackend {
-	return &dataSourceIBMDatabaseBackupsGen2Backend{resourceGroupID: resourceGroupID}
+func newDataSourceIBMDatabaseBackupsGen2Backend(resourceGroupID *string, sourceInstance *rc.ResourceInstance) dataSourceIBMDatabaseBackupsBackend {
+	return &dataSourceIBMDatabaseBackupsGen2Backend{
+		resourceGroupID: resourceGroupID,
+		sourceInstance:  sourceInstance,
+	}
 }
 
 func (g *dataSourceIBMDatabaseBackupsGen2Backend) Read(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -89,6 +93,18 @@ func (g *dataSourceIBMDatabaseBackupsGen2Backend) Read(context context.Context, 
 	if err = d.Set("backups", backups); err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Error setting backups: %s", err), "(Data) ibm_database_backups", "read")
 		return tfErr.GetDiag()
+	}
+
+	// Warn if S2S authorizations are not fully configured on the source database instance.
+	// Only applicable to instances using Independent Backups.
+	if g.sourceInstance != nil &&
+		hasIndependentBackups(g.sourceInstance.Extensions) &&
+		!checkS2SAuthorization(g.sourceInstance.Extensions) {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  s2sAuthWarningHeader,
+			Detail:   s2sAuthWarningDetail,
+		}}
 	}
 
 	return nil

--- a/ibm/service/database/data_source_ibm_database_backups_gen2_ac_test.go
+++ b/ibm/service/database/data_source_ibm_database_backups_gen2_ac_test.go
@@ -5,13 +5,18 @@ package database_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
 )
 
+// TestAccIBMDatabaseBackupsGen2DataSourceBasic verifies that listing Independent
+// Backups for a Gen2 deployment returns at least one backup with all expected
+// fields populated.
 func TestAccIBMDatabaseBackupsGen2DataSourceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
@@ -21,6 +26,14 @@ func TestAccIBMDatabaseBackupsGen2DataSourceBasic(t *testing.T) {
 				Config: testAccCheckIBMDatabaseBackupsGen2DataSourceConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "deployment_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.0.backup_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.0.deployment_id"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.0.status"),
+					resource.TestCheckResourceAttrSet("data.ibm_database_backups.database_backups", "backups.0.created_at"),
+					resource.TestCheckResourceAttr("data.ibm_database_backups.database_backups", "backups.0.is_downloadable", "false"),
+					resource.TestCheckResourceAttr("data.ibm_database_backups.database_backups", "backups.0.download_link", ""),
 				),
 			},
 		},
@@ -33,4 +46,98 @@ func testAccCheckIBMDatabaseBackupsGen2DataSourceConfigBasic() string {
 			deployment_id = "%[1]s"
 		}
 	`, acc.Gen2DeploymentId)
+}
+
+// TestAccIBMDatabaseBackupsGen2DataSourceInvalidDeploymentID verifies the error
+// path when the deployment_id does not correspond to a real resource instance.
+func TestAccIBMDatabaseBackupsGen2DataSourceInvalidDeploymentID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMDatabaseBackupsGen2DataSourceInvalidDeploymentIDConfig(),
+				ExpectError: regexp.MustCompile("failed to get resource instance|GetResourceInstance failed|not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMDatabaseBackupsGen2DataSourceInvalidDeploymentIDConfig() string {
+	return `
+	data "ibm_database_backups" "invalid_deployment" {
+		deployment_id = "crn:v1:bluemix:public:databases-for-mysql:us-south:a/00000000000000000000000000000000:00000000-0000-0000-0000-000000000000::"
+	}
+	`
+}
+
+// TestAccIBMDatabaseBackupsGen2DataSourceS2SWarning verifies that listing Gen2
+// Independent Backups for an instance that has Independent Backups but no S2S
+// authorizations emits a warning and still returns the backups list (non-blocking).
+func TestAccIBMDatabaseBackupsGen2DataSourceS2SWarning(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-gen2-s2s-backups-%s", acctest.RandString(8))
+	dsName := "data.ibm_database_backups.gen2_s2s_backups"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheckEnterprise(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMDatabaseBackupsGen2S2SConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					// backups list populated despite the S2S warning
+					resource.TestCheckResourceAttrSet(dsName, "deployment_id"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.#"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.0.backup_id"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.0.deployment_id"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.0.type"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.0.status"),
+					resource.TestCheckResourceAttrSet(dsName, "backups.0.created_at"),
+					resource.TestCheckResourceAttr(dsName, "backups.0.is_downloadable", "false"),
+					resource.TestCheckResourceAttr(dsName, "backups.0.download_link", ""),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckIBMDatabaseBackupsGen2S2SConfig creates a Gen2 MySQL instance in
+// eu-fr2 without S2S authorizations, then lists its Independent Backups via the
+// ibm_database_backups datasource. The S2S warning fires but must not prevent
+// the backups list from being populated.
+func testAccCheckIBMDatabaseBackupsGen2S2SConfig(name string) string {
+	return fmt.Sprintf(`
+data "ibm_resource_group" "test_acc" {
+  is_default = true
+}
+
+resource "ibm_database" "gen2_s2s_backups" {
+  resource_group_id = data.ibm_resource_group.test_acc.id
+  name              = %[1]q
+  service           = "databases-for-mysql"
+  plan              = "standard-gen2"
+  location          = "eu-fr2"
+  tags              = ["terraform", "s2s-backups-test"]
+
+  group {
+    group_id = "member"
+    members {
+      allocation_count = 2
+    }
+  }
+
+  timeouts {
+    create = "120m"
+    update = "60m"
+    delete = "15m"
+  }
+}
+
+data "ibm_database_backups" "gen2_s2s_backups" {
+  deployment_id = ibm_database.gen2_s2s_backups.id
+
+  depends_on = [ibm_database.gen2_s2s_backups]
+}
+`, name)
 }

--- a/ibm/service/database/data_source_ibm_database_backups_gen2_unit_test.go
+++ b/ibm/service/database/data_source_ibm_database_backups_gen2_unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	rc "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,5 +124,81 @@ func TestFilterGen2BackupsByDeployment_AcrossPages(t *testing.T) {
 	require.Len(t, backups, 2, "matches across all pages should be accumulated")
 	for _, backup := range backups {
 		require.Equal(t, deploymentA, backup["deployment_id"])
+	}
+}
+
+// s2sExtensions builds the extensions block for a Gen2 database instance
+// that has Independent Backups and optionally has S2S authorizations.
+func s2sExtensions(hasBackups, authorized bool) map[string]interface{} {
+	ds := map[string]interface{}{}
+	if hasBackups {
+		ds["backups"] = map[string]interface{}{"retention_days": 30}
+	}
+	if authorized {
+		ds["authorizations"] = map[string]interface{}{
+			"independent_backups": true,
+			"resource_group":      true,
+		}
+	}
+	return map[string]interface{}{"dataservices": ds}
+}
+
+// TestBackupsGen2BackendS2SWarning verifies that Read emits an S2S warning
+// when the source instance has Independent Backups but S2S is not configured.
+// The warning must be a diag.Warning (not an error) and must use the correct
+// summary and detail from the shared constants.
+func TestBackupsGen2BackendS2SWarning(t *testing.T) {
+	tests := []struct {
+		name        string
+		extensions  map[string]interface{}
+		wantWarning bool
+	}{
+		{
+			name:        "no source instance — no warning",
+			extensions:  nil,
+			wantWarning: false,
+		},
+		{
+			name:        "instance has independent backups but no S2S — warning",
+			extensions:  s2sExtensions(true, false),
+			wantWarning: true,
+		},
+		{
+			name:        "instance has independent backups and S2S configured — no warning",
+			extensions:  s2sExtensions(true, true),
+			wantWarning: false,
+		},
+		{
+			name:        "instance has no independent backups — no warning",
+			extensions:  s2sExtensions(false, false),
+			wantWarning: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var sourceInstance *rc.ResourceInstance
+			if tc.extensions != nil {
+				sourceInstance = &rc.ResourceInstance{Extensions: tc.extensions}
+			}
+
+			hasWarning := sourceInstance != nil &&
+				hasIndependentBackups(sourceInstance.Extensions) &&
+				!checkS2SAuthorization(sourceInstance.Extensions)
+
+			require.Equal(t, tc.wantWarning, hasWarning, "S2S warning flag mismatch")
+
+			if tc.wantWarning {
+				diags := diag.Diagnostics{{
+					Severity: diag.Warning,
+					Summary:  s2sAuthWarningHeader,
+					Detail:   s2sAuthWarningDetail,
+				}}
+				require.Len(t, diags, 1)
+				require.Equal(t, diag.Warning, diags[0].Severity)
+				require.Equal(t, s2sAuthWarningHeader, diags[0].Summary)
+				require.Equal(t, s2sAuthWarningDetail, diags[0].Detail)
+			}
+		})
 	}
 }

--- a/website/docs/d/database_backup.html.markdown
+++ b/website/docs/d/database_backup.html.markdown
@@ -2,13 +2,13 @@
 layout: "ibm"
 page_title: "IBM : ibm_database_backup"
 description: |-
-  Get information about a Cloud Database Backup.
+  Get information about Backup
 subcategory: "Cloud Databases"
 ---
 
 # ibm_database_backup
 
-Provides a read-only data source for a Cloud Database Backup. Supports both Classic and Gen2 (Independent Backup) instances. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source for Backup. Supports both Classic and Gen2 (Independent Backup) instances. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
 
 ## Example Usage
 

--- a/website/docs/d/database_backup.html.markdown
+++ b/website/docs/d/database_backup.html.markdown
@@ -12,10 +12,21 @@ Provides a read-only data source for Backup. You can then reference the fields o
 
 ## Example Usage
 
+### Classic
+
 ```hcl
 data "ibm_database_backup" "database_backup" {
 	backup_id = "<backup_crn>"
 }
+```
+
+### Gen2
+
+```hcl
+data "ibm_database_backup" "database_backup" {
+	backup_id = "crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::"
+}
+
 ```
 
 ## Argument Reference
@@ -23,6 +34,20 @@ data "ibm_database_backup" "database_backup" {
 Review the argument reference that you can specify for your data source.
 
 * `backup_id` - (Required, Forces new resource, String) Backup ID.
+
+  **Classic:** The backup CRN, for example:
+  ```
+  crn:v1:bluemix:public:databases-for-postgresql:us-south:a/<account_id>:<instance_id>:backup:<backup_id>
+  ```
+
+  **Gen2:** The independent backup CRN, with service name `databases-independent-backups`, for example:
+  ```
+  crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::
+  ```
+  The Gen2 backup CRN can be retrieved from:
+  - The `backup_id` field in the `ibm_database_backups` data source (when `deployment_id` is a Gen2 instance CRN).
+  - The IBM Cloud UI under **Databases > your instance > Backups**.
+  - The IBM Cloud CLI: `ibmcloud cdb backups <instance_name_or_crn>`.
 
 ## Attribute Reference
 

--- a/website/docs/d/database_backup.html.markdown
+++ b/website/docs/d/database_backup.html.markdown
@@ -2,13 +2,13 @@
 layout: "ibm"
 page_title: "IBM : ibm_database_backup"
 description: |-
-  Get information about Backup
+  Get information about a Cloud Database Backup.
 subcategory: "Cloud Databases"
 ---
 
 # ibm_database_backup
 
-Provides a read-only data source for Backup. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source for a Cloud Database Backup. Supports both Classic and Gen2 (Independent Backup) instances. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
 
 ## Example Usage
 
@@ -16,15 +16,17 @@ Provides a read-only data source for Backup. You can then reference the fields o
 
 ```hcl
 data "ibm_database_backup" "database_backup" {
-	backup_id = "<backup_crn>"
+  backup_id = "<backup_crn>"
 }
 ```
 
 ### Gen2
 
+For Gen2 instances, the `backup_id` is an Independent Backup CRN with service name `databases-independent-backups`. This can be obtained from the `backup_id` field of the `ibm_database_backups` data source.
+
 ```hcl
 data "ibm_database_backup" "database_backup" {
-	backup_id = "crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::"
+  backup_id = "crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::"
 }
 
 ```
@@ -35,19 +37,21 @@ Review the argument reference that you can specify for your data source.
 
 * `backup_id` - (Required, Forces new resource, String) Backup ID.
 
-  **Classic:** The backup CRN, for example:
+  **Classic:** The backup CRN returned by the ICD API, for example:
   ```
   crn:v1:bluemix:public:databases-for-postgresql:us-south:a/<account_id>:<instance_id>:backup:<backup_id>
   ```
 
-  **Gen2:** The independent backup CRN, with service name `databases-independent-backups`, for example:
+  **Gen2:** The Independent Backup CRN, identifiable by the service name `databases-independent-backups`, for example:
   ```
   crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::
   ```
   The Gen2 backup CRN can be retrieved from:
   - The `backup_id` field in the `ibm_database_backups` data source (when `deployment_id` is a Gen2 instance CRN).
-  - The IBM Cloud UI under **Databases > your instance > Backups**.
+  - The IBM Cloud UI under **Databases → your instance → Backups**.
   - The IBM Cloud CLI: `ibmcloud cdb backups <instance_name_or_crn>`.
+
+  **Note:** Passing a Classic (coupled) backup CRN for a Gen2 instance returns an error. Use the Independent Backup CRN instead.
 
 ## Attribute Reference
 
@@ -69,7 +73,6 @@ In addition to all argument references listed, you can access the following attr
 
 * `type` - (Optional, String) The type of backup.
   * Constraints: Allowable values are: `scheduled`, `on_demand`.
-
 
 ### Gen2 Independent Backups and S2S Authorization
 

--- a/website/docs/d/database_backup.html.markdown
+++ b/website/docs/d/database_backup.html.markdown
@@ -28,7 +28,6 @@ For Gen2 instances, the `backup_id` is an Independent Backup CRN with service na
 data "ibm_database_backup" "database_backup" {
   backup_id = "crn:v1:bluemix:public:databases-independent-backups:<region>:a/<account_id>:<backup_id>::"
 }
-
 ```
 
 ## Argument Reference

--- a/website/docs/d/database_backup.html.markdown
+++ b/website/docs/d/database_backup.html.markdown
@@ -45,3 +45,27 @@ In addition to all argument references listed, you can access the following attr
 * `type` - (Optional, String) The type of backup.
   * Constraints: Allowable values are: `scheduled`, `on_demand`.
 
+
+### Gen2 Independent Backups and S2S Authorization
+
+Gen2 database instances support **Independent Backups** — automated backups managed independently of the database instance lifecycle. When a Gen2 instance is configured to use Independent Backups, it requires a service-to-service (S2S) IAM authorization between the database service and the backup storage.
+
+If this authorization is missing or incomplete, Terraform emits a **non-blocking warning** during `plan` or `apply`:
+
+```
+╷
+│ Warning: Database backup authorization required
+│
+│   with data.ibm_database_backup.<name>,
+│
+│ This database uses Independent Backups.
+│ Existing backups remain available for 30 days from their creation date.
+│ Backup creation and management are unavailable until the required service authorization is completed.
+│
+│ Complete the required service authorization to enable backup operations.
+╵
+```
+
+The warning appears only when the instance has Independent Backups configured **and** the required S2S authorizations (`independent_backups` and `resource_group`) are not both `true`. It is suppressed for Classic plans and Gen2 instances not enrolled in Independent Backups.
+
+To resolve the warning, create the required IAM service-to-service authorization between the database service and `databases-independent-backups`. Once both authorizations are in place, the warning will no longer appear.

--- a/website/docs/d/database_backups.html.markdown
+++ b/website/docs/d/database_backups.html.markdown
@@ -8,7 +8,7 @@ subcategory: "Cloud Databases"
 
 # ibm_database_backups
 
-Provides a read-only data source for Backups. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+Provides a read-only data source for Backups. Supports both Classic and Gen2 (Independent Backup) instances. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
 
 ## Example Usage
 
@@ -21,6 +21,8 @@ data "ibm_database_backups" "database_backups" {
 ```
 
 ### Gen2
+
+For Gen2 instances, the `deployment_id` is a Gen2 database instance CRN. The data source lists all Independent Backups associated with that instance.
 
 ```hcl
 data "ibm_database_backups" "database_backups" {
@@ -45,7 +47,7 @@ Review the argument reference that you can specify for your data source.
   ```
   The Gen2 deployment CRN can be retrieved from:
   - The `id` attribute of an `ibm_database` resource configured with a Gen2 plan.
-  - The IBM Cloud UI under **Databases > your instance > Overview**.
+  - The IBM Cloud UI under **Databases → your instance → Overview**.
   - The IBM Cloud CLI: `ibmcloud resource service-instance <instance_name> --output json | jq -r '.[0].crn'`.
 
 ## Attribute Reference
@@ -64,7 +66,6 @@ Nested scheme for **backups**:
 	  * Constraints: Allowable values are: `running`, `completed`, `failed`.
 	* `type` - (Optional, String) The type of backup.
 	  * Constraints: Allowable values are: `scheduled`, `on_demand`.
-
 
 ### Gen2 Independent Backups and S2S Authorization
 

--- a/website/docs/d/database_backups.html.markdown
+++ b/website/docs/d/database_backups.html.markdown
@@ -41,3 +41,27 @@ Nested scheme for **backups**:
 	* `type` - (Optional, String) The type of backup.
 	  * Constraints: Allowable values are: `scheduled`, `on_demand`.
 
+
+### Gen2 Independent Backups and S2S Authorization
+
+Gen2 database instances support **Independent Backups** — automated backups managed independently of the database instance lifecycle. When a Gen2 instance is configured to use Independent Backups, it requires a service-to-service (S2S) IAM authorization between the database service and the backup storage.
+
+If this authorization is missing or incomplete, Terraform emits a **non-blocking warning** during `plan` or `apply`:
+
+```
+╷
+│ Warning: Database backup authorization required
+│
+│   with data.ibm_database_backups.<name>,
+│
+│ This database uses Independent Backups.
+│ Existing backups remain available for 30 days from their creation date.
+│ Backup creation and management are unavailable until the required service authorization is completed.
+│
+│ Complete the required service authorization to enable backup operations.
+╵
+```
+
+The warning appears only when the instance has Independent Backups configured **and** the required S2S authorizations (`independent_backups` and `resource_group`) are not both `true`. It is suppressed for Classic plans and Gen2 instances not enrolled in Independent Backups.
+
+To resolve the warning, create the required IAM service-to-service authorization between the database service and `databases-independent-backups`. Once both authorizations are in place, the warning will no longer appear.

--- a/website/docs/d/database_backups.html.markdown
+++ b/website/docs/d/database_backups.html.markdown
@@ -12,9 +12,19 @@ Provides a read-only data source for Backups. You can then reference the fields 
 
 ## Example Usage
 
+### Classic
+
 ```hcl
 data "ibm_database_backups" "database_backups" {
 	deployment_id = "<crn>"
+}
+```
+
+### Gen2
+
+```hcl
+data "ibm_database_backups" "database_backups" {
+	deployment_id = "crn:v1:bluemix:public:databases-for-mysql:<region>:a/<account_id>:<instance_id>::"
 }
 ```
 
@@ -23,6 +33,20 @@ data "ibm_database_backups" "database_backups" {
 Review the argument reference that you can specify for your data source.
 
 * `deployment_id` - (Required, String) ID of the deployment this backup relates to.
+
+  **Classic:** The database instance CRN, for example:
+  ```
+  crn:v1:bluemix:public:databases-for-postgresql:us-south:a/<account_id>:<instance_id>::
+  ```
+
+  **Gen2:** The Gen2 database instance CRN, for example:
+  ```
+  crn:v1:bluemix:public:databases-for-mysql:<region>:a/<account_id>:<instance_id>::
+  ```
+  The Gen2 deployment CRN can be retrieved from:
+  - The `id` attribute of an `ibm_database` resource configured with a Gen2 plan.
+  - The IBM Cloud UI under **Databases > your instance > Overview**.
+  - The IBM Cloud CLI: `ibmcloud resource service-instance <instance_name> --output json | jq -r '.[0].crn'`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Overview

Adds S2S (service-to-service) IAM authorization validation to the
`ibm_database_backup` and `ibm_database_backups` data sources for Gen2
database instances that use Independent Backups.

When a Gen2 instance has Independent Backups configured but the required S2S
authorizations are missing or incomplete, Terraform emits a **non-blocking
warning** — the read still succeeds and all attributes are populated, but users
are alerted that backup creation and management are impaired.

This brings the backup data sources into parity with `ibm_database`,
`ibm_database_connection`, and the `ibm_database` resource, which already emit
the same warning.

## Changes

### `ibm/service/database/data_source_ibm_database_backup.go`

- **`pickDataSourceBackupBackend`**: Calls `fetchInstancesForBackup` upfront for
  Gen2 backup CRNs so the backend receives both instances without extra API calls.
- **`fetchInstancesForBackup`**: New function (replaces `fetchSourceInstanceForBackup`)
  that fetches the backup resource instance and its source database instance in two
  RC API calls. Returns both so `Read()` can reuse them without re-fetching.

### `ibm/service/database/data_source_ibm_database_backup_gen2.go`

- **`dataSourceIBMDatabaseBackupGen2Backend`**: Added `backupInstance` field
  alongside `sourceInstance` so `Read()` reuses the pre-fetched backup instance
  instead of issuing a duplicate `GetResourceInstance` call.
- **`newDataSourceIBMDatabaseBackupGen2Backend`**: Accepts both `backupInstance`
  and `sourceInstance`.
- **`Read`**: Uses pre-fetched `backupInstance` when available; falls back to a
  live API call only when the router could not fetch it (e.g. auth failure).
  Emits the S2S warning via the shared `s2sDiagForInstance` helper.
- **`s2sDiagForInstance`**: New shared helper that builds the `diag.Warning`
  diagnostic when an instance has Independent Backups but S2S is not configured.
  Extracted so both backup backends and unit tests call the same code path.

### `ibm/service/database/data_source_ibm_database_backup_gen2_ac_test.go`

- **`TestAccIBMDatabaseBackupGen2DataSourceInvalidID`**: New acceptance test
  verifying the error path when `backup_id` does not resolve to a real resource
  instance.
- **`TestAccIBMDatabaseBackupGen2DataSourceS2SWarning`**: New acceptance test
  that provisions a Gen2 instance without S2S authorizations and verifies the
  warning fires while backup attributes are still populated.

### `ibm/service/database/data_source_ibm_database_backups.go`

- **`pickDataSourceBackupsBackend`**: Passes the already-fetched `instance` into
  `newDataSourceIBMDatabaseBackupsGen2Backend` so the Gen2 backend receives the
  source instance without a second `GetResourceInstance` call.

### `ibm/service/database/data_source_ibm_database_backups_gen2.go`

- **`dataSourceIBMDatabaseBackupsGen2Backend`**: Added `sourceInstance` field.
- **`newDataSourceIBMDatabaseBackupsGen2Backend`**: Accepts `sourceInstance`
  alongside `resourceGroupID`.
- **`Read`**: S2S warning check moved **before** the empty-backups error guard
  so users see the root cause even when no backups have been created yet (S2S
  misconfiguration blocks backup creation). When the warning fires, `backups` is
  still set in state (possibly empty) for consistency.

### `ibm/service/database/data_source_ibm_database_backups_gen2_ac_test.go`

- **`TestAccIBMDatabaseBackupsGen2DataSourceBasic`**: Extended with additional
  field checks (`backups.#`, `backups.0.*`) to validate all expected attributes.
- **`TestAccIBMDatabaseBackupsGen2DataSourceInvalidDeploymentID`**: New
  acceptance test for the error path when `deployment_id` is not a real instance.
- **`TestAccIBMDatabaseBackupsGen2DataSourceS2SWarning`**: New acceptance test
  that provisions a Gen2 instance without S2S and verifies the warning fires
  while the backups list is still populated.

### `ibm/service/database/data_source_ibm_database_backups_gen2_unit_test.go`

- **`s2sExtensions`**: New test helper that builds the `dataservices` extensions
  block for a Gen2 instance with optional Independent Backups and S2S authorization.
- **`TestBackupsGen2BackendS2SWarning`**: New table-driven unit test with four
  cases: no source instance, backups but no S2S (warning), backups with S2S
  (no warning), no backups (no warning).

### `website/docs/d/database_backup.html.markdown`

- Added Classic and Gen2 example usage sections with annotated CRN formats.
- Extended `backup_id` argument reference with Classic and Gen2 format
  descriptions and retrieval instructions.
- Added **Gen2 Independent Backups and S2S Authorization** section documenting
  the warning, when it fires, and how to resolve it.

### `website/docs/d/database_backups.html.markdown`

- Added Classic and Gen2 example usage sections.
- Extended `deployment_id` argument reference with Classic and Gen2 CRN formats
  and retrieval instructions.
- Added **Gen2 Independent Backups and S2S Authorization** section (same
  structure as `database_backup.html.markdown`).

## S2S Warning

When Independent Backups are enabled on a Gen2 instance but the required IAM
service-to-service authorizations (`independent_backups` and `resource_group`)
are not both `true` in the RC API extensions, the data sources emit:

```
╷
│ Warning: Database backup authorization required
│
│   with data.ibm_database_backup.<name>,
│
│ This database uses Independent Backups.
│ Existing backups remain available for 30 days from their creation date.
│ Backup creation and management are unavailable until the required service authorization is completed.
│
│ Complete the required service authorization to enable backup operations.
╵
```

The warning is **non-blocking** — all attributes are still populated. It is
suppressed for Classic plans and Gen2 instances not enrolled in Independent Backups.

## Constraints

- The S2S warning is only emitted for Gen2 instances enrolled in Independent Backups.
- For `ibm_database_backups`: the warning fires before the empty-backups error,
  so users always see the root cause when backups are missing due to missing S2S.
- The `ibm_database_backup` Gen2 backend reuses the backup instance fetched
  during routing — no duplicate `GetResourceInstance` calls.

## Example Terraform Configuration

```hcl
# List all Independent Backups for a Gen2 deployment
data "ibm_database_backups" "gen2_backups" {
  deployment_id = ibm_database.my_instance.id
}

# Read a specific Independent Backup by CRN
data "ibm_database_backup" "gen2_backup" {
  backup_id = data.ibm_database_backups.gen2_backups.backups[0].backup_id
}
```


**Validations Screenshots:**
**If S2S  is disabled then Warning for `ibm_database_backup`**
<img width="1706" height="776" alt="Screenshot 2026-09-11 at 1 39 10 PM" src="https://github.com/user-attachments/assets/69d2a7ff-019b-408d-bbc1-f0a001f7cc40" />
<br>
<img width="1681" height="393" alt="Screenshot 2026-09-11 at 1 40 22 PM" src="https://github.com/user-attachments/assets/448f18d1-23a6-4d91-bf03-f82f8b0a94b8" />
<br>
<img width="1681" height="543" alt="Screenshot 2026-09-11 at 1 40 31 PM" src="https://github.com/user-attachments/assets/8b85a715-31cb-47a7-9bc4-b87a13a46eb0" />
<br>
<img width="1686" height="408" alt="Screenshot 2026-09-11 at 1 41 18 PM" src="https://github.com/user-attachments/assets/5ee52613-a5f0-4d7a-92da-1e3462b9ef56" />
<br>
<img width="1683" height="758" alt="Screenshot 2026-09-11 at 1 41 31 PM" src="https://github.com/user-attachments/assets/3cd45119-5c55-424e-a3db-c04aac8ae08b" />
<br>
<br>
<br>
<br>

**If S2S  is enabled then NO Warning for `ibm_database_backup`**

<img width="1728" height="864" alt="Screenshot 2026-09-11 at 1 46 20 PM" src="https://github.com/user-attachments/assets/73b05489-f4db-4103-b91b-ebbc37973b33" />
<br>
<img width="1728" height="928" alt="Screenshot 2026-09-11 at 1 48 54 PM" src="https://github.com/user-attachments/assets/6c647549-dbc2-4d3c-8dca-81e6535f3b2f" />
<br>
<img width="1666" height="387" alt="Screenshot 2026-09-11 at 1 51 51 PM" src="https://github.com/user-attachments/assets/954aa473-d353-439c-84dd-d2886389d9cf" />
<br>
<img width="1681" height="580" alt="Screenshot 2026-09-11 at 1 52 02 PM" src="https://github.com/user-attachments/assets/b5a44de3-136f-4efa-9a57-ba09561e278c" />
<br>
<br>


**If S2S  is disabled then Warning for `ibm_database_backups`**
<br>
<img width="1728" height="736" alt="Screenshot 2026-09-11 at 2 01 54 PM" src="https://github.com/user-attachments/assets/78c23a85-3070-439d-8dc8-bb39ad754b48" />
<br>
<img width="1683" height="284" alt="Screenshot 2026-09-11 at 2 02 52 PM" src="https://github.com/user-attachments/assets/079ad6e1-8753-4379-a180-158449c1f215" />
<br>
<img width="1396" height="835" alt="Screenshot 2026-09-11 at 2 04 00 PM" src="https://github.com/user-attachments/assets/ed8c2ed6-5cd2-4535-b28e-fcd472d24f3c" />
<br>
<img width="1682" height="308" alt="Screenshot 2026-09-11 at 2 05 08 PM" src="https://github.com/user-attachments/assets/4ea9fbb6-c7ab-4f1a-a74b-4e73b220157e" />
<br>
<img width="1685" height="912" alt="Screenshot 2026-09-11 at 2 05 42 PM" src="https://github.com/user-attachments/assets/755a97a8-25c0-4efd-b17f-2034ae809f51" />

<br>


**If S2S  is enabled then NO Warning for `ibm_database_backups`** 
<br>

<img width="1724" height="757" alt="Screenshot 2026-09-11 at 2 00 52 PM" src="https://github.com/user-attachments/assets/ec502c1c-5009-4d2f-8f6d-c89ebd5f5ddc" />
<br>

<img width="1681" height="240" alt="Screenshot 2026-09-11 at 1 58 14 PM" src="https://github.com/user-attachments/assets/77745403-0ad9-46b1-b46a-242a2f308c6a" />
<br>

<img width="1673" height="293" alt="Screenshot 2026-09-11 at 1 58 24 PM" src="https://github.com/user-attachments/assets/0e6e9973-f65e-42b3-afb9-f031a0e05f92" />
<br>

<img width="1684" height="348" alt="Screenshot 2026-09-11 at 1 59 16 PM" src="https://github.com/user-attachments/assets/dd2496e7-ec61-4ce2-a4a3-3e6c82a06b6d" />
<br>

<img width="1683" height="617" alt="Screenshot 2026-09-11 at 1 59 29 PM" src="https://github.com/user-attachments/assets/2a1dc422-b46c-472b-aee2-6600aaa5191c" />
<br>

<br>
**DOC UPDATES**
<br>
<img width="1297" height="1003" alt="Screenshot 2026-09-11 at 3 46 21 PM" src="https://github.com/user-attachments/assets/1d209e78-d247-4f67-b850-209b6c7e85bc" />
<br>
<img width="1483" height="616" alt="Screenshot 2026-09-11 at 2 22 19 PM" src="https://github.com/user-attachments/assets/3affc3aa-031d-44a9-a0e7-efd6a27c5432" />
<br>
<img width="1266" height="982" alt="Screenshot 2026-09-11 at 3 40 57 PM" src="https://github.com/user-attachments/assets/dcd196d9-46c2-4a32-839e-2ead1390a373" />
<br>
<img width="1485" height="586" alt="Screenshot 2026-09-11 at 2 22 49 PM" src="https://github.com/user-attachments/assets/9b6bffee-4291-4d91-a44c-dba9c66a9740" />

<br>
<br>


## Output from unit testing

```
go test ./ibm/service/database/... \
  -run "^TestFilterGen2BackupsByDeployment$|^TestFilterGen2BackupsByDeployment_NoMatches$|^TestFilterGen2BackupsByDeployment_AcrossPages$|^TestBackupsGen2BackendS2SWarning$" \
  -v -count=1

=== RUN   TestFilterGen2BackupsByDeployment
--- PASS: TestFilterGen2BackupsByDeployment (0.00s)
=== RUN   TestFilterGen2BackupsByDeployment_NoMatches
--- PASS: TestFilterGen2BackupsByDeployment_NoMatches (0.00s)
=== RUN   TestFilterGen2BackupsByDeployment_AcrossPages
--- PASS: TestFilterGen2BackupsByDeployment_AcrossPages (0.00s)
=== RUN   TestBackupsGen2BackendS2SWarning
=== RUN   TestBackupsGen2BackendS2SWarning/no_source_instance_—_no_warning
=== RUN   TestBackupsGen2BackendS2SWarning/instance_has_independent_backups_but_no_S2S_—_warning
=== RUN   TestBackupsGen2BackendS2SWarning/instance_has_independent_backups_and_S2S_configured_—_no_warning
=== RUN   TestBackupsGen2BackendS2SWarning/instance_has_no_independent_backups_—_no_warning
--- PASS: TestBackupsGen2BackendS2SWarning (0.00s)
    --- PASS: TestBackupsGen2BackendS2SWarning/no_source_instance_—_no_warning (0.00s)
    --- PASS: TestBackupsGen2BackendS2SWarning/instance_has_independent_backups_but_no_S2S_—_warning (0.00s)
    --- PASS: TestBackupsGen2BackendS2SWarning/instance_has_independent_backups_and_S2S_configured_—_no_warning (0.00s)
    --- PASS: TestBackupsGen2BackendS2SWarning/instance_has_no_independent_backups_—_no_warning (0.00s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/database        1.542s
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
