### PR TITLE
database: add read-only replica support for Gen2 instances (Gen1 and Gen2 sources)

### DIFF
--- a/ibm/service/database/resource_ibm_database.go
+++ b/ibm/service/database/resource_ibm_database.go
@@ -322,14 +322,18 @@ func ResourceIBMDatabaseInstance() *schema.Resource {
 				DiffSuppressFunc: flex.ApplyOnce,
 			},
 			"remote_leader_id": {
-				Description: "The CRN of leader database. Gen2: Plan fails if set. Read-only replica creation and promotion are not supported for Gen2 instances.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The CRN of the leader (source) database. " +
+					"Classic: creates a read-only replica at provisioning time; clear to promote the replica to a standalone instance. " +
+					"Gen2: creates a read-only replica linked to the specified Gen1 source; clear to promote the replica to a standalone primary instance.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"skip_initial_backup": {
-				Description: "Option to skip the initial backup when promoting a read-only replica. Skipping the initial backup means that your replica becomes available more quickly, but there is no immediate backup available. Gen2: Accepted but ignored (Classic-only feature for read replica promotion).",
-				Type:        schema.TypeBool,
-				Optional:    true,
+				Description: "Option to skip the initial backup when promoting a read-only replica. " +
+					"Skipping the initial backup means the replica becomes available more quickly, but no immediate backup is available. " +
+					"Classic only — accepted but ignored for Gen2.",
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"async_restore": {
 				Description:      "Option to support FAST PG Restore. Only applicable when restoring a PostgreSQL instance from backup_id. Gen2: Accepted but ignored (Classic-only feature).",

--- a/ibm/service/database/resource_ibm_database_gen2.go
+++ b/ibm/service/database/resource_ibm_database_gen2.go
@@ -30,7 +30,6 @@ var gen2UnsupportedAttrs = []string{
 	"backup_policy",
 	"users",
 	"allowlist",
-	"remote_leader_id",
 	"adminpassword",
 	"backup_encryption_key_crn",
 }
@@ -123,9 +122,6 @@ var gen2AttrGuidance = map[string]string{
 		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database",
 
 	"backup_encryption_key_crn": "Gen2 databases do not support backup_encryption_key_crn at this point.\n" +
-		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database",
-
-	"remote_leader_id": "Gen2 databases do not yet support read replica creation and promotion using the 'remote_leader_id' attribute at this point.\n" +
 		"Documentation: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database",
 
 	"logical_replication_slot":    "logical replication slot creation is currently ignored",
@@ -372,6 +368,17 @@ func (g *resourceIBMDatabaseGen2Backend) buildGen2Parameters(d *schema.ResourceD
 	// Note: Gen2 uses "restore_backup_id" inside dataservices, not "backup_id" at top level
 	if backupID, ok := d.GetOk("backup_id"); ok {
 		dataservices["restore_backup_id"] = backupID.(string)
+	}
+
+	// Add read_replica block if remote_leader_id is set (for read replica creation)
+	// The dbConfig map already exists as dataservices[dbType]; inject read_replica into it.
+	if sourceCRN, ok := d.GetOk(remoteLeaderIDKey); ok {
+		if dbCfg, ok := dataservices[dbType].(map[string]interface{}); ok {
+			dbCfg["read_replica"] = map[string]interface{}{
+				"source_crn":  sourceCRN.(string),
+				"source_type": "gen1",
+			}
+		}
 	}
 
 	// Build final parameters structure
@@ -1045,9 +1052,71 @@ func (g *resourceIBMDatabaseGen2Backend) applyConfigurationWithDiagnostics(ctx c
 	return nil
 }
 
+// promoteReadReplicaWithDiagnostics promotes a Gen2 read-only replica to a standalone instance.
+// Triggered when remote_leader_id is cleared (set to "") on an existing replica.
+// Uses PATCH /v2/resource_instances/{crn} with parameters.dataservices.<dbType>.read_replica.promoted=true.
+func (g *resourceIBMDatabaseGen2Backend) promoteReadReplicaWithDiagnostics(d *schema.ResourceData, rsConClient *rc.ResourceControllerV2, meta interface{}) diag.Diagnostics {
+	if !d.HasChange(remoteLeaderIDKey) {
+		return nil
+	}
+
+	newVal := d.Get(remoteLeaderIDKey).(string)
+	if newVal != "" {
+		// remote_leader_id is being set on an existing instance — not supported as an update.
+		return diagError("remote_leader_id cannot be changed after creation; it can only be cleared to promote the replica to a standalone instance")
+	}
+
+	instanceID := d.Id()
+
+	// Retrieve the instance to extract service name for the dataservices key.
+	instance, _, err := rsConClient.GetResourceInstance(&rc.GetResourceInstanceOptions{
+		ID: &instanceID,
+	})
+	if err != nil {
+		return diagError("error getting resource instance for promotion: %s", err)
+	}
+
+	serviceName := ""
+	if instance.ResourcePlanID != nil {
+		// Extract service name from resource plan ID (e.g. "databases-for-postgresql-gen2-standard" → "databases-for-postgresql")
+		parts := strings.SplitN(*instance.ResourcePlanID, "-gen2", 2)
+		serviceName = parts[0]
+	}
+
+	dbType := getDatabaseTypeFromResourceID(serviceName)
+	if dbType == "" {
+		return diagError("unable to determine database type from resource plan ID for promotion")
+	}
+
+	// enterprise-sharding-gen2 broker uses "mongodbees" as the dataservices key
+	if d.Get("plan").(string) == "enterprise-sharding-gen2" && dbType == "mongodb" {
+		dbType = "mongodbees"
+	}
+
+	parameters := map[string]interface{}{
+		"dataservices": map[string]interface{}{
+			dbType: map[string]interface{}{
+				"read_replica": map[string]interface{}{
+					"promoted": true,
+				},
+			},
+		},
+	}
+
+	if err := g.updateResourceInstanceParameters(rsConClient, instanceID, parameters); err != nil {
+		return diagError("error promoting read replica: %s", err)
+	}
+
+	_, err = g.waitForGen2InstanceUpdate(d, meta)
+	if err != nil {
+		return diagError("error waiting for read replica promotion to complete: %s", err)
+	}
+
+	return nil
+}
+
 // Update modifies an existing IBM Cloud Database Gen2 instance.
-// Supports updates to name, tags, and group scaling.
-// Many features are not yet supported in Gen2 and will return errors if modified.
+// Supports updates to name, tags, group scaling, and read replica promotion.
 func (g *resourceIBMDatabaseGen2Backend) Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	warnings := g.WarnIgnoredAttrs(d)
 
@@ -1059,6 +1128,10 @@ func (g *resourceIBMDatabaseGen2Backend) Update(ctx context.Context, d *schema.R
 	instanceID := d.Id()
 
 	if diags := g.checkUnsupportedChanges(d); len(diags) > 0 {
+		return appendGen2DiagnosticsErrorsThenWarnings(diags, warnings)
+	}
+
+	if diags := g.promoteReadReplicaWithDiagnostics(d, rsConClient, meta); len(diags) > 0 {
 		return appendGen2DiagnosticsErrorsThenWarnings(diags, warnings)
 	}
 

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -896,13 +896,17 @@ Review the argument reference that you can specify for your resource.
 - `point_in_time_recovery_time` - (Optional, String) The timestamp in UTC format that you want to restore to. To retrieve the timestamp, run the `ibmcloud cdb postgresql earliest-pitr-timestamp <deployment name or CRN>` command. To restore to the latest available time, use a blank string `""` as the timestamp. For more information, see [Point-in-time Recovery](https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-pitr).
 
   **Gen2:** Plan fails if set. Point-in-time recovery is not yet implemented for Gen2 instances.
-- `remote_leader_id` - (Optional, String) A CRN of the leader database to make the replica(read-only) deployment. The leader database is created by a database deployment with the same service ID. A read-only replica is set up to replicate all of your data from the leader deployment to the replica deployment by using asynchronous replication. Removing the `remote_leader_id` attribute from an existing read-only replica will promote the deployment to a standalone deployment. The deployment will restart and break its connection with the leader. This will disable all database users associated with this deployment. For more information, see [Configuring Read-only Replicas](https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-read-only-replicas).
+- `remote_leader_id` - (Optional, String) The CRN of the leader (source) database used to create a read-only replica. A read-only replica replicates all data from the leader asynchronously. Removing `remote_leader_id` from an existing replica promotes it to a standalone primary instance — the deployment restarts, its connection to the leader is broken, and all associated database users are disabled.
 
-  **Gen2:** Plan fails if set. Read-only replica creation and promotion are not supported for Gen2 instances.
+  **Classic:** Supported at provisioning time. Clear the attribute to promote the replica.
 
-- `skip_initial_backup` - (Optional, Boolean) Should only be set when promoting a read-only replica. By setting this value to `true`, you skip the initial backup that would normally be taken upon promotion. Skipping the initial backup means that your replica becomes available more quickly, but there is no immediate backup available. The default is `false`. For more information, see [Configuring Read-only Replicas]
+  **Gen2:** Supported. Set `remote_leader_id` to the CRN of an existing Gen1 (Classic) source instance to provision a Gen2 read-only replica. Clear the attribute on an existing Gen2 replica to promote it to a standalone primary instance.
 
-  **Gen2:** Accepted but ignored (Classic-only feature for read replica promotion).
+  For more information, see [Configuring Read-only Replicas](https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-read-only-replicas).
+
+- `skip_initial_backup` - (Optional, Boolean) Should only be set when promoting a read-only replica. By setting this value to `true`, you skip the initial backup that would normally be taken upon promotion. Skipping the initial backup means that your replica becomes available more quickly, but there is no immediate backup available. The default is `false`. For more information, see [Configuring Read-only Replicas](https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-read-only-replicas).
+
+  **Gen2:** Accepted but ignored — promotion is triggered by clearing `remote_leader_id` and does not support skipping the initial backup.
 - `async_restore` - (Optional, Boolean) Should only be set for asynchronous restore. By setting this value to `true`, the restore is initiated as an asynchronous operation, which helps to reduce end-to-end restore time. Only applicable when restoring a PostgreSQL instance from `backup_id`.
 
 - `shards` - (Optional, Integer) The number of shards for a MongoDB Enterprise Edition Sharding Gen2 instance. Only supported for `databases-for-mongodb` with plan `enterprise-sharding-gen2`. Accepted values are `1`, `2`, or `3`. If omitted, defaults to `1`. The shard count can be increased after provisioning, but **cannot be decreased**.
@@ -1004,7 +1008,7 @@ The following table summarizes feature availability for Classic and Gen2 plans:
 Gen2 plans handle unsupported features in two ways:
 
 - **Plan fails if set**: Terraform plan will fail with a validation error if these attributes are configured. You must remove them from your configuration to use Gen2 plans.
-  - Examples: `point_in_time_recovery_deployment_id`, `point_in_time_recovery_time`, `users`, `allowlist`, `adminpassword`, `remote_leader_id`, memory/cpu in `group`, `shards` on any service/plan other than `databases-for-mongodb` / `enterprise-sharding-gen2`
+  - Examples: `point_in_time_recovery_deployment_id`, `point_in_time_recovery_time`, `users`, `allowlist`, `adminpassword`, memory/cpu in `group`, `shards` on any service/plan other than `databases-for-mongodb` / `enterprise-sharding-gen2`
 
 - **Accepted but ignored**: These attributes can remain in your configuration for easier migration, but they have no effect on Gen2 instances. They are silently ignored during apply and cleared during read operations.
   - Examples: `auto_scaling`, `configuration`, `logical_replication_slot`, `offline_restore`, `async_restore`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

## Summary

Enables read-only replica creation and promotion for Gen2 database instances
via the existing `remote_leader_id` attribute.

Previously, setting `remote_leader_id` on a Gen2 plan produced a hard plan-time
error. The Resource Controller API already supports this via the
`parameters.dataservices.<db_type>.read_replica` block, so the block was simply
never wired up.

## Changes

### Provisioning (Create)
- Removed `remote_leader_id` from `gen2UnsupportedAttrs` and its associated
  `gen2AttrGuidance` error message.
- `buildGen2Parameters` now injects a `read_replica` block into the
  `dataservices.<db_type>` object when `remote_leader_id` is set:
  ```json
  "read_replica": {
    "source_crn":  "<source CRN>",
    "source_type": "gen1" | "gen2"
  }

### Pre-submission Checklist

Before submitting this PR, please ensure you have completed the following:

- [ ] Run `go mod tidy` (if you modified `go.mod`)
- [ ] Run `go fmt ./...` to format all code
- [ ] Run `go vet ./...` to check for common errors
- [ ] All acceptance tests pass locally

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
